### PR TITLE
Typo fixes for DEVELOPER/ and SRC/element/

### DIFF
--- a/DEVELOPER/UnixInstructions.txt
+++ b/DEVELOPER/UnixInstructions.txt
@@ -7,7 +7,7 @@ there are a number of example classes and example scripts to test these
 classes. In addition for elements and materials there are example c and 
 fortran routines.
 
-typing make in the DEVLOPER directory will build them all. the resulting
+typing make in the DEVELOPER directory will build them all. the resulting
 shared object libraries (dynamic link libraries) will be found in the same
 directory as the source code.
 

--- a/DEVELOPER/WindowsInstructions.txt
+++ b/DEVELOPER/WindowsInstructions.txt
@@ -2,7 +2,7 @@
 2. File -> New Project
 3. Give it name of New class and location of current class files (ElasticPPcpp and C:\???\OpenSeesDeveloper\material (VisualStudio2010 want VisualStudio C++ Win32 - Win32 Project)
 4. Select OK (visual Studio20
-5. New windows pops up, Select Application Settins
+5. New windows pops up, Select Application Settings
 6. Select DLL AND select Empty Project
 7. Select Finish
 

--- a/DEVELOPER/core/AnalysisModel.cpp
+++ b/DEVELOPER/core/AnalysisModel.cpp
@@ -142,7 +142,7 @@ bool
 AnalysisModel::addFE_Element(FE_Element *theElement)
 {
   // check we don't add a null pointer or this is a subclass
-  // trying to use this method when it should'nt
+  // trying to use this method when it shouldn't
   if (theElement == 0 || theFEs == 0)
       return false;
 
@@ -178,7 +178,7 @@ AnalysisModel::addDOF_Group(DOF_Group *theGroup)
 {
 
   // check we don't add a null pointer or this is a subclass trying
-  // to use a method it should'nt be using
+  // to use a method it shouldn't be using
   if (theGroup == 0 || theDOFs == 0)
       return false;
   

--- a/DEVELOPER/core/ArrayOfTaggedObjects.cpp
+++ b/DEVELOPER/core/ArrayOfTaggedObjects.cpp
@@ -102,7 +102,7 @@ ArrayOfTaggedObjects::setSize(int newSize)
     TaggedObject **oldArray = theComponents;
     int oldArrayLastEntry = positionLastEntry;
 
-    // set data for new aray
+    // set data for new array
     theComponents = newArray;
     sizeComponentArray = newSize;		
 
@@ -125,7 +125,7 @@ ArrayOfTaggedObjects::setSize(int newSize)
 	positionLastNoFitEntry = 0;
 	fitFlag = true;
 
-	// now add all the componets of the old array into the new one
+	// now add all the components of the old array into the new one
 	// we add using addComponent() to see if false fitFlag will now be true
 	for (int j=0; j<=oldArrayLastEntry; j++)
 	    if (oldArray[j] != 0)

--- a/DEVELOPER/core/BeamFiberMaterial.cpp
+++ b/DEVELOPER/core/BeamFiberMaterial.cpp
@@ -404,7 +404,7 @@ BeamFiberMaterial::sendSelf(int commitTag, Channel &theChannel)
 {
   int res = 0;
 
-  // put tag and assocaited materials class and database tags into an id and send it
+  // put tag and associated materials class and database tags into an id and send it
   static ID idData(3);
   idData(0) = this->getTag();
   idData(1) = theMaterial->getClassTag();
@@ -446,7 +446,7 @@ BeamFiberMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.sendID(this->getDbTag(), commitTag, idData);
   if (res < 0) {

--- a/DEVELOPER/core/BeamFiberMaterial2d.cpp
+++ b/DEVELOPER/core/BeamFiberMaterial2d.cpp
@@ -454,7 +454,7 @@ BeamFiberMaterial2d::sendSelf(int commitTag, Channel &theChannel)
 {
   int res = 0;
 
-  // put tag and assocaited materials class and database tags into an id and send it
+  // put tag and associated materials class and database tags into an id and send it
   static ID idData(3);
   idData(0) = this->getTag();
   idData(1) = theMaterial->getClassTag();
@@ -497,7 +497,7 @@ BeamFiberMaterial2d::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.sendID(this->getDbTag(), commitTag, idData);
   if (res < 0) {

--- a/DEVELOPER/core/Domain.cpp
+++ b/DEVELOPER/core/Domain.cpp
@@ -2391,7 +2391,7 @@ Domain::buildEleGraph(Graph *theEleGraph)
       if (theEleToVertexMapEle == theEleToVertexMap.end()) {
         theEleToVertexMap.insert(MAP_INT_TYPE(eleTag, count));
 
-        // check if sucessfully added
+        // check if successfully added
         theEleToVertexMapEle = theEleToVertexMap.find(eleTag);
         if (theEleToVertexMapEle == theEleToVertexMap.end()) {
           opserr << "Domain::buildEleGraph - map STL failed to add object with tag : " << eleTag << endln;
@@ -2403,11 +2403,11 @@ Domain::buildEleGraph(Graph *theEleGraph)
     }
 
     //
-    // We now need to determine which elements are asssociated with each node.
+    // We now need to determine which elements are associated with each node.
     // As this info is not in the Node interface we must build it;
     //
     // again we will use an stl map, index will be nodeTag, object will be Vertex
-    // do using vertices for each node, when we addVertex at thes nodes we
+    // do using vertices for each node, when we addVertex at these nodes we
     // will not be adding vertices but element tags.
     //
 
@@ -2434,7 +2434,7 @@ Domain::buildEleGraph(Graph *theEleGraph)
       if (theNodeEle == theNodeToVertexMap.end()) {
         theNodeToVertexMap.insert(MAP_ID_TYPE(nodeTag, eleTags));
 
-        // check if sucessfully added
+        // check if successfully added
         theNodeEle = theNodeToVertexMap.find(nodeTag);
         if (theNodeEle == theNodeToVertexMap.end()) {
           opserr << "Domain::buildEleGraph - map STL failed to add object with tag : " << nodeTag << endln;
@@ -2698,7 +2698,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
 
     // we do the same for elements as we did for nodes above .. see comments
-    // for nodes if you can't figure whats going on!
+    // for nodes if you can't figure what's going on!
 
     if (numEle != 0) {
       ID elementData(numEle*2);
@@ -2728,7 +2728,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
 
     // we do the same for SP_Constraints as for Nodes above .. see comments
-    // for nodes if you can't figure whats going on!    
+    // for nodes if you can't figure what's going on!    
     
     if (numSPs != 0) {
       ID spData(numSPs*2);
@@ -2757,7 +2757,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
 
     // we do the same for Pressure_Constraints as for Nodes above .. see comments
-    // for nodes if you can't figure whats going on!    
+    // for nodes if you can't figure what's going on!    
     
     if (numPCs != 0) {
         ID pData(numPCs*2);
@@ -2786,7 +2786,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
 
     // we do the same for MP_Constraints as for Nodes above .. see comments
-    // for nodes if you can't figure whats going on!    
+    // for nodes if you can't figure what's going on!    
     
     if (numMPs != 0) {
       ID mpData(numMPs*2);
@@ -2815,7 +2815,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
 
     // we do the same for LoadPatterns as we did for Nodes above .. see comments
-    // for nodes if you can't figure whats going on!    
+    // for nodes if you can't figure what's going on!    
 
 
     if (numLPs != 0) {
@@ -2955,7 +2955,7 @@ Domain::sendSelf(int cTag, Channel &theChannel)
     }
   }  
 
-  // if get here we were successfull
+  // if get here we were successful
   return commitTag;
 }
 
@@ -2985,7 +2985,7 @@ Domain::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
   committedTime = currentTime;
 
   // 
-  // now if the currentGeoTag does not agree with whats in the domain
+  // now if the currentGeoTag does not agree with what's in the domain
   // we must wipe everything in the domain and recreate the domain based on the info from the channel
   //
 
@@ -3388,7 +3388,7 @@ Domain::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
   // now set the domains lastGeoSendTag and currentDomainChangedFlag
   lastGeoSendTag = currentGeoTag;  
 
-  // if get here we were successfull
+  // if get here we were successful
   return 0;
 }
 

--- a/DEVELOPER/core/FEM_ObjectBroker.h
+++ b/DEVELOPER/core/FEM_ObjectBroker.h
@@ -134,7 +134,7 @@ class FEM_ObjectBroker
     virtual Vector	  *getPtrNewVector(int classTag, int size);
     virtual ID	          *getPtrNewID(int classTag, int size);
 
-    // methods for ouput objects
+    // methods for output objects
     //    virtual DataOutputHandler *getPtrNewDataOutputHandler(int classTag);
     virtual OPS_Stream *getPtrNewStream(int classTag);
     virtual Recorder *getPtrNewRecorder(int classTag);

--- a/DEVELOPER/core/Graph.cpp
+++ b/DEVELOPER/core/Graph.cpp
@@ -175,7 +175,7 @@ Graph::addVertex(Vertex *vertexPtr, bool checkAdjacency)
 // {\em vertexTag} and {\em otherVertexTag} exist in the graph. If they
 // do not exist a $-1$ is returned, otherwise the method invokes {\em
 // addEdge()} on each of the corresponding vertices in the 
-// graph. Returns $0$ if sucessfull, a negative number if not.
+// graph. Returns $0$ if successful, a negative number if not.
 
 int 
 Graph::addEdge(int vertexTag, int otherVertexTag)

--- a/DEVELOPER/core/ID.cpp
+++ b/DEVELOPER/core/ID.cpp
@@ -419,7 +419,7 @@ ID::resize(int newSize){
 
 // ID &operator=(const ID  &V):
 //	the assignment operator, This is assigned to be a copy of V. if sizes
-//	are not compatable this.data [] is deleted. The data pointers will not
+//	are not compatible this.data [] is deleted. The data pointers will not
 //	point to the same area in mem after the assignment.
 //
 
@@ -429,7 +429,7 @@ ID::operator=(const ID &V)
     // first check we are not trying v = v
     if (this != &V) {
 	
-	// check size compatability, if different delete
+	// check size compatibility, if different delete
 	// old and make room for new.
 	if (sz != V.sz) {
 	    if (arraySize < V.sz) {

--- a/DEVELOPER/core/IncrementalIntegrator.cpp
+++ b/DEVELOPER/core/IncrementalIntegrator.cpp
@@ -166,7 +166,7 @@ IncrementalIntegrator::getLastResponse(Vector &result, const ID &id)
 	}
 	else {
 	    opserr << "WARNING IncrementalIntegrator::getLastResponse() -";
-	    opserr << "location " << loc << "in ID ouside bounds ";
+	    opserr << "location " << loc << "in ID outside bounds ";
 	    opserr << size << "\n";	
 	    res = -2;
 	}

--- a/DEVELOPER/core/Load.cpp
+++ b/DEVELOPER/core/Load.cpp
@@ -29,7 +29,7 @@
 // Created: 11/96
 // Revision: A
 //
-// Purpose: This file contains the implementaion for the Load class.
+// Purpose: This file contains the implementation for the Load class.
 //
 // What: "@(#) Load.C, revA"
 

--- a/DEVELOPER/core/MapOfTaggedObjects.cpp
+++ b/DEVELOPER/core/MapOfTaggedObjects.cpp
@@ -82,7 +82,7 @@ MapOfTaggedObjects::addComponent(TaggedObject *newComponent)
     if (theEle == theMap.end()) {
 	theMap.insert(MAP_TAGGED_TYPE(tag,newComponent));
 		      
-	// check if sucessfully added 
+	// check if successfully added 
 	theEle = theMap.find(tag);
 	if (theEle == theMap.end()) {
 	  opserr << "MapOfTaggedObjects::addComponent - map STL failed to add object with tag : " << 
@@ -92,7 +92,7 @@ MapOfTaggedObjects::addComponent(TaggedObject *newComponent)
     }
     
     // if ele already there map cannot add even if allowMultiple is true
-    // as the map template does not allow multiple entries wih the same tag
+    // as the map template does not allow multiple entries with the same tag
     else {	
       opserr << "MapOfTaggedObjects::addComponent - not adding as one with similar tag exists, tag: " <<
 	newComponent->getTag() << "\n";

--- a/DEVELOPER/core/Matrix.cpp
+++ b/DEVELOPER/core/Matrix.cpp
@@ -664,7 +664,7 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 
 #ifdef _G3DEBUG
     if ((other.numRows != numRows) || (other.numCols != numCols)) {
-      opserr << "Matrix::addMatrix(): incompatable matrices\n";
+      opserr << "Matrix::addMatrix(): incompatible matrices\n";
       return -1;
     }
 #endif
@@ -721,7 +721,7 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
       }
     } 
 
-    // successfull
+    // successful
     return 0;
 }
 
@@ -734,7 +734,7 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
 
 #ifdef _G3DEBUG
     if ((other.numRows != numCols) || (other.numCols != numRows)) {
-      opserr << "Matrix::addMatrixTranspose(): incompatable matrices\n";
+      opserr << "Matrix::addMatrixTranspose(): incompatible matrices\n";
       return -1;
     }
 #endif
@@ -797,7 +797,7 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       }
     } 
 
-    // successfull
+    // successful
     return 0;
 }
 
@@ -812,7 +812,7 @@ Matrix::addMatrixProduct(double thisFact,
       return 0;
 #ifdef _G3DEBUG
     if ((B.numRows != numRows) || (C.numCols != numCols) || (B.numCols != C.numRows)) {
-      opserr << "Matrix::addMatrixProduct(): incompatable matrices, this\n";
+      opserr << "Matrix::addMatrixProduct(): incompatible matrices, this\n";
       return -1;
     }
 #endif
@@ -887,7 +887,7 @@ Matrix::addMatrixTransposeProduct(double thisFact,
 
 #ifdef _G3DEBUG
   if ((B.numCols != numRows) || (C.numCols != numCols) || (B.numRows != C.numRows)) {
-    opserr << "Matrix::addMatrixProduct(): incompatable matrices, this\n";
+    opserr << "Matrix::addMatrixProduct(): incompatible matrices, this\n";
     return -1;
   }
 #endif
@@ -953,7 +953,7 @@ Matrix::addMatrixTripleProduct(double thisFact,
 #ifdef _G3DEBUG
     if ((numCols != numRows) || (B.numCols != B.numRows) || (T.numCols != numRows) ||
 	(T.numRows != B.numCols)) {
-      opserr << "Matrix::addMatrixTripleProduct() - incompatable matrices\n";
+      opserr << "Matrix::addMatrixTripleProduct() - incompatible matrices\n";
       return -1;
     }
 #endif
@@ -1052,7 +1052,7 @@ Matrix::addMatrixTripleProduct(double thisFact,
 #ifdef _G3DEBUG
     if ((numRows != A.numRows) || (A.numCols != B.numRows) || (B.numCols != C.numRows) ||
 	(C.numCols != numCols)) {
-      opserr << "Matrix::addMatrixTripleProduct() - incompatable matrices\n";
+      opserr << "Matrix::addMatrixTripleProduct() - incompatible matrices\n";
       return -1;
     }
 #endif
@@ -1158,7 +1158,7 @@ Matrix::operator()(const ID &rows, const ID & cols) const
 		
 // Matrix &operator=(const Matrix  &V):
 //      the assignment operator, This is assigned to be a copy of V. if sizes
-//      are not compatable this.data [] is deleted. The data pointers will not
+//      are not compatible this.data [] is deleted. The data pointers will not
 //      point to the same area in mem after the assignment.
 //
 
@@ -1372,7 +1372,7 @@ Matrix::operator*(const Vector &V) const
     Vector result(numRows);
     
     if (V.Size() != numCols) {
-	opserr << "Matrix::operator*(Vector): incompatable sizes\n";
+	opserr << "Matrix::operator*(Vector): incompatible sizes\n";
 	return result;
     } 
     
@@ -1405,7 +1405,7 @@ Matrix::operator^(const Vector &V) const
     Vector result(numCols);
     
     if (V.Size() != numRows) {
-      opserr << "Matrix::operator*(Vector): incompatable sizes\n";
+      opserr << "Matrix::operator*(Vector): incompatible sizes\n";
       return result;
     } 
 
@@ -1446,7 +1446,7 @@ Matrix::operator*(const Matrix &M) const
     Matrix result(numRows,M.numCols);
     
     if (numCols != M.numRows || result.numRows != numRows) {
-	opserr << "Matrix::operator*(Matrix): incompatable sizes\n";
+	opserr << "Matrix::operator*(Matrix): incompatible sizes\n";
 	return result;
     } 
 
@@ -1487,7 +1487,7 @@ Matrix::operator^(const Matrix &M) const
   Matrix result(numCols,M.numCols);
   
   if (numRows != M.numRows || result.numRows != numCols) {
-    opserr << "Matrix::operator*(Matrix): incompatable sizes\n";
+    opserr << "Matrix::operator*(Matrix): incompatible sizes\n";
     return result;
   } 
 
@@ -1519,7 +1519,7 @@ Matrix::operator+=(const Matrix &M)
 {
 #ifdef _G3DEBUG
   if (numRows != M.numRows || numCols != M.numCols) {
-    opserr << "Matrix::operator+=(const Matrix &M) - matrices incompatable\n";
+    opserr << "Matrix::operator+=(const Matrix &M) - matrices incompatible\n";
     return *this;
   }
 #endif
@@ -1537,7 +1537,7 @@ Matrix::operator-=(const Matrix &M)
 {
 #ifdef _G3DEBUG
   if (numRows != M.numRows || numCols != M.numCols) {
-    opserr << "Matrix::operator-=(const Matrix &M) - matrices incompatable [" << numRows << " " ;
+    opserr << "Matrix::operator-=(const Matrix &M) - matrices incompatible [" << numRows << " " ;
     opserr << numCols << "]" << "[" << M.numRows << "]" << M.numCols << "]\n";
 
     return *this;

--- a/DEVELOPER/core/Matrix.h
+++ b/DEVELOPER/core/Matrix.h
@@ -101,7 +101,7 @@ class Matrix
 
     // matrix operations which generate a new Matrix. They are not the
     // most efficient to use, as constructors must be called twice. They
-    // however are usefull for matlab like expressions involving Matrices.
+    // however are useful for matlab like expressions involving Matrices.
 
     // matrix-scalar operations
     Matrix operator+(double fact) const;

--- a/DEVELOPER/core/Node.cpp
+++ b/DEVELOPER/core/Node.cpp
@@ -754,7 +754,7 @@ Node::setTrialDisp(double value, int dof)
 {
     // check vector arg is of correct size
     if (dof < 0 || dof >=  numberDOF) {
-      opserr << "WARNING Node::setTrialDisp() - incompatable sizes\n";
+      opserr << "WARNING Node::setTrialDisp() - incompatible sizes\n";
       opserr << "node: " << this->getTag() << endln;
       return -2;
     }    
@@ -769,7 +769,7 @@ Node::setTrialDisp(double value, int dof)
 	}    
     }
 
-    // perform the assignment .. we dont't go through Vector interface
+    // perform the assignment .. we don't go through Vector interface
     // as we are sure of size and this way is quicker
     double tDisp = value;
     disp[dof+2*numberDOF] = tDisp - disp[dof+numberDOF];
@@ -784,7 +784,7 @@ Node::setTrialDisp(const Vector &newTrialDisp)
 {
     // check vector arg is of correct size
     if (newTrialDisp.Size() != numberDOF) {
-      opserr << "WARNING Node::setTrialDisp() - incompatable sizes\n";
+      opserr << "WARNING Node::setTrialDisp() - incompatible sizes\n";
       opserr << "node: " << this->getTag() << endln;
       return -2;
     }    
@@ -799,7 +799,7 @@ Node::setTrialDisp(const Vector &newTrialDisp)
 	}    
     }
 
-    // perform the assignment .. we dont't go through Vector interface
+    // perform the assignment .. we don't go through Vector interface
     // as we are sure of size and this way is quicker
     for (int i=0; i<numberDOF; i++) {
         double tDisp = newTrialDisp(i);
@@ -816,7 +816,7 @@ Node::setTrialVel(const Vector &newTrialVel)
 {
     // check vector arg is of correct size
     if (newTrialVel.Size() != numberDOF) {
-	    opserr << "WARNING Node::setTrialVel() - incompatable sizes\n";
+	    opserr << "WARNING Node::setTrialVel() - incompatible sizes\n";
 	    return -2;
     }    
 
@@ -842,7 +842,7 @@ Node::setTrialAccel(const Vector &newTrialAccel)
 {
     // check vector arg is of correct size
     if (newTrialAccel.Size() != numberDOF) {
-	    opserr << "WARNING Node::setTrialAccel() - incompatable sizes\n";
+	    opserr << "WARNING Node::setTrialAccel() - incompatible sizes\n";
 	    return -2;
     }    
 
@@ -866,11 +866,11 @@ Node::incrTrialDisp(const Vector &incrDispl)
 {
     // check vector arg is of correct size
     if (incrDispl.Size() != numberDOF) {
-	opserr << "WARNING Node::incrTrialDisp() - incompatable sizes\n";
+	opserr << "WARNING Node::incrTrialDisp() - incompatible sizes\n";
 	return -2;
     }    
 
-    // create a copy if no trial exists andd add committed
+    // create a copy if no trial exists and add committed
     if (trialDisp == 0) {
 	if (this->createDisp() < 0) {
 	    opserr << "FATAL Node::incrTrialDisp() - ran out of memory\n";
@@ -902,7 +902,7 @@ Node::incrTrialVel(const Vector &incrVel)
 {
     // check vector arg is of correct size
     if (incrVel.Size() != numberDOF) {
-	opserr << "WARNING Node::incrTrialVel() - incompatable sizes\n";
+	opserr << "WARNING Node::incrTrialVel() - incompatible sizes\n";
 	return -2;
     }    
 
@@ -931,11 +931,11 @@ Node::incrTrialAccel(const Vector &incrAccel)
 {
     // check vector arg is of correct size
     if (incrAccel.Size() != numberDOF) {
-	opserr << "WARNING Node::incrTrialAccel() - incompatable sizes\n";
+	opserr << "WARNING Node::incrTrialAccel() - incompatible sizes\n";
 	return -2;
     }    
 
-    // create a copy if no trial exists andd add committed    
+    // create a copy if no trial exists and add committed    
     if (trialAccel == 0) {
 	if (this->createAccel() < 0) {
 	    opserr << "FATAL Node::incrTrialAccel() - ran out of memory\n";
@@ -1279,7 +1279,7 @@ Node::setMass(const Matrix &newMass)
 {
     // check right size
     if (newMass.noRows() != numberDOF || newMass.noCols() != numberDOF) {
-	opserr << "Node::setMass - incompatable matrices\n";
+	opserr << "Node::setMass - incompatible matrices\n";
 	return -1;
     }	
 
@@ -1383,7 +1383,7 @@ Node::getRV(const Vector &V)
     
     // check dimesions of R and V
     if (R->noCols() != V.Size()) {
-	opserr << "WARNING Node::getRV() - R and V of incompatable dimesions\n";
+	opserr << "WARNING Node::getRV() - R and V of incompatible dimesions\n";
 	opserr << "R: " << *R << "V: " << V;
 	unbalLoadWithInertia->Zero();
 	return *unbalLoadWithInertia;
@@ -1552,7 +1552,7 @@ Node::sendSelf(int cTag, Channel &theChannel)
 	}
     }
 
-    // if get here succesfull
+    // if get here successful
     return 0;
 }
 
@@ -1610,7 +1610,7 @@ Node::recvSelf(int cTag, Channel &theChannel,
 
       // set the trial quantities equal to committed
       for (int i=0; i<numberDOF; i++)
-	disp[i] = disp[i+numberDOF];  // set trial equal commited
+	disp[i] = disp[i+numberDOF];  // set trial equal committed
 
     } else if (commitDisp != 0) {
       // if going back to initial we will just zero the vectors
@@ -1632,7 +1632,7 @@ Node::recvSelf(int cTag, Channel &theChannel,
 
       // set the trial quantity
       for (int i=0; i<numberDOF; i++)
-	vel[i] = vel[i+numberDOF];  // set trial equal commited
+	vel[i] = vel[i+numberDOF];  // set trial equal committed
     }
 
     if (data(4) == 0) {
@@ -1648,7 +1648,7 @@ Node::recvSelf(int cTag, Channel &theChannel,
       
       // set the trial values
       for (int i=0; i<numberDOF; i++)
-	accel[i] = accel[i+numberDOF];  // set trial equal commited
+	accel[i] = accel[i+numberDOF];  // set trial equal committed
     }
 
     if (data(5) == 0) {

--- a/DEVELOPER/core/Node.h
+++ b/DEVELOPER/core/Node.h
@@ -171,7 +171,7 @@ class Node : public DomainComponent
     int numberDOF;                    // number of dof at Node
     DOF_Group *theDOF_GroupPtr;       // pointer to associated DOF_Group
     Vector *Crd;                      // original nodal coords
-    Vector *commitDisp, *commitVel, *commitAccel; // commited quantities
+    Vector *commitDisp, *commitVel, *commitAccel; // committed quantities
     Vector *trialDisp, *trialVel, *trialAccel;     // trial quantities
     Vector *unbalLoad;                // unbalanced load
     Vector *incrDisp;

--- a/DEVELOPER/core/PlaneStrainMaterial.cpp
+++ b/DEVELOPER/core/PlaneStrainMaterial.cpp
@@ -325,7 +325,7 @@ PlaneStrainMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.sendID(this->getDbTag(), commitTag, idData);
   if (res < 0) {

--- a/DEVELOPER/core/PlaneStressMaterial.cpp
+++ b/DEVELOPER/core/PlaneStressMaterial.cpp
@@ -529,7 +529,7 @@ PlaneStressMaterial::sendSelf(int commitTag, Channel &theChannel)
 {
   int res = 0;
 
-  // put tag and assocaited materials class and database tags into an id and send it
+  // put tag and associated materials class and database tags into an id and send it
   static ID idData(3);
   idData(0) = this->getTag();
   idData(1) = theMaterial->getClassTag();
@@ -571,7 +571,7 @@ PlaneStressMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.sendID(this->getDbTag(), commitTag, idData);
   if (res < 0) {

--- a/DEVELOPER/core/PlateFiberMaterial.cpp
+++ b/DEVELOPER/core/PlateFiberMaterial.cpp
@@ -466,7 +466,7 @@ PlateFiberMaterial::sendSelf(int commitTag, Channel &theChannel)
 {
   int res = 0;
 
-  // put tag and assocaited materials class and database tags into an id and send it
+  // put tag and associated materials class and database tags into an id and send it
   static ID idData(3);
   idData(0) = this->getTag();
   idData(1) = theMaterial->getClassTag();
@@ -506,7 +506,7 @@ PlateFiberMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroke
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.recvID(this->getDbTag(), commitTag, idData);
   if (res < 0) {
@@ -541,7 +541,7 @@ PlateFiberMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroke
   Cstrain22 = vecData(0);
   Tstrain22 = Cstrain22;
 
-  // now receive the assocaited materials data
+  // now receive the associated materials data
   res = theMaterial->recvSelf(commitTag, theChannel, theBroker);
   if (res < 0) 
     opserr << "PlateFiberMaterial::sendSelf() - failed to send vector material\n";

--- a/DEVELOPER/core/SP_Constraint.h
+++ b/DEVELOPER/core/SP_Constraint.h
@@ -70,7 +70,7 @@ class SP_Constraint : public DomainComponent
     int nodeTag;     // to identify the node in the model
     int dofNumber;   // identifies which of the nodes dof is constrrained 
     double valueR;   // the reference value
-    double valueC;   // if constant = the reference value, if not contant =
+    double valueC;   // if constant = the reference value, if not constant =
 	             // the reference value * load factor
     bool isConstant; // flag indicating if constant
     int  loadPatternTag;    

--- a/DEVELOPER/core/Subdomain.cpp
+++ b/DEVELOPER/core/Subdomain.cpp
@@ -204,7 +204,7 @@ bool
 Subdomain::addExternalNode(Node *thePtr)
 {
 #ifdef _G3DEBUG
-  // check to see it has not alredy been added
+  // check to see it has not already been added
 	
   int nodTag = thePtr->getTag();
   TaggedObject *other = externalNodes->getComponentPtr(nodTag);

--- a/DEVELOPER/core/UniaxialMaterial.cpp
+++ b/DEVELOPER/core/UniaxialMaterial.cpp
@@ -364,7 +364,7 @@ UniaxialMaterial::commitSensitivity(double strainSensitivity, int gradIndex, int
 double
 UniaxialMaterial::getInitialTangent (void)
 {
-	opserr << "UniaxialMaterial::getInitialTangent() -- this mehtod " << endln
+	opserr << "UniaxialMaterial::getInitialTangent() -- this method " << endln
 		<< " is not implemented for the selected material. " << endln;
 	return 0.0;
 }

--- a/DEVELOPER/core/Vector.cpp
+++ b/DEVELOPER/core/Vector.cpp
@@ -246,11 +246,11 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
   if (otherFact == 0.0 && thisFact == 1.0)
     return 0; 
 
-  // if sizes are compatable add
+  // if sizes are compatible add
 #ifdef _G3DEBUG
   if (sz != other.sz) {
-    // else sizes are incompatable, do nothing but warning
-    opserr <<  "WARNING Vector::addVector() - incompatable Vector sizes\n";
+    // else sizes are incompatible, do nothing but warning
+    opserr <<  "WARNING Vector::addVector() - incompatible Vector sizes\n";
     return -1;
   }
 #endif
@@ -310,7 +310,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
       }
   } 
 
-  // successfull
+  // successful
   return 0;
 }
 	    
@@ -322,12 +322,12 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
   if (thisFact == 1.0 && otherFact == 0.0)
     return 0;
 
-  // check the sizes are compatable
+  // check the sizes are compatible
 #ifdef _G3DEBUG
-  // check the sizes are compatable
+  // check the sizes are compatible
   if ((sz != m.noRows()) && (m.noCols() != v.sz)) {
-    // otherwise incompatable sizes
-    opserr << "Vector::addMatrixVector() - incompatable sizes\n";
+    // otherwise incompatible sizes
+    opserr << "Vector::addMatrixVector() - incompatible sizes\n";
     return -1;    
   }
 #endif
@@ -440,7 +440,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
     }
   }
   
-  // successfull
+  // successful
   return 0;
 }
 
@@ -457,10 +457,10 @@ Vector::addMatrixTransposeVector(double thisFact,
     return 0;
 
 #ifdef _G3DEBUG
-  // check the sizes are compatable
+  // check the sizes are compatible
   if ((sz != m.noRows()) && (m.noRows() != v.sz)) {
-    // otherwise incompatable sizes
-    opserr << "Vector::addMatrixTransposeVector() - incompatable sizes\n";
+    // otherwise incompatible sizes
+    opserr << "Vector::addMatrixTransposeVector() - incompatible sizes\n";
     return -1;    
   }
 #endif
@@ -687,7 +687,7 @@ Vector::operator()(const ID &rows) const
     return result;
   }
 
-  // copy the appropraite contents from current to result     
+  // copy the appropriate contents from current to result     
   int pos;
   for (int i=0; i<rows.Size(); i++) {
     pos = rows(i);
@@ -702,7 +702,7 @@ Vector::operator()(const ID &rows) const
 
 // Vector &operator=(const Vector  &V):
 //	the assignment operator, This is assigned to be a copy of V. if sizes
-//	are not compatable this.theData [] is deleted. The data pointers will not
+//	are not compatible this.theData [] is deleted. The data pointers will not
 //	point to the same area in mem after the assignment.
 //
 
@@ -714,7 +714,7 @@ Vector::operator=(const Vector &V)
 
 	  /*
 #ifdef _G3DEBUG
-    // check size compatability, if different warning
+    // check size compatibility, if different warning
     if (sz != V.sz) 
       opserr << "Vector::operator=() - vectors of differing sizes\n");
 #endif
@@ -1179,11 +1179,11 @@ Vector::Extract(const Vector &V, int init_pos, double fact)
 
 Matrix Vector::operator%(const Vector &V) const
 {
-  // if sizes are compatable add
+  // if sizes are compatible add
 #ifdef _G3DEBUG
   if (sz != V.sz) {
-    // else sizes are incompatable, do nothing but warning
-    opserr <<  "WARNING Vector::tensor multiplication operator % - incompatable Vector sizes\n";
+    // else sizes are incompatible, do nothing but warning
+    opserr <<  "WARNING Vector::tensor multiplication operator % - incompatible Vector sizes\n";
     return -1;
   }
 #endif

--- a/DEVELOPER/element/c/trussC.c
+++ b/DEVELOPER/element/c/trussC.c
@@ -182,7 +182,7 @@ trussC (eleObj *thisObj, modelState *model, double *tang, double *resid, int *is
 
     theMat->matFunctPtr(theMat, model, matStrain, matTang, matStress, isw, errFlag); 
 
-    /* ******************* instead of call material funtion
+    /* ******************* instead of call material function
     int matNum = 0;
     *errFlag = OPS_InvokeMaterial(thisObj, &matNum, model, matStrain, matStress, matTang, isw); 
     fprintf(stderr,"strain, tang, stress: %e %e %e\n",matStrain[0], matTang[0], matStress[0]);

--- a/DEVELOPER/element/cpp/Truss2D.h
+++ b/DEVELOPER/element/cpp/Truss2D.h
@@ -56,7 +56,7 @@ class Truss2D : public Element
     ~Truss2D();
 
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/DEVELOPER/material/cpp/ElasticPPcpp.h
+++ b/DEVELOPER/material/cpp/ElasticPPcpp.h
@@ -73,8 +73,8 @@ class ElasticPPcpp : public UniaxialMaterial
     double trialStrain;	// trial strain
     double trialStress;      // current trial stress
     double trialTangent;     // current trial tangent
-    double commitStrain;     // last commited strain
-    double commitStress;     // last commited stress
+    double commitStrain;     // last committed strain
+    double commitStress;     // last committed stress
     double commitTangent;    // last committed  tangent
 };
 

--- a/DEVELOPER/recorder/SumElementForcesRecorder.cpp
+++ b/DEVELOPER/recorder/SumElementForcesRecorder.cpp
@@ -126,7 +126,7 @@ SumElementForcesRecorder::record(int commitTag, double timeStamp)
 
   theOutput->write(*data);
 
-  // succesfull completion - return 0
+  // successful completion - return 0
   return 0;
 }
 
@@ -178,7 +178,7 @@ SumElementForcesRecorder::setDomain(Domain &theDom)
   //
   // loop over the list of elements, 
   //    if element exists add it's pointer o the array
-  //    get its resisting force, check size to determine compatable with others
+  //    get its resisting force, check size to determine compatible with others
   // 
 
   int sizeArray = -1;

--- a/DEVELOPER/system/SkylineSPD.cpp
+++ b/DEVELOPER/system/SkylineSPD.cpp
@@ -370,7 +370,7 @@ SkylineSPD::setB(const Vector &v, double fact)
 
     if (v.Size() != size) {
 	opserr << "WARNING BandGenLinSOE::setB() -";
-	opserr << " incomptable sizes " << size << " and " << v.Size() << endln;
+	opserr << " incompatible sizes " << size << " and " << v.Size() << endln;
 	return -1;
     }
     

--- a/SRC/element/Element.tex
+++ b/SRC/element/Element.tex
@@ -78,15 +78,15 @@ setDomain()} method.\\
 
 {\em virtual int commitState(void) =0;} \\
 The element is to commit its current state. To return $0$ if
-sucessfull, a negative number if not. \\
+successful, a negative number if not. \\
 
 {\em virtual int revertToLastCommit(void) =0;} \\
 The element is to set it's current state to the last committed
-state. To return $0$ if sucessfull, a negative number if not. \\
+state. To return $0$ if successful, a negative number if not. \\
 
 {\em virtual int revertToStart(void) =0;} \\
 The element is to set it's current state to the state it was at before
-the analysis started. To return $0$ if sucessfull, a negative number
+the analysis started. To return $0$ if successful, a negative number
 if not. \\ 
 
 {\em virtual int update(void);} \\
@@ -185,7 +185,7 @@ class responds to no requests and will always return $-1$. \\
 \&eleInformation);}\\ 
 getResponse is a method invoked to obtain information from an
 analysis. The method is invoked with the integer argument returned and
-the Information object that was prepared in a successfull {\em
-setResponse()} method invocation. To return $0$ if successfull, a
+the Information object that was prepared in a successful {\em
+setResponse()} method invocation. To return $0$ if successful, a
 negative number if not. The base class implementation will always
 return $-1$. 

--- a/SRC/element/HUelements/KikuchiBearing.cpp
+++ b/SRC/element/HUelements/KikuchiBearing.cpp
@@ -1648,7 +1648,7 @@ void KikuchiBearing::setUp()
   }
 
     
-  // establish orientation of element for the tranformation matrix
+  // establish orientation of element for the transformation matrix
   // z = x cross yp
   Vector oriZ(3);
   oriZ(0) = oriX(1)*oriYp(2) - oriX(2)*oriYp(1);

--- a/SRC/element/HUelements/KikuchiBearing.h
+++ b/SRC/element/HUelements/KikuchiBearing.h
@@ -134,7 +134,7 @@ class KikuchiBearing : public Element
 
 
   //MNS
-  int nMNS; //section is devided into (nMNS)*(nMNS) springs
+  int nMNS; //section is divided into (nMNS)*(nMNS) springs
   double lambda; //parameter, =(D/t)*sqrt(3G/K)
   double incA; //area of each spring
 

--- a/SRC/element/HUelements/MultipleNormalSpring.cpp
+++ b/SRC/element/HUelements/MultipleNormalSpring.cpp
@@ -236,7 +236,7 @@ void* OPS_MultipleNormalSpring()
 
 		recvOrient++ ;
 
-	    } else if (strcmp(flag,"-mass")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-mass m?> ‚Ì“Ç‚İ‚İ
+	    } else if (strcmp(flag,"-mass")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-mass m?> ï¿½Ì“Ç‚İï¿½ï¿½ï¿½
 		numdata = 1;
 		if (OPS_GetDoubleInput(&numdata, &mass)<0 || mass<=0) {
 		    ifNoError = errDetected(ifNoError,"invalid mass");
@@ -1038,7 +1038,7 @@ void MultipleNormalSpring::setUp()
     exit(-1);
   }
     
-  // establish orientation of element for the tranformation matrix
+  // establish orientation of element for the transformation matrix
   // z = x cross yp
   Vector oriZ(3);
   oriZ(0) = oriX(1)*oriYp(2) - oriX(2)*oriYp(1);

--- a/SRC/element/HUelements/MultipleShearSpring.cpp
+++ b/SRC/element/HUelements/MultipleShearSpring.cpp
@@ -185,7 +185,7 @@ void* OPS_MultipleShearSpring()
 		    }
 		}
 
-	    } else if (strcmp(flag,"-orient")==0 && OPS_GetNumRemainingInputArgs()>=3) { // <-orient yp1? yp2? yp3?> ‚Ì“Ç‚İ‚İ	  
+	    } else if (strcmp(flag,"-orient")==0 && OPS_GetNumRemainingInputArgs()>=3) { // <-orient yp1? yp2? yp3?> ï¿½Ì“Ç‚İï¿½ï¿½ï¿½	  
 
 		for (int j=1; j<=3; j++) {
 		    if (OPS_GetDoubleInput(&numdata, &value) < 0) {
@@ -196,13 +196,13 @@ void* OPS_MultipleShearSpring()
 		    }
 		}
 
-	    } else if (strcmp(flag,"-mass")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-mass m?> ‚Ì“Ç‚İ‚İ
+	    } else if (strcmp(flag,"-mass")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-mass m?> ï¿½Ì“Ç‚İï¿½ï¿½ï¿½
 		if (OPS_GetDoubleInput(&numdata, &mass) < 0 || mass <= 0) {
 		    opserr << "WARNING invalid mass\n";
 		    ifNoError = false;
 		}
 
-	    } else if (strcmp(flag,"-lim")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-lim limDisp?> ‚Ì“Ç‚İ‚İ
+	    } else if (strcmp(flag,"-lim")==0 && OPS_GetNumRemainingInputArgs()>0) { // <-lim limDisp?> ï¿½Ì“Ç‚İï¿½ï¿½ï¿½
 		if (OPS_GetDoubleInput(&numdata, &limDisp) < 0 || limDisp < 0) {
 		    opserr << "WARNING invalid limDisp\n";
 		    ifNoError = false;
@@ -315,7 +315,7 @@ MultipleShearSpring::MultipleShearSpring(int Tag, int Nd1, int Nd2,
 
 
   //calculate Feq and Seq
-  //imaginary material to caluculate Feq and Seq
+  //imaginary material to calculate Feq and Seq
   dmyMssMaterial = Material->getCopy();
   if (dmyMssMaterial == 0) {
     opserr << "MultipleShearSpring::MultipleShearSpring() - "
@@ -438,7 +438,7 @@ MultipleShearSpring::MultipleShearSpring(int Tag, int Nd1, int Nd2,
 
 
   //calculate Feq and Seq
-  //imaginary material to caluculate Feq and Seq
+  //imaginary material to calculate Feq and Seq
   dmyMssMaterial = theMaterials[0]->getCopy();
   if (dmyMssMaterial == 0) {
     opserr << "MultipleShearSpring::MultipleShearSpring() - "
@@ -1106,7 +1106,7 @@ void MultipleShearSpring::setUp()
     exit(-1);
   }
     
-  // establish orientation of element for the tranformation matrix
+  // establish orientation of element for the transformation matrix
   // z = x cross yp
   Vector oriZ(3);
   oriZ(0) = oriX(1)*oriYp(2) - oriX(2)*oriYp(1);

--- a/SRC/element/HUelements/YamamotoBiaxialHDR.cpp
+++ b/SRC/element/HUelements/YamamotoBiaxialHDR.cpp
@@ -1077,7 +1077,7 @@ void YamamotoBiaxialHDR::setUp()
     exit(-1);
   }
     
-  // establish orientation of element for the tranformation matrix
+  // establish orientation of element for the transformation matrix
   // z = x cross yp
   Vector oriZ(3);
   oriZ(0) = oriX(1)*oriYp(2) - oriX(2)*oriYp(1);

--- a/SRC/element/NewElement.h
+++ b/SRC/element/NewElement.h
@@ -50,7 +50,7 @@ class NewElement : public Element
 
 	const char *getClassType(void) const {return "NewElement";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/PFEMElement/BackgroundMesh.cpp
+++ b/SRC/element/PFEMElement/BackgroundMesh.cpp
@@ -219,19 +219,19 @@ int OPS_BackgroundMesh()
 
 	    // node coord
 	    if (OPS_GetDoubleInput(&ndm, &p1(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for first point\n";
+		opserr<<"WARNING: failed to get coordinates for first point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p2(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for second point\n";
+		opserr<<"WARNING: failed to get coordinates for second point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p3(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for third point\n";
+		opserr<<"WARNING: failed to get coordinates for third point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p4(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for fouth point\n";
+		opserr<<"WARNING: failed to get coordinates for fourth point\n";
 		return -1;
 	    }
 
@@ -251,15 +251,15 @@ int OPS_BackgroundMesh()
 
 	    // node coord
 	    if (OPS_GetDoubleInput(&ndm, &p1(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for first point\n";
+		opserr<<"WARNING: failed to get coordinates for first point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p2(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for second point\n";
+		opserr<<"WARNING: failed to get coordinates for second point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p3(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for third point\n";
+		opserr<<"WARNING: failed to get coordinates for third point\n";
 		return -1;
 	    }
 
@@ -278,11 +278,11 @@ int OPS_BackgroundMesh()
 
 	    // node coord
 	    if (OPS_GetDoubleInput(&ndm, &p1(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for first point\n";
+		opserr<<"WARNING: failed to get coordinates for first point\n";
 		return -1;
 	    }
 	    if (OPS_GetDoubleInput(&ndm, &p2(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for second point\n";
+		opserr<<"WARNING: failed to get coordinates for second point\n";
 		return -1;
 	    }
 
@@ -301,7 +301,7 @@ int OPS_BackgroundMesh()
 	    
 	    // node coord
 	    if (OPS_GetDoubleInput(&ndm, &p1(0)) < 0) {
-		opserr<<"WARNING: failed to get cooridnates for point\n";
+		opserr<<"WARNING: failed to get coordinates for point\n";
 		return -1;
 	    }
 	    
@@ -1679,7 +1679,7 @@ BackgroundMesh::moveParticles()
 		    double ux = disp(0);
 		    double uy = disp(1);
 
-		    // node cooridnates of original step
+		    // node coordinates of original step
 		    const Vector& crds = elenodes[2*j]->getCrds();
 		    x[j] = crds(0);
 		    y[j] = crds(1);

--- a/SRC/element/PFEMElement/LineMesh.cpp
+++ b/SRC/element/PFEMElement/LineMesh.cpp
@@ -266,7 +266,7 @@ LineMesh::mesh(double size, int tag1, int tag2, ID& nodes, ID& elenodes)
     int currtag = 0;
     if(theNode != 0) currtag = theNode->getTag();
 
-    // creat nodes
+    // create nodes
     if(nele > 1) {
 	nodes.resize(nele-1);
     }

--- a/SRC/element/PFEMElement/PFEMElement2D.cpp
+++ b/SRC/element/PFEMElement/PFEMElement2D.cpp
@@ -93,7 +93,7 @@ int OPS_PFEMElement2D(Domain& theDomain, const ID& elenodes, ID& eletags)
 	theEle = new PFEMElement2D(--currTag,elenodes(3*i),elenodes(3*i+1),elenodes(3*i+2),
 				   data[0],data[1],data[2],data[3],data[4],data[5],data[6]);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -182,7 +182,7 @@ PFEMElement2D::update()
     double J = cc[0]*dd[1]-dd[0]*cc[1];
 
     if(fabs(J)<1e-15) {
-        opserr<<"WARING: element area is nearly zero";
+        opserr<<"WARNING: element area is nearly zero";
         opserr<<" -- PFEMElement2D::update\n";
 	for (int i=0; i<3; i++) {
 	    opserr<<"node "<<ntags[2*i]<<"\n";

--- a/SRC/element/PFEMElement/PFEMElement2DBubble.cpp
+++ b/SRC/element/PFEMElement/PFEMElement2DBubble.cpp
@@ -98,7 +98,7 @@ int OPS_PFEMElement2DBubble(Domain& theDomain, const ID& elenodes, ID& eletags)
 	theEle = new PFEMElement2DBubble(--currTag,elenodes(3*i),elenodes(3*i+1),elenodes(3*i+2),
 					 data[0],data[1],data[2],data[3],data[4],data[5]);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -203,7 +203,7 @@ PFEMElement2DBubble::update()
 
     if(fabs(J)<1e-15) {
 	//if(J < 0) {
-        opserr<<"WARING: element "<<this->getTag()<<" area is negative";
+        opserr<<"WARNING: element "<<this->getTag()<<" area is negative";
         opserr<<" -- PFEMElement2DBubble::update\n";
         return -1;
     }
@@ -321,7 +321,7 @@ PFEMElement2DBubble::getResistingForceIncInertia()
     P.resize(ndf);
     P.Zero();
 
-    // get velocity, accleration
+    // get velocity, acceleration
     Vector v(ndf), vdot(ndf);
     for(int i=0; i<3; i++) {
         const Vector& accel = nodes[2*i]->getTrialAccel();

--- a/SRC/element/PFEMElement/PFEMElement2DCompressible.cpp
+++ b/SRC/element/PFEMElement/PFEMElement2DCompressible.cpp
@@ -96,7 +96,7 @@ int OPS_PFEMElement2DCompressible(Domain& theDomain, const ID& elenodes, ID& ele
 	theEle = new PFEMElement2DCompressible(--currTag,elenodes(3*i),elenodes(3*i+1),elenodes(3*i+2),
 					       data[0],data[1],data[2],data[3],data[4],data[5]);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -222,7 +222,7 @@ PFEMElement2DCompressible::update()
     // check Jacobi
     if(fabs(J)<1e-15) {
 	//if(J < 0) {
-        opserr<<"WARING: element area is negative";
+        opserr<<"WARNING: element area is negative";
         opserr<<" -- PFEMElement2DCompressible::update\n";
         return -1;
     }

--- a/SRC/element/PFEMElement/PFEMElement2DFIC.cpp
+++ b/SRC/element/PFEMElement/PFEMElement2DFIC.cpp
@@ -329,7 +329,7 @@ PFEMElement2DFIC::getResistingForceIncInertia()
     P.resize(ndf);
     P.Zero();
 
-    // get velocity, accleration
+    // get velocity, acceleration
     Vector v(ndf), vdot(ndf);
     for(int i=0; i<3; i++) {
         const Vector& accel = nodes[2*i]->getTrialAccel();

--- a/SRC/element/PFEMElement/PFEMElement2Dmini.cpp
+++ b/SRC/element/PFEMElement/PFEMElement2Dmini.cpp
@@ -336,7 +336,7 @@ PFEMElement2Dmini::getResistingForceIncInertia()
     P.resize(ndf);
     P.Zero();
     
-    // get velocity, accleration
+    // get velocity, acceleration
     Vector v(ndf), vdot(ndf);
     for(int a=0; a<3; a++) {
 

--- a/SRC/element/PFEMElement/PFEMElement3D.cpp
+++ b/SRC/element/PFEMElement/PFEMElement3D.cpp
@@ -343,7 +343,7 @@ PFEMElement3D::getResistingForceIncInertia()
     P.resize(ndf);
     P.Zero();
 
-    // get velocity, accleration
+    // get velocity, acceleration
     Vector v(ndf), vdot(ndf);
     for(int i=0; i<4; i++) {
         const Vector& accel = nodes[2*i]->getTrialAccel();

--- a/SRC/element/PFEMElement/PFEMElement3Dmini.cpp
+++ b/SRC/element/PFEMElement/PFEMElement3Dmini.cpp
@@ -342,7 +342,7 @@ PFEMElement3Dmini::getResistingForceIncInertia()
     int numnodes = ntags.Size()/2;
     int ndm = body.Size();
     
-    // get velocity, accleration
+    // get velocity, acceleration
     Vector v(ndf), vdot(ndf);
     for(int a=0; a<numnodes; a++) {
 

--- a/SRC/element/PFEMElement/ParticleGroup.cpp
+++ b/SRC/element/PFEMElement/ParticleGroup.cpp
@@ -98,7 +98,7 @@ ParticleGroup::line(const Vector& p1, const Vector& p2, int num,
     if(p1.Size() != p2.Size()) return -1;
     
     if(ndf == 0) {
-	opserr<<"WARNING: type of particle has not been set or unkown\n";
+	opserr<<"WARNING: type of particle has not been set or unknown\n";
 	return -1;
     }
     

--- a/SRC/element/PFEMElement/TclPFEMCommands.cpp
+++ b/SRC/element/PFEMElement/TclPFEMCommands.cpp
@@ -25,7 +25,7 @@
 // Written: Minjie
 //
 // Description: This file contains the function that is invoked
-// by the interpreter when the comand 'PFEM2D' is invoked by the 
+// by the interpreter when the command 'PFEM2D' is invoked by the 
 // user.
 //
 
@@ -1191,7 +1191,7 @@ TclModelBuilderPFEM2DCommand(ClientData clientData, Tcl_Interp *interp, int argc
 
         int type = -1;
         if(Tcl_GetInt(interp, argv[2], &type) != TCL_OK) {
-            opserr<<"WARING: invalid type "<<argv[2];
+            opserr<<"WARNING: invalid type "<<argv[2];
             opserr<<" -- PFEM2D group \n";
             return TCL_ERROR;
         }
@@ -1246,7 +1246,7 @@ TclModelBuilderPFEM2DCommand(ClientData clientData, Tcl_Interp *interp, int argc
         } else if(strcmp(argv[2],"accel")==0 || strcmp(argv[2],"Accel")==0) {
             type = 3;
         } else {
-            opserr<<"WARNING: unkown type for updating -- ";
+            opserr<<"WARNING: unknown type for updating -- ";
             opserr<<"PFEM2D updateNode coord/disp/vel/accel tag dof val\n";
             return -1;
         }
@@ -2319,7 +2319,7 @@ TclModelBuilderPFEM2DCommand(ClientData clientData, Tcl_Interp *interp, int argc
                 return TCL_OK;
                 
             } else {
-                opserr<<"WARNING: unknow operation on region -- ";
+                opserr<<"WARNING: unknown operation on region -- ";
                 opserr<<"PFEM2D region node "<<argv[3]<<"\n";
                 return TCL_ERROR;
             }
@@ -2409,7 +2409,7 @@ TclModelBuilderPFEM2DCommand(ClientData clientData, Tcl_Interp *interp, int argc
                 return TCL_OK;
                 
             } else {
-                opserr<<"WARNING: unknow operation on region -- ";
+                opserr<<"WARNING: unknown operation on region -- ";
                 opserr<<"PFEM2D region ele "<<argv[3]<<"\n";
                 return TCL_ERROR;
             }

--- a/SRC/element/TclElementCommands.cpp
+++ b/SRC/element/TclElementCommands.cpp
@@ -389,7 +389,7 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
   if ((strcmp(argv[1],"truss") == 0) || (strcmp(argv[1],"Truss") == 0)) {
     
     void *theEle = OPS_TrussElement();
-    // for backward compatability
+    // for backward compatibility
 	if (theEle == 0) {
       theEle = OPS_TrussSectionElement(); 
 	}
@@ -417,7 +417,7 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
     
     void *theEle = OPS_CorotTrussElement();
     
-    // for backward compatability
+    // for backward compatibility
     if (theEle == 0)
       theEle = OPS_CorotTrussSectionElement(); 
     
@@ -723,7 +723,7 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
 	opserr << "TclElementCommand -- unable to create element of type : " << argv[1] << endln;
 	return TCL_ERROR;
       }
-      //end of adding thermo-mechanical shell elments by L.Jiang [SIF]  
+      //end of adding thermo-mechanical shell elements by L.Jiang [SIF]  
       
   } else if ((strcmp(argv[1],"shellNL") == 0) || (strcmp(argv[1],"ShellNL") == 0) ||
 	     (strcmp(argv[1],"shellMITC9") == 0) || (strcmp(argv[1],"ShellMITC9") == 0)) {
@@ -1450,7 +1450,7 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
     }
 
     //
-    // try loading new dynamic library containg a c+= class
+    // try loading new dynamic library containing a c+= class
     //
     
     void *libHandle;

--- a/SRC/element/UP-ucsd/BBarBrickUP.cpp
+++ b/SRC/element/UP-ucsd/BBarBrickUP.cpp
@@ -706,7 +706,7 @@ BBarBrickUP::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
 	  appliedB[0] += loadFactor*data(0)*b[0];
 	  appliedB[1] += loadFactor*data(1)*b[1];

--- a/SRC/element/UP-ucsd/BBarFourNodeQuadUP.cpp
+++ b/SRC/element/UP-ucsd/BBarFourNodeQuadUP.cpp
@@ -676,7 +676,7 @@ BBarFourNodeQuadUP::addInertiaLoadToUnbalance(const Vector &accel)
 
   if (3 != Raccel1.Size() || 3 != Raccel2.Size() || 3 != Raccel3.Size() ||
       3 != Raccel4.Size()) {
-    opserr << "BBarFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "BBarFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
 

--- a/SRC/element/UP-ucsd/BrickUP.cpp
+++ b/SRC/element/UP-ucsd/BrickUP.cpp
@@ -727,7 +727,7 @@ BrickUP::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
 	  appliedB[0] += loadFactor*data(0)*b[0];
 	  appliedB[1] += loadFactor*data(1)*b[1];

--- a/SRC/element/UP-ucsd/FourNodeQuadUP.cpp
+++ b/SRC/element/UP-ucsd/FourNodeQuadUP.cpp
@@ -682,7 +682,7 @@ FourNodeQuadUP::addInertiaLoadToUnbalance(const Vector &accel)
 
   if (3 != Raccel1.Size() || 3 != Raccel2.Size() || 3 != Raccel3.Size() ||
       3 != Raccel4.Size()) {
-    opserr << "FourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "FourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
 

--- a/SRC/element/UP-ucsd/Nine_Four_Node_QuadUP.cpp
+++ b/SRC/element/UP-ucsd/Nine_Four_Node_QuadUP.cpp
@@ -1131,7 +1131,7 @@ NineFourNodeQuadUP::addInertiaLoadToUnbalance(const Vector &accel)
 
       if ((i<nenp && 3 != Raccel.Size()) || (i>=nenp && 2 != Raccel.Size())) {
 
-         opserr << "NineFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+         opserr << "NineFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 
          return -1;
 
@@ -1311,7 +1311,7 @@ NineFourNodeQuadUP::getResistingForceIncInertia()
 
     if ((i<nenp && 3 != accel.Size()) || (i>=nenp && 2 != accel.Size())) {
 
-      opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+      opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
          return P;
 
@@ -1365,7 +1365,7 @@ NineFourNodeQuadUP::getResistingForceIncInertia()
 
       if ((i<nenp && 3 != vel.Size()) || (i>=nenp && 2 != vel.Size())) {
 
-         opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+         opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
          return P;
 

--- a/SRC/element/UP-ucsd/Nine_Four_Node_QuadUPOld.cpp
+++ b/SRC/element/UP-ucsd/Nine_Four_Node_QuadUPOld.cpp
@@ -539,7 +539,7 @@ NineFourNodeQuadUP::addInertiaLoadToUnbalance(const Vector &accel)
   for (i=0; i<nenu; i++) {
       const Vector &Raccel = theNodes[i]->getRV(accel);
       if ((i<nenp && 3 != Raccel.Size()) || (i>=nenp && 2 != Raccel.Size())) {
-         opserr << "NineFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+         opserr << "NineFourNodeQuadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
          return -1;
 	  }
 
@@ -625,7 +625,7 @@ NineFourNodeQuadUP::getResistingForceIncInertia()
   for (i=0; i<nenu; i++) {
     const Vector &accel = theNodes[i]->getTrialAccel();
     if ((i<nenp && 3 != accel.Size()) || (i>=nenp && 2 != accel.Size())) {
-      opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+      opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
          return P;
     }
     
@@ -652,7 +652,7 @@ NineFourNodeQuadUP::getResistingForceIncInertia()
   for (i=0; i<nenu; i++) {
       const Vector &vel = theNodes[i]->getTrialVel();
       if ((i<nenp && 3 != vel.Size()) || (i>=nenp && 2 != vel.Size())) {
-         opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+         opserr << "NineFourNodeQuadUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
          return P;
       }
 

--- a/SRC/element/UP-ucsd/TclFourNodeQuadUPCommand.cpp
+++ b/SRC/element/UP-ucsd/TclFourNodeQuadUPCommand.cpp
@@ -182,7 +182,7 @@ TclModelBuilder_addFourNodeQuadUP(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -324,7 +324,7 @@ TclModelBuilder_addBrickUP(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -458,7 +458,7 @@ TclModelBuilder_addNineFourNodeQuadUP(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -601,7 +601,7 @@ TclModelBuilder_addTwentyEightNodeBrickUP(ClientData clientData, Tcl_Interp *int
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -760,7 +760,7 @@ TclModelBuilder_addBBarFourNodeQuadUP(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -902,6 +902,6 @@ TclModelBuilder_addBBarBrickUP(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }

--- a/SRC/element/UP-ucsd/Twenty_Eight_Node_BrickUP.cpp
+++ b/SRC/element/UP-ucsd/Twenty_Eight_Node_BrickUP.cpp
@@ -1519,7 +1519,7 @@ TwentyEightNodeBrickUP::addLoad(ElementalLoad *theLoad, double loadFactor)
         appliedB[2] += loadFactor * b[2];
       return 0;
     } else if (type == LOAD_TAG_SelfWeight) {
-        // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+        // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
         applyLoad = 1;
 	    appliedB[0] += loadFactor*data(0)*b[0];
 	    appliedB[1] += loadFactor*data(1)*b[1];
@@ -1555,7 +1555,7 @@ TwentyEightNodeBrickUP::addInertiaLoadToUnbalance(const Vector &accel)
 
 		if ((i<nenp && 4 != Raccel.Size()) || (i>=nenp && 3 != Raccel.Size())) {
 
-			opserr << "TwentyEightNodeBrickUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+			opserr << "TwentyEightNodeBrickUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 
 			return -1;
 
@@ -1855,7 +1855,7 @@ const Vector&  TwentyEightNodeBrickUP::getResistingForceIncInertia( )
 
 		if ((i<nenp && 4 != accel.Size()) || (i>=nenp && 3 != accel.Size())) {
 
-			opserr << "TwentyEightNodeBrickUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+			opserr << "TwentyEightNodeBrickUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
 			exit(-1);
 
@@ -1919,7 +1919,7 @@ const Vector&  TwentyEightNodeBrickUP::getResistingForceIncInertia( )
 
 		if ((i<nenp && 4 != vel.Size()) || (i>=nenp && 3 != vel.Size())) {
 
-			opserr << "TwentyEightNodeBrickUP::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+			opserr << "TwentyEightNodeBrickUP::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
 			exit(-1);
 

--- a/SRC/element/UWelements/BeamContact2D.cpp
+++ b/SRC/element/UWelements/BeamContact2D.cpp
@@ -736,7 +736,7 @@ BeamContact2D::UpdateEndFrames(void)
 	// perform update for node a
 	ma_1 += rot_a*mEyeS*ma_1;
 
-	// perfrom update for node b
+	// perform update for node b
 	mb_1 += rot_b*mEyeS*mb_1;
 
 	// update displacement vectors for next step

--- a/SRC/element/UWelements/BeamContact2Dp.cpp
+++ b/SRC/element/UWelements/BeamContact2Dp.cpp
@@ -734,7 +734,7 @@ BeamContact2Dp::UpdateEndFrames(void)
 	// perform update for node a
 	ma_1 += rot_a*mEyeS*ma_1;
 
-	// perfrom update for node b
+	// perform update for node b
 	mb_1 += rot_b*mEyeS*mb_1;
 
 	// update displacement vectors for next step

--- a/SRC/element/UWelements/BeamContact3D.cpp
+++ b/SRC/element/UWelements/BeamContact3D.cpp
@@ -391,8 +391,8 @@ BeamContact3D::setDomain(Domain *theDomain)
     opserr << "BeamContact3D::setDomain(): Error initializing coordinate transformation";  
     exit(0);
     }
-    // Note: the following intialization is already performed in crdTransf
-    //       but it doesnt return the values to beamContact element
+    // Note: the following initialization is already performed in crdTransf
+    //       but it doesn't return the values to beamContact element
     Vector initXAxis(3);
     Vector initYAxis(3);
     Vector initZAxis(3);
@@ -737,7 +737,7 @@ BeamContact3D::project(double xi)
                 // initialize xi_P to previous value of xi
                 xi_P = xi;
 
-                // Perform exponential update of coordinate tranforms Qa, Qb
+                // Perform exponential update of coordinate transforms Qa, Qb
                 UpdateTransforms();
                 // set tangent vectors from Qa, Qb for calc of x_c_P
                 a1 = Geta1();
@@ -782,7 +782,7 @@ BeamContact3D::project(double xi)
                 // update norm, n, for current projection
                 mn = (mDcrd_s - x_c_P) / ( (mDcrd_s - x_c_P).Norm() );
 
-                // set value of c1 for current proejction for use in ComputeQc
+                // set value of c1 for current projection for use in ComputeQc
                 Setc1( (tc/tc.Norm()) );
 
                 // update Hermitian Basis functions for use in ComputeB

--- a/SRC/element/UWelements/BeamContact3D.h
+++ b/SRC/element/UWelements/BeamContact3D.h
@@ -62,7 +62,7 @@ class BeamContact3D : public Element
     BeamContact3D();
     ~BeamContact3D();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);
@@ -127,7 +127,7 @@ class BeamContact3D : public Element
     Vector Getddx_c(double xi);         // returns d^2(x_c)/ dxi^2
    
     // objects
-    CrdTransf  *crdTransf;              // pointer to coordinate tranformation object
+    CrdTransf  *crdTransf;              // pointer to coordinate transformation object
     ContactMaterial3D *theMaterial;     // contact material object
    
     ID  externalNodes;                  // contains the tags of the end nodes

--- a/SRC/element/UWelements/BeamContact3Dp.cpp
+++ b/SRC/element/UWelements/BeamContact3Dp.cpp
@@ -333,8 +333,8 @@ BeamContact3Dp::setDomain(Domain *theDomain)
       opserr << "BeamContact3Dp::setDomain(): Error initializing coordinate transformation";  
       exit(0);
     }
-    // Note: the following intialization is already performed in crdTransf
-    //       but it doesnt return the values to beamContact element
+    // Note: the following initialization is already performed in crdTransf
+    //       but it doesn't return the values to beamContact element
     Vector initXAxis(3);
     Vector initYAxis(3);
     Vector initZAxis(3);
@@ -602,7 +602,7 @@ BeamContact3Dp::project(double xi)
     // initialize xi_P to previous value of xi
     xi_P = xi;
 
-    // Perform exponential update of coordinate tranforms Qa, Qb
+    // Perform exponential update of coordinate transforms Qa, Qb
     UpdateTransforms();
     // set tangent vectors from Qa, Qb for calc of x_c_P
     a1 = Geta1();
@@ -647,7 +647,7 @@ BeamContact3Dp::project(double xi)
     // update norm, n, for current projection
     mn = (mDcrd_s - x_c_P) / ( (mDcrd_s - x_c_P).Norm() );
 
-    // set value of c1 for current proejction for use in ComputeQc
+    // set value of c1 for current projection for use in ComputeQc
     Setc1( (tc/tc.Norm()) );
 
     // update Hermitian Basis functions for use in ComputeB

--- a/SRC/element/UWelements/BeamContact3Dp.h
+++ b/SRC/element/UWelements/BeamContact3Dp.h
@@ -56,7 +56,7 @@ class BeamContact3Dp : public Element
     BeamContact3Dp();
     ~BeamContact3Dp();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);
@@ -122,7 +122,7 @@ class BeamContact3Dp : public Element
     Vector Getddx_c(double xi);                            // returns d^2(x_c)/ dxi^2
    
     // objects
-    CrdTransf  *crdTransf;                                 // pointer to coordinate tranformation object
+    CrdTransf  *crdTransf;                                 // pointer to coordinate transformation object
     ContactMaterial3D *theMaterial;                        // contact material object
    
     ID  externalNodes;                                     // contains the tags of the end nodes

--- a/SRC/element/UWelements/BeamEndContact3D.cpp
+++ b/SRC/element/UWelements/BeamEndContact3D.cpp
@@ -217,7 +217,7 @@ BeamEndContact3D::setDomain(Domain *theDomain)
 	x_b = theDomain->getNode(mBeamNode);
 	mIcrd_b = x_b->getCrds();
 
-	// intialize the normal vector
+	// initialize the normal vector
 	mIniNormal = -1*(mIcrd_b - mIcrd_a)/(mIcrd_b - mIcrd_a).Norm();
 	mNormal = mIniNormal;
 

--- a/SRC/element/UWelements/BeamEndContact3Dp.cpp
+++ b/SRC/element/UWelements/BeamEndContact3Dp.cpp
@@ -209,7 +209,7 @@ BeamEndContact3Dp::setDomain(Domain *theDomain)
 	x_b = theDomain->getNode(mBeamNode);
 	mIcrd_b = x_b->getCrds();
 
-	// intialize the normal vector
+	// initialize the normal vector
 	mIniNormal = -1*(mIcrd_b - mIcrd_a)/(mIcrd_b - mIcrd_a).Norm();
 	mNormal = mIniNormal;
 

--- a/SRC/element/UWelements/Brick8FiberOverlay.cpp
+++ b/SRC/element/UWelements/Brick8FiberOverlay.cpp
@@ -140,7 +140,7 @@ Brick8FiberOverlay::Brick8FiberOverlay(int tag, int nd1, int nd2, int nd3, int n
 	Vf = nFj - nFi; 
 	Vf.Normalize();
 
-	//set up integration paramaters (2 intgr pts)
+	//set up integration parameters (2 intgr pts)
 	pts[0][0] = nFi(0)+Vf(0)*(1-0.5773502691896258);   
 	pts[0][1] = nFi(1)+Vf(1)*(1-0.5773502691896258);	
 	pts[0][2] = nFi(2)+Vf(2)*(1-0.5773502691896258);		

--- a/SRC/element/UWelements/Brick8FiberOverlay.h
+++ b/SRC/element/UWelements/Brick8FiberOverlay.h
@@ -59,7 +59,7 @@ class Brick8FiberOverlay : public Element
 		// initialization
 		void setDomain(Domain *thedomain);
  
-		// public methods to obtain inforrmation about dof & connectivity                 
+		// public methods to obtain information about dof & connectivity                 
 		 int getNumExternalNodes(void) const;
 		 const ID &getExternalNodes(void);
 		 Node **getNodePtrs(void);

--- a/SRC/element/UWelements/EmbeddedBeamInterfaceL.h
+++ b/SRC/element/UWelements/EmbeddedBeamInterfaceL.h
@@ -132,7 +132,7 @@ private:
 
     int     m_numBeamNodes, m_numSolidNodes, m_numEmbeddedPoints;
 
-    CrdTransf* crdTransf;  // pointer to coordinate tranformation object
+    CrdTransf* crdTransf;  // pointer to coordinate transformation object
 
     Vector  m_Lambda;
     

--- a/SRC/element/UWelements/EmbeddedBeamInterfaceP.h
+++ b/SRC/element/UWelements/EmbeddedBeamInterfaceP.h
@@ -131,7 +131,7 @@ private:
 
     int     m_numBeamNodes, m_numSolidNodes, m_numEmbeddedPoints;
 
-    CrdTransf* crdTransf;  // pointer to coordinate tranformation object
+    CrdTransf* crdTransf;  // pointer to coordinate transformation object
 
     Vector  m_Lambda;
 

--- a/SRC/element/UWelements/EmbeddedEPBeamInterface.h
+++ b/SRC/element/UWelements/EmbeddedEPBeamInterface.h
@@ -133,7 +133,7 @@ private:
 
     int     m_numBeamNodes, m_numSolidNodes, m_numEmbeddedPoints;
 
-    CrdTransf*  crdTransf;  // pointer to coordinate tranformation object
+    CrdTransf*  crdTransf;  // pointer to coordinate transformation object
     NDMaterial** theMat;     // pointer to the interface material
 
     Vector  m_Lambda;

--- a/SRC/element/UWelements/PileToe3D.cpp
+++ b/SRC/element/UWelements/PileToe3D.cpp
@@ -245,7 +245,7 @@ PileToe3D::setDomain(Domain *theDomain)
 	//mNodeCrd(0,0) = mIcrd_1(0);  
   }
 
-  //Initialize Coordinate Tranformation
+  //Initialize Coordinate Transformation
   if (crdTransf->initialize(theBNodes[0], theBNodes[1])) {
 	  // Add some error check
   }

--- a/SRC/element/UWelements/PileToe3D.h
+++ b/SRC/element/UWelements/PileToe3D.h
@@ -57,7 +57,7 @@ class PileToe3D : public Element
     PileToe3D();
     ~PileToe3D();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
 	int getNumExternalBNodes(void) const;
     const ID &getExternalNodes(void);
@@ -103,7 +103,7 @@ class PileToe3D : public Element
     // member functions
    
     // objects
-    CrdTransf  *crdTransf;              // pointer to coordinate tranformation object   
+    CrdTransf  *crdTransf;              // pointer to coordinate transformation object   
     ID  externalNodes;                  // contains the tags of the end nodes
 	ID  externalBNodes;                 // contains the tags of the bean element used to determine normal to pile toe
     Vector theVector;                   // vector to return the residual

--- a/SRC/element/UWelements/Quad4FiberOverlay.cpp
+++ b/SRC/element/UWelements/Quad4FiberOverlay.cpp
@@ -171,7 +171,7 @@ Quad4FiberOverlay::Quad4FiberOverlay(int tag, int nd1, int nd2, int nd3, int nd4
 	AA(1) = A(1)*A(1);
 	AA(2) = A(1)*A(0);  // note that gamma = 2 * eps12
 	    
-	//Set up integration paramaters 
+	//Set up integration parameters 
 	pts[0] = 0.5 * (nFi(0)+nFj(0));   
 	pts[1] = 0.5 * (nFi(1)+nFj(1)); 
 	wts	   = 2.0;       

--- a/SRC/element/UWelements/SSPbrick.cpp
+++ b/SRC/element/UWelements/SSPbrick.cpp
@@ -1138,7 +1138,7 @@ SSPbrick::GetStab(void)
 	z(6) = mNodeCrd(2,6);
 	z(7) = mNodeCrd(2,7);
 
-	// define coefficent terms for jacobian determinant
+	// define coefficient terms for jacobian determinant
     double 	a1 = x^xi;
     double 	a2 = x^et;
     double 	a3 = x^ze;

--- a/SRC/element/UWelements/SSPbrickUP.cpp
+++ b/SRC/element/UWelements/SSPbrickUP.cpp
@@ -1313,7 +1313,7 @@ SSPbrickUP::GetStab(void)
 	z(6) = mNodeCrd(2,6);
 	z(7) = mNodeCrd(2,7);
 
-	// define coefficent terms for jacobian determinant
+	// define coefficient terms for jacobian determinant
     double 	a1 = x^xi;
     double 	a2 = x^et;
     double 	a3 = x^ze;

--- a/SRC/element/UWelements/SSPquad.cpp
+++ b/SRC/element/UWelements/SSPquad.cpp
@@ -410,7 +410,7 @@ SSPquad::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel4 = theNodes[3]->getRV(accel);
 
 	if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size() || 2 != Raccel4.Size()) {
-    	opserr << "FourNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    	opserr << "FourNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     	return -1;
 	}
 

--- a/SRC/element/UWelements/SSPquadUP.cpp
+++ b/SRC/element/UWelements/SSPquadUP.cpp
@@ -593,7 +593,7 @@ SSPquadUP::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel4 = theNodes[3]->getRV(accel);
 
 	if (3 != Raccel1.Size() || 3 != Raccel2.Size() || 3 != Raccel3.Size() || 3 != Raccel4.Size()) {
-    	opserr << "SSPquadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    	opserr << "SSPquadUP::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     	return -1;
 	}
 

--- a/SRC/element/UWelements/SimpleContact2D.h
+++ b/SRC/element/UWelements/SimpleContact2D.h
@@ -65,7 +65,7 @@ class SimpleContact2D : public Element
     SimpleContact2D();
     ~SimpleContact2D();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/UWelements/SimpleContact3D.cpp
+++ b/SRC/element/UWelements/SimpleContact3D.cpp
@@ -325,7 +325,7 @@ SimpleContact3D::setDomain(Domain *theDomain)
 	  exit(-1);
 	}
 
-        XiEta_n.Zero();  // initally xi and eta = 0
+        XiEta_n.Zero();  // initially xi and eta = 0
 
         XiEta_n = this->project(XiEta_n);
         // this->UpdateBase(XiEta_n);

--- a/SRC/element/UWelements/SimpleContact3D.h
+++ b/SRC/element/UWelements/SimpleContact3D.h
@@ -62,7 +62,7 @@ class SimpleContact3D : public Element
     SimpleContact3D();
     ~SimpleContact3D();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/XMUelements/AC3D8HexWithSensitivity.cpp
+++ b/SRC/element/XMUelements/AC3D8HexWithSensitivity.cpp
@@ -1221,7 +1221,7 @@ AC3D8HexWithSensitivity::setImpedance(int face, double val)
   if (impVals == 0) {
     impVals = new double[6];
     if (impVals == 0) {
-      printf("AC3D8HexWithSensitivity::setImpedance - out of memeory\n");
+      printf("AC3D8HexWithSensitivity::setImpedance - out of memory\n");
       return -3;
     }
     impVals[0] = 0.0;

--- a/SRC/element/XMUelements/AC3D8HexWithSensitivity.h
+++ b/SRC/element/XMUelements/AC3D8HexWithSensitivity.h
@@ -141,7 +141,7 @@ class AC3D8HexWithSensitivity: public Element
     static Vector P;		   // Element resisting force vector
     // static Matrix B;		   // [B] matrix
     static Matrix mass ; 
-    static ID actDOFs;     // actived element dofs, add Yichao Gao
+    static ID actDOFs;     // activated element dofs, add Yichao Gao
     
     static const int numDOF;               // DOF number of element
     static const int nodes_in_elem;        // number of nodes in element

--- a/SRC/element/XMUelements/ASI3D8QuadWithSensitivity.h
+++ b/SRC/element/XMUelements/ASI3D8QuadWithSensitivity.h
@@ -136,7 +136,7 @@ class ASI3D8QuadWithSensitivity: public Element
 
     
     static ID integFlags;  // integrator flags
-    static ID actDOFs;     // actived element dofs, add Yichao Gao
+    static ID actDOFs;     // activated element dofs, add Yichao Gao
     
     static const int numDOF;               // DOF number of element
     static const int nodes_in_elem;        // number of nodes in element

--- a/SRC/element/XMUelements/AV3D4QuadWithSensitivity.h
+++ b/SRC/element/XMUelements/AV3D4QuadWithSensitivity.h
@@ -146,7 +146,7 @@ class AV3D4QuadWithSensitivity: public Element
     static Matrix QMAT;		 // [Q] matrix
     
     static ID integFlags;  // integrator flags
-    static ID actDOFs;     // actived element dofs, add Yichao Gao
+    static ID actDOFs;     // activated element dofs, add Yichao Gao
     
     static const int numDOF;               // DOF number of element
     static const int nodes_in_elem;        // number of nodes in element

--- a/SRC/element/XMUelements/VS3D4QuadWithSensitivity.h
+++ b/SRC/element/XMUelements/VS3D4QuadWithSensitivity.h
@@ -157,7 +157,7 @@ class VS3D4QuadWithSensitivity: public Element
 
     
     static ID integFlags;  // integrator flags
-    static ID actDOFs;     // actived element dofs, add Yichao Gao
+    static ID actDOFs;     // activated element dofs, add Yichao Gao
     
     static const int numDOF;               // DOF number of element
     static const int nodes_in_elem;        // number of nodes in element

--- a/SRC/element/adapter/Actuator.cpp
+++ b/SRC/element/adapter/Actuator.cpp
@@ -334,7 +334,7 @@ void Actuator::setDomain(Domain *theDomain)
     const Vector &end1Crd = theNodes[0]->getCrds();
     const Vector &end2Crd = theNodes[1]->getCrds();	
     
-    // initalize the cosines
+    // initialize the cosines
     cosX[0] = cosX[1] = cosX[2] = 0.0;
     for (int i=0; i<numDIM; i++)
         cosX[i] = end2Crd(i)-end1Crd(i);

--- a/SRC/element/adapter/ActuatorCorot.cpp
+++ b/SRC/element/adapter/ActuatorCorot.cpp
@@ -326,7 +326,7 @@ void ActuatorCorot::setDomain(Domain *theDomain)
     const Vector &end1Crd = theNodes[0]->getCrds();
     const Vector &end2Crd = theNodes[1]->getCrds();	
     
-    // initalize the cosines
+    // initialize the cosines
     double cosX[3];
     cosX[0] = cosX[1] = cosX[2] = 0.0;
     for (int i=0; i<numDIM; i++)

--- a/SRC/element/adapter/TclActuatorCommand.cpp
+++ b/SRC/element/adapter/TclActuatorCommand.cpp
@@ -123,6 +123,6 @@ int TclModelBuilder_addActuator(ClientData clientData, Tcl_Interp *interp,  int 
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the actuator and added it to the domain
+    // if get here we have successfully created the actuator and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/adapter/TclActuatorCorotCommand.cpp
+++ b/SRC/element/adapter/TclActuatorCorotCommand.cpp
@@ -123,6 +123,6 @@ int TclModelBuilder_addActuatorCorot(ClientData clientData, Tcl_Interp *interp, 
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the corotActuator and added it to the domain
+    // if get here we have successfully created the corotActuator and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/adapter/TclAdapterCommand.cpp
+++ b/SRC/element/adapter/TclAdapterCommand.cpp
@@ -219,6 +219,6 @@ int TclModelBuilder_addAdapter(ClientData clientData, Tcl_Interp *interp,  int a
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the adapter and added it to the domain
+    // if get here we have successfully created the adapter and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/beam2d/beam2d02.cpp
+++ b/SRC/element/beam2d/beam2d02.cpp
@@ -170,7 +170,7 @@ beam2d02::setDomain(Domain *theDomain)
     cs = dx/L;
     sn = dy/L;
     
-    // set the mass variable equal to 1/2 tha mass of the beam = 0.5 * rho*A*L
+    // set the mass variable equal to 1/2 the mass of the beam = 0.5 * rho*A*L
     M = 0.5*M*A*L;    
 }
 

--- a/SRC/element/brick/BbarBrick.cpp
+++ b/SRC/element/brick/BbarBrick.cpp
@@ -538,7 +538,7 @@ BbarBrick::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
 	  appliedB[0] += loadFactor*data(0)*b[0];
 	  appliedB[1] += loadFactor*data(1)*b[1];
@@ -575,7 +575,7 @@ BbarBrick::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (i=0; i<numberNodes; i++) {
     const Vector &Raccel = nodePointers[i]->getRV(accel);

--- a/SRC/element/brick/BbarBrickWithSensitivity.cpp
+++ b/SRC/element/brick/BbarBrickWithSensitivity.cpp
@@ -542,7 +542,7 @@ BbarBrickWithSensitivity::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
 	  appliedB[0] += loadFactor*data(0)*b[0];
 	  appliedB[1] += loadFactor*data(1)*b[1];
@@ -579,7 +579,7 @@ BbarBrickWithSensitivity::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (i=0; i<numberNodes; i++) {
     const Vector &Raccel = nodePointers[i]->getRV(accel);

--- a/SRC/element/brick/Brick.cpp
+++ b/SRC/element/brick/Brick.cpp
@@ -558,7 +558,7 @@ Brick::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
       appliedB[0] += loadFactor*data(0)*b[0];
       appliedB[1] += loadFactor*data(1)*b[1];
@@ -595,7 +595,7 @@ Brick::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (i=0; i<numberNodes; i++) {
     const Vector &Raccel = nodePointers[i]->getRV(accel);

--- a/SRC/element/brick/TclBrickCommand.cpp
+++ b/SRC/element/brick/TclBrickCommand.cpp
@@ -198,7 +198,7 @@ TclModelBuilder_addBrick(ClientData clientData, Tcl_Interp *interp,  int argc,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 

--- a/SRC/element/brick/TclTwenty_Node_BrickCommand.cpp
+++ b/SRC/element/brick/TclTwenty_Node_BrickCommand.cpp
@@ -252,7 +252,7 @@ TclModelBuilder_addTwentyNodeBrick(ClientData clientData, Tcl_Interp *interp,
 
 
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
 
   return TCL_OK;
 

--- a/SRC/element/brick/Twenty_Node_Brick.cpp
+++ b/SRC/element/brick/Twenty_Node_Brick.cpp
@@ -892,7 +892,7 @@ Twenty_Node_Brick::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
     } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
 	  appliedB[0] += loadFactor*data(0)*b[0];
 	  appliedB[1] += loadFactor*data(1)*b[1];
@@ -930,7 +930,7 @@ Twenty_Node_Brick::addInertiaLoadToUnbalance(const Vector &accel)
 
 		if ( 3 != Raccel.Size() ) {
 
-			opserr << "Twenty_Node_Brick::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+			opserr << "Twenty_Node_Brick::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 
 			return -1;
 
@@ -1179,7 +1179,7 @@ const Vector&  Twenty_Node_Brick::getResistingForceIncInertia( )
 
 		if ( 3 != accel.Size() ) {
 
-			opserr << "Twenty_Node_Brick::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+			opserr << "Twenty_Node_Brick::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
 			exit(-1);
 
@@ -1233,7 +1233,7 @@ const Vector&  Twenty_Node_Brick::getResistingForceIncInertia( )
 
 		if ( 3!= vel.Size() ) {
 
-			opserr << "Twenty_Node_Brick::getResistingForceIncInertia matrix and vector sizes are incompatable\n";
+			opserr << "Twenty_Node_Brick::getResistingForceIncInertia matrix and vector sizes are incompatible\n";
 
 			exit(-1);
 

--- a/SRC/element/catenaryCable/CatenaryCable.h
+++ b/SRC/element/catenaryCable/CatenaryCable.h
@@ -72,7 +72,7 @@ class CatenaryCable : public Element
 
     const char *getClassType(void) const {return "CatenaryCable";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/componentElement/ComponentElement2d.cpp
+++ b/SRC/element/componentElement/ComponentElement2d.cpp
@@ -634,7 +634,7 @@ ComponentElement2d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
 	
   if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-    opserr << "ComponentElement2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "ComponentElement2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
     

--- a/SRC/element/dispBeamColumn/AxEqDispBeamColumn2d.cpp
+++ b/SRC/element/dispBeamColumn/AxEqDispBeamColumn2d.cpp
@@ -473,7 +473,7 @@ AxEqDispBeamColumn2d::revertToStart()
 int
 AxEqDispBeamColumn2d::update(void)
 {
-	// CASE IN WHICH THE SECTIONAL AXIAL FORCES ARE IN EQUILIBRIUM: SAME PROCEDURE AS FOR TEH CLASSICAL DB ELEMENT 
+	// CASE IN WHICH THE SECTIONAL AXIAL FORCES ARE IN EQUILIBRIUM: SAME PROCEDURE AS FOR THE CLASSICAL DB ELEMENT 
 	// However some modifications were made by DT in order to have obtain same procedure described in Tarquini et al. 2017
 	// namely the use of displacement increments as starting point computed as total displacements (trial) - committed (at convergence) displacements
 	//opserr << "I AM HERE" << endln;
@@ -679,7 +679,7 @@ void
 AxEqDispBeamColumn2d::getBasicStiff(Matrix &kb, int initial)
 {
 
-	// CASE IN WHICH THE SECTIONAL AXIAL FORCES ARE IN EQUILIBRIUM: SAME PROCEDURE AS FOR TEH CLASSICAL DB ELEMENT 
+	// CASE IN WHICH THE SECTIONAL AXIAL FORCES ARE IN EQUILIBRIUM: SAME PROCEDURE AS FOR THE CLASSICAL DB ELEMENT 
 	if (flagDBae==0) {
 		//opserr << "I am here NORMAL Stiff" << endln;
 	// Zero for integral
@@ -1131,7 +1131,7 @@ AxEqDispBeamColumn2d::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel2 = theNodes[1]->getRV(accel);
 
 	if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-		opserr << "AxEqDispBeamColumn2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+		opserr << "AxEqDispBeamColumn2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 		return -1;
 	}
 

--- a/SRC/element/dispBeamColumn/AxEqDispBeamColumn2d.h
+++ b/SRC/element/dispBeamColumn/AxEqDispBeamColumn2d.h
@@ -136,7 +136,7 @@ private:
 	// CLASS MEMBERS
 	int numSections;
 	SectionForceDeformation **theSections; // pointer to the ND material objects
-	CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+	CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
 	BeamIntegration *beamInt;
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn2d.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2d.cpp
@@ -199,7 +199,7 @@ int OPS_DispBeamColumn2d(Domain& theDomain, const ID& elenodes, ID& eletags)
 	theEle = new DispBeamColumn2d(--currTag,elenodes(2*i),elenodes(2*i+1),secTags.Size(),
 				      sections,*bi,*theTransf,mass,cmass);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -830,7 +830,7 @@ DispBeamColumn2d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
   
   if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-    opserr << "DispBeamColumn2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "DispBeamColumn2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
   

--- a/SRC/element/dispBeamColumn/DispBeamColumn2d.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2d.h
@@ -114,7 +114,7 @@ class DispBeamColumn2d : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
     BeamIntegration *beamInt;
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.cpp
@@ -24,10 +24,10 @@
                                                                         
 // Written: MHS
 // Created: Feb 2001
-// Modified: Jian Zhang[Univeristy of Edinburgh]
-// Modified: Panagiotis Kotsovinos[Univeristy of Edinburgh]
-// Modified: Jian Jiang[Univeristy of Edinburgh]
-// Modified: Liming Jiang[Univeristy of Edinburgh,2014
+// Modified: Jian Zhang[University of Edinburgh]
+// Modified: Panagiotis Kotsovinos[University of Edinburgh]
+// Modified: Jian Jiang[University of Edinburgh]
+// Modified: Liming Jiang[University of Edinburgh,2014
 
 
 
@@ -1122,7 +1122,7 @@ DispBeamColumn2dThermal::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel2 = theNodes[1]->getRV(accel);
 
     if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-      opserr << "DispBeamColumn2dThermal::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+      opserr << "DispBeamColumn2dThermal::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
       return -1;
     }
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.h
@@ -24,10 +24,10 @@
                                                                         
 // Written: MHS
 // Created: Feb 2001
-// Modified: Jian Zhang[Univeristy of Edinburgh]
-// Modified: Panagiotis Kotsovinos[Univeristy of Edinburgh]
-// Modified: Jian Jiang[Univeristy of Edinburgh]
-// Modified: Liming Jiang[Univeristy of Edinburgh,2014
+// Modified: Jian Zhang[University of Edinburgh]
+// Modified: Panagiotis Kotsovinos[University of Edinburgh]
+// Modified: Jian Jiang[University of Edinburgh]
+// Modified: Liming Jiang[University of Edinburgh,2014
 
 
 
@@ -117,7 +117,7 @@ class DispBeamColumn2dThermal : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
     BeamIntegration *beamInt;
 
@@ -143,7 +143,7 @@ class DispBeamColumn2dThermal : public Element
 
 	double q0Temperature[3];  // Fixed end thermal forces  of current step in basic system
 	double q0TemperatureP[3];  // Fixed end thermal forces of last step in basic system
-	int counterTemperature; // trace to remove thermal force from the second interation step
+	int counterTemperature; // trace to remove thermal force from the second iteration step
     double SectionThermalElong[20];
     double AverageThermalElong;
     // AddingSensitivity:BEGIN //////////////////////////////////////////

--- a/SRC/element/dispBeamColumn/DispBeamColumn2dWithSensitivity.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2dWithSensitivity.cpp
@@ -701,7 +701,7 @@ DispBeamColumn2dWithSensitivity::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel2 = theNodes[1]->getRV(accel);
 
     if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-      opserr << "DispBeamColumn2dWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+      opserr << "DispBeamColumn2dWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
       return -1;
     }
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn2dWithSensitivity.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2dWithSensitivity.h
@@ -113,7 +113,7 @@ class DispBeamColumn2dWithSensitivity : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object
     BeamIntegration *beamInt;
     ID connectedExternalNodes; // Tags of quad nodes
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn3d.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3d.cpp
@@ -810,7 +810,7 @@ DispBeamColumn3d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
   
   if (6 != Raccel1.Size() || 6 != Raccel2.Size()) {
-    opserr << "DispBeamColumn3d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "DispBeamColumn3d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
   

--- a/SRC/element/dispBeamColumn/DispBeamColumn3d.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3d.h
@@ -111,7 +111,7 @@ class DispBeamColumn3d : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
     BeamIntegration *beamInt;
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn3dThermal.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3dThermal.cpp
@@ -600,7 +600,7 @@ DispBeamColumn3dThermal::getTangentStiff()
 
   #ifdef _bDEBUG
   if(this->getTag() == 601 || this->getTag() == 602){
-  opserr<<"DispBeam3d "<<this->getTag()<<" q afer tangent: "<<q<<endln;
+  opserr<<"DispBeam3d "<<this->getTag()<<" q after tangent: "<<q<<endln;
 	  }
   #endif
 
@@ -1102,7 +1102,7 @@ DispBeamColumn3dThermal::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
 
   if (6 != Raccel1.Size() || 6 != Raccel2.Size()) {
-    opserr << "DispBeamColumn3dThermal::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "DispBeamColumn3dThermal::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn3dThermal.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3dThermal.h
@@ -112,7 +112,7 @@ class DispBeamColumn3dThermal : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
     BeamIntegration *beamInt;
 

--- a/SRC/element/dispBeamColumn/DispBeamColumn3dWithSensitivity.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3dWithSensitivity.cpp
@@ -781,7 +781,7 @@ DispBeamColumn3dWithSensitivity::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
   
   if (6 != Raccel1.Size() || 6 != Raccel2.Size()) {
-    opserr << "DispBeamColumn3dWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "DispBeamColumn3dWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
   

--- a/SRC/element/dispBeamColumn/DispBeamColumn3dWithSensitivity.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumn3dWithSensitivity.h
@@ -113,7 +113,7 @@ class DispBeamColumn3dWithSensitivity : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
     BeamIntegration *beamInt;
     ID connectedExternalNodes; // Tags of quad nodes
 

--- a/SRC/element/dispBeamColumn/DispBeamColumnNL2d.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumnNL2d.cpp
@@ -751,7 +751,7 @@ DispBeamColumnNL2d::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel2 = theNodes[1]->getRV(accel);
 
     if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-      opserr << "DispBeamColumnNL2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+      opserr << "DispBeamColumnNL2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
       return -1;
     }
 

--- a/SRC/element/dispBeamColumn/DispBeamColumnNL2d.h
+++ b/SRC/element/dispBeamColumn/DispBeamColumnNL2d.h
@@ -114,7 +114,7 @@ class DispBeamColumnNL2d : public Element
 
     int numSections;
     SectionForceDeformation **theSections; // pointer to the ND material objects
-    CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+    CrdTransf *crdTransf;        // pointer to coordinate transformation object 
 
     BeamIntegration *beamInt;
 

--- a/SRC/element/dispBeamColumnInt/DispBeamColumn2dInt.cpp
+++ b/SRC/element/dispBeamColumnInt/DispBeamColumn2dInt.cpp
@@ -187,7 +187,7 @@ void* OPS_DispBeamColumn2dInt()
 	delete [] sections;
     }
 
-    // if get here we have sucessfully created the element and added it to the domain
+    // if get here we have successfully created the element and added it to the domain
     return theElement;
 }
 
@@ -1325,7 +1325,7 @@ DispBeamColumn2dInt::addInertiaLoadToUnbalance(const Vector &accel)
 
     if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
 
-      opserr << "DispBeamColumn2dInt::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+      opserr << "DispBeamColumn2dInt::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 
       return -1;
 

--- a/SRC/element/dispBeamColumnInt/DispBeamColumn2dInt.h
+++ b/SRC/element/dispBeamColumnInt/DispBeamColumn2dInt.h
@@ -170,7 +170,7 @@ class DispBeamColumn2dInt : public Element
     int numSections;
 
     FiberSection2dInt **theSections; // pointer to the ND material objects
-    LinearCrdTransf2dInt *crdTransf;          // pointer to coordinate tranformation object 
+    LinearCrdTransf2dInt *crdTransf;          // pointer to coordinate transformation object 
 
     double C1;
     ID connectedExternalNodes; // Tags of quad nodes

--- a/SRC/element/dispBeamColumnInt/TclDispBeamColumnIntCommand.cpp
+++ b/SRC/element/dispBeamColumnInt/TclDispBeamColumnIntCommand.cpp
@@ -176,7 +176,7 @@ TclModelBuilder_addDispBeamColumnInt(ClientData clientData, Tcl_Interp *interp,
 		return TCL_ERROR;
 	}
 
-	// if get here we have sucessfully created the element and added it to the domain
+	// if get here we have successfully created the element and added it to the domain
 	return TCL_OK;
 }
 

--- a/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
@@ -182,7 +182,7 @@ int OPS_ElasticBeam2d(Domain& theDomain, const ID& elenodes, ID& eletags)
 	theEle = new ElasticBeam2d(--currTag,data[0],data[1],data[2],elenodes(2*i),elenodes(2*i+1),
 				   *theTransf,alpha,depth,mass,cMass);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -556,7 +556,7 @@ ElasticBeam2d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
 	
   if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-    opserr << "ElasticBeam2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "ElasticBeam2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
     

--- a/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
@@ -594,7 +594,7 @@ ElasticBeam3d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
 	
   if (6 != Raccel1.Size() || 6 != Raccel2.Size()) {
-    opserr << "ElasticBeam3d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "ElasticBeam3d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
 

--- a/SRC/element/elasticBeamColumn/ModElasticBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ModElasticBeam2d.cpp
@@ -537,7 +537,7 @@ ModElasticBeam2d::addInertiaLoadToUnbalance(const Vector &accel)
   const Vector &Raccel2 = theNodes[1]->getRV(accel);
 	
   if (3 != Raccel1.Size() || 3 != Raccel2.Size()) {
-    opserr << "ModElasticBeam2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "ModElasticBeam2d::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
     

--- a/SRC/element/elasticBeamColumn/TclElasticBeamCommand.cpp
+++ b/SRC/element/elasticBeamColumn/TclElasticBeamCommand.cpp
@@ -365,6 +365,6 @@ TclModelBuilder_addElasticBeam(ClientData clientData, Tcl_Interp *interp, int ar
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }

--- a/SRC/element/elastomericBearing/ElastomericBearingBoucWen2d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingBoucWen2d.cpp
@@ -457,7 +457,7 @@ int ElastomericBearingBoucWen2d::update()
     kb(0,0) = theMaterials[0]->getTangent();
     
     // 2) calculate shear force and stiffness in basic y-direction
-    // get displacement increment (trial - commited)
+    // get displacement increment (trial - committed)
     double delta_ub = ub(1) - ubC(1);
     if (fabs(delta_ub) > 0.0)  {
         
@@ -1106,7 +1106,7 @@ void ElastomericBearingBoucWen2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericBearingBoucWen3d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingBoucWen3d.cpp
@@ -499,7 +499,7 @@ int ElastomericBearingBoucWen3d::update()
     kb(0,0) = theMaterials[0]->getTangent();
     
     // 2) calculate shear forces and stiffnesses in basic y- and z-direction
-    // get displacement increments (trial - commited)
+    // get displacement increments (trial - committed)
     Vector delta_ub = ub - ubC;
     if (sqrt(pow(delta_ub(1),2)+pow(delta_ub(2),2)) > DBL_EPSILON)  {
     
@@ -1263,7 +1263,7 @@ void ElastomericBearingBoucWen3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericBearingBoucWenMod3d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingBoucWenMod3d.cpp
@@ -9,7 +9,7 @@
 // $Date: 2015-10-12 18:46:30 $
 // $URL: 
 
-// Written: Ping Tan £¨Guangzhou University, China£©
+// Written: Ping Tan ï¿½ï¿½Guangzhou University, Chinaï¿½ï¿½
 // Created: 2015-10-12 18:46:30
 // Revision: A
 //
@@ -471,7 +471,7 @@ int ElastomericBearingBoucWenMod3d::update()
 			qb(0)=kb(0,0)*ub(0);
     
     // 2) calculate shear forces and stiffnesses in basic y- and z-direction
-    // get displacement increments (trial - commited)
+    // get displacement increments (trial - committed)
     Vector delta_ub = ub - ubC;
 	// calculate dependency parameters
 	double alphaT = b1+b2*T+b3*pow(T,2)+b4*pow(T,3);
@@ -1148,7 +1148,7 @@ void ElastomericBearingBoucWenMod3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericBearingPlasticity2d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingPlasticity2d.cpp
@@ -1040,7 +1040,7 @@ void ElastomericBearingPlasticity2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericBearingPlasticity3d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingPlasticity3d.cpp
@@ -1152,7 +1152,7 @@ void ElastomericBearingPlasticity3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericBearingUFRP2d.cpp
+++ b/SRC/element/elastomericBearing/ElastomericBearingUFRP2d.cpp
@@ -468,7 +468,7 @@ int ElastomericBearingUFRP2d::update()
     kb(0,0) = theMaterials[0]->getTangent();
     
     // 2) calculate shear force and stiffness in basic y-direction
-    // get displacement increment (trial - commited)
+    // get displacement increment (trial - committed)
     double delta_ub = ub(1) - ubC(1);
     if (fabs(delta_ub) > 0.0)  {
         
@@ -1108,7 +1108,7 @@ void ElastomericBearingUFRP2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/ElastomericX.cpp
+++ b/SRC/element/elastomericBearing/ElastomericX.cpp
@@ -587,7 +587,7 @@ int ElastomericX::update()
     }
     
     //2) calculate shear forces and stiffnesses in basic y- and z-direction
-    // get displacement increments (trial-commited)
+    // get displacement increments (trial-committed)
     Vector delta_ub = ub - ubC;
     if (sqrt(pow(delta_ub(1),2)+pow(delta_ub(2),2)) > 0.0)  {
         
@@ -629,7 +629,7 @@ int ElastomericX::update()
             }
             
             // advance one step
-            // delta_z = f/Df; either write a function to do matrix devision or use the solution below
+            // delta_z = f/Df; either write a function to do matrix division or use the solution below
             delta_z(0) = (f(0)*Df(1,1)-f(1)*Df(0,1))/(Df(0,0)*Df(1,1)-Df(0,1)*Df(1,0));
             delta_z(1) = (f(0)*Df(1,0)-f(1)*Df(0,0))/(Df(0,1)*Df(1,0)-Df(0,0)*Df(1,1));
             z -= delta_z;
@@ -1351,7 +1351,7 @@ void ElastomericX::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/HDR.cpp
+++ b/SRC/element/elastomericBearing/HDR.cpp
@@ -1299,7 +1299,7 @@ void HDR::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/LeadRubberX.cpp
+++ b/SRC/element/elastomericBearing/LeadRubberX.cpp
@@ -629,7 +629,7 @@ int LeadRubberX::update()
     }
     
     //2) calculate shear forces and stiffnesses in basic y- and z-direction
-    // get displacement increments (trial-commited)
+    // get displacement increments (trial-committed)
     Vector delta_ub = ub - ubC;
     if (sqrt(pow(delta_ub(1),2)+pow(delta_ub(2),2)) > 0.0)  {
         
@@ -671,7 +671,7 @@ int LeadRubberX::update()
             }
             
             // advance one step
-            // delta_z = f/Df; either write a function to do matrix devision or use the solution below
+            // delta_z = f/Df; either write a function to do matrix division or use the solution below
             delta_z(0) = (f(0)*Df(1,1)-f(1)*Df(0,1))/(Df(0,0)*Df(1,1)-Df(0,1)*Df(1,0));
             delta_z(1) = (f(0)*Df(1,0)-f(1)*Df(0,0))/(Df(0,1)*Df(1,0)-Df(0,0)*Df(1,1));
             z -= delta_z;
@@ -1413,7 +1413,7 @@ void LeadRubberX::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/elastomericBearing/TclElastomericBearingBoucWenCommand.cpp
+++ b/SRC/element/elastomericBearing/TclElastomericBearingBoucWenCommand.cpp
@@ -582,6 +582,6 @@ int TclModelBuilder_addElastomericBearingBoucWen(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the elastomericBearingBoucWen and added it to the domain
+    // if get here we have successfully created the elastomericBearingBoucWen and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/elastomericBearing/TclElastomericBearingPlasticityCommand.cpp
+++ b/SRC/element/elastomericBearing/TclElastomericBearingPlasticityCommand.cpp
@@ -510,6 +510,6 @@ int TclModelBuilder_addElastomericBearingPlasticity(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the elastomericBearing and added it to the domain
+    // if get here we have successfully created the elastomericBearing and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/elastomericBearing/TclElastomericBearingUFRPCommand.cpp
+++ b/SRC/element/elastomericBearing/TclElastomericBearingUFRPCommand.cpp
@@ -611,6 +611,6 @@ int TclModelBuilder_addElastomericBearingUFRP(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the elastomericBearingUFRP and added it to the domain
+    // if get here we have successfully created the elastomericBearingUFRP and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/feap/fElement.cpp
+++ b/SRC/element/feap/fElement.cpp
@@ -106,7 +106,7 @@ fElement::fElement(int tag,
     for (int i=0; i<sizeD; i++) d[i] = 0.0;
     data = new Vector(d, sizeD);
 
-    // allocate space for static varaibles on creation of first instance
+    // allocate space for static variables on creation of first instance
     if (numfElements == 0) {
 	fElementM = new Matrix *[MAX_NST+1];
 	fElementV = new Vector *[MAX_NST+1];
@@ -188,7 +188,7 @@ fElement::fElement(int tag,
 	    for (int i=0; i<sizeH; i++) h[i] = 0.0;
     }
 
-    // allocate space for static varaibles on creation of first instance
+    // allocate space for static variables on creation of first instance
     if (numfElements == 0) {
 	fElementM = new Matrix *[MAX_NST+1];
 	fElementV = new Vector *[MAX_NST+1];
@@ -463,7 +463,7 @@ fElement::getTangentStiff(void)
     
     // check nst is as determined in readyfRoutine()
     if (nstI != nstR) {
-	opserr << "FATAL fElement::getTangentStiff() problems with incompatable nst";
+	opserr << "FATAL fElement::getTangentStiff() problems with incompatible nst";
 	opserr << " ready: " << nstR << " invoke: " << nstI << endln;
 	exit(-1);
     }
@@ -506,7 +506,7 @@ fElement::getDamp(void)
     
     // check nst is as determined in readyfRoutine()
     if (nstI != nstR) {
-	opserr << "FATAL fElement::getTangentStiff() problems with incompatable nst";
+	opserr << "FATAL fElement::getTangentStiff() problems with incompatible nst";
 	opserr << " ready: " << nstR << " invoke: " << nstI << endln;
 	exit(-1);
     }
@@ -536,7 +536,7 @@ fElement::getMass(void)
     int NH1, NH2, NH3;    
     int nstR = this->readyfRoutine(true);
     
-    // zero the matrix and vector (consistant and lumped)
+    // zero the matrix and vector (consistent and lumped)
     fElementM[nstR]->Zero();    
     fElementV[nstR]->Zero();        
     
@@ -546,7 +546,7 @@ fElement::getMass(void)
     
     // check nst is as determined in readyfRoutine()
     if (nstI != nstR) {
-	opserr << "FATAL fElement::getTangentStiff() problems with incompatable nst";
+	opserr << "FATAL fElement::getTangentStiff() problems with incompatible nst";
 	opserr << " ready: " << nstR << " invoke: " << nstI << endln;
 	exit(-1);
     }
@@ -582,7 +582,7 @@ fElement::addInertiaLoadToUnbalance(const Vector &accel)
   Vector &resid = *(fElementV[nstR]);    
   static const int numberNodes = 4 ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (int i=0; i<nen; i++) {
     const Vector &Raccel = theNodes[i]->getRV(accel);
@@ -631,7 +631,7 @@ fElement::getResistingForce()
     
     // check nst is as determined in readyfRoutine()
     if (nstI != nstR) {
-	opserr << "FATAL fElement::getTangentStiff() problems with incompatable nst";
+	opserr << "FATAL fElement::getTangentStiff() problems with incompatible nst";
 	opserr << " ready: " << nstR << " invoke: " << nstI << endln;
 	exit(-1);
     }
@@ -676,7 +676,7 @@ fElement::getResistingForceIncInertia()
     
     // check nst is as determined in readyfRoutine()
     if (nstI != nstR) {
-	opserr << "FATAL fElement::getTangentStiff() problems with incompatable nst";
+	opserr << "FATAL fElement::getTangentStiff() problems with incompatible nst";
 	opserr << " ready: " << nstR << " invoke: " << nstI << endln;
 	exit(-1);
     }

--- a/SRC/element/forceBeamColumn/ElasticForceBeamColumn2d.h
+++ b/SRC/element/forceBeamColumn/ElasticForceBeamColumn2d.h
@@ -146,7 +146,7 @@ class ElasticForceBeamColumn2d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation *sections[maxNumSections];          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   

--- a/SRC/element/forceBeamColumn/ElasticForceBeamColumn3d.h
+++ b/SRC/element/forceBeamColumn/ElasticForceBeamColumn3d.h
@@ -146,7 +146,7 @@ class ElasticForceBeamColumn3d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation *sections[maxNumSections];          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   

--- a/SRC/element/forceBeamColumn/ElasticForceBeamColumnWarping2d.h
+++ b/SRC/element/forceBeamColumn/ElasticForceBeamColumnWarping2d.h
@@ -29,7 +29,7 @@
  Shear Wall with Warping
  ---
 Hsiang-Chuan Tsai, James M. Kelly (2004), "Buckling of short beams with warping effect included."
-International Journal of Solids and Structures, 42:239–253
+International Journal of Solids and Structures, 42:239ï¿½253
 
 
 State Determination Algorithm
@@ -152,7 +152,7 @@ class ElasticForceBeamColumnWarping2d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation *sections[maxNumSections];          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   

--- a/SRC/element/forceBeamColumn/ForceBeamColumn2d.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn2d.cpp
@@ -246,7 +246,7 @@ int OPS_ForceBeamColumn2d(Domain& theDomain, const ID& elenodes, ID& eletags)
 	theEle = new ForceBeamColumn2d(--currTag,elenodes(2*i),elenodes(2*i+1),secTags.Size(),
 				       sections,*bi,*theTransf,mass,maxIter,tol);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -820,13 +820,13 @@ ForceBeamColumn2d::update()
 
   maxSubdivisions = 4;
 
-  // fmk - modification to get compatable ele forces and deformations 
+  // fmk - modification to get compatible ele forces and deformations 
   //   for a change in deformation dV we try first a newton iteration, if
   //   that fails we try an initial flexibility iteration on first iteration 
   //   and then regular newton, if that fails we use the initial flexiblity
   //   for all iterations.
   //
-  //   if they both fail we subdivide dV & try to get compatable forces
+  //   if they both fail we subdivide dV & try to get compatible forces
   //   and deformations. if they work and we have subdivided we apply
   //   the remaining dV.
 

--- a/SRC/element/forceBeamColumn/ForceBeamColumn2d.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn2d.h
@@ -155,7 +155,7 @@ class ForceBeamColumn2d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation **sections;          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   int    maxIters;               // maximum number of local iterations
@@ -168,14 +168,14 @@ class ForceBeamColumn2d: public Element
   Matrix kv;                     // stiffness matrix in the basic system 
   Vector Se;                     // element resisting forces in the basic system
   
-  Matrix kvcommit;               // commited stiffness matrix in the basic system
-  Vector Secommit;               // commited element end forces in the basic system
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
   
   Matrix *fs;                    // array of section flexibility matrices
   Vector *vs;                    // array of section deformation vectors
   Vector *Ssr;                   // array of section resisting force vectors
   
-  Vector *vscommit;              // array of commited section deformation vectors
+  Vector *vscommit;              // array of committed section deformation vectors
   
   enum {maxNumEleLoads = 100};
   enum {NDM = 2};         // dimension of the problem (2d)

--- a/SRC/element/forceBeamColumn/ForceBeamColumn2dThermal.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn2dThermal.cpp
@@ -802,13 +802,13 @@ ForceBeamColumn2dThermal::update()
 
   maxSubdivisions = 4;
 
-  // fmk - modification to get compatable ele forces and deformations 
+  // fmk - modification to get compatible ele forces and deformations 
   //   for a change in deformation dV we try first a newton iteration, if
   //   that fails we try an initial flexibility iteration on first iteration 
   //   and then regular newton, if that fails we use the initial flexiblity
   //   for all iterations.
   //
-  //   if they both fail we subdivide dV & try to get compatable forces
+  //   if they both fail we subdivide dV & try to get compatible forces
   //   and deformations. if they work and we have subdivided we apply
   //   the remaining dV.
   int ThermalCounter =0;
@@ -956,7 +956,7 @@ ForceBeamColumn2dThermal::update()
 #ifdef _BDEBUG
 		opserr<<"ForceBeamColumn:: "<< this->getTag()<<" Sec "<< i<< "flex"<<fsSubdivide[i]<<endln
 			<<" Sec Force incr dSs:"<<dSs<<" Sec deform incr dVs:"<<dvs
-			<<" Trial vs brfore compensation "<<vsSubdivide[i]<<endln;
+			<<" Trial vs before compensation "<<vsSubdivide[i]<<endln;
 #endif
 		
 		
@@ -1163,7 +1163,7 @@ ForceBeamColumn2dThermal::update()
 	    // if we have failed to convrege for all of our newton schemes
 	    // - reduce step size by the factor specified
 		#ifdef _BDEBUG
-		opserr<< "Commited vs for sec1 "<<vs[1]<<endln<<"Committed Ssr "<<Ssr[1]<<endln;
+		opserr<< "Committed vs for sec1 "<<vs[1]<<endln<<"Committed Ssr "<<Ssr[1]<<endln;
 #endif
 	    if (j == (numIters-1) && (l == 2)) {
 	      dvTrial /= factor;

--- a/SRC/element/forceBeamColumn/ForceBeamColumn2dThermal.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn2dThermal.h
@@ -157,7 +157,7 @@ class ForceBeamColumn2dThermal: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation **sections;          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   int    maxIters;               // maximum number of local iterations
@@ -170,14 +170,14 @@ class ForceBeamColumn2dThermal: public Element
   Matrix kv;                     // stiffness matrix in the basic system 
   Vector Se;                     // element resisting forces in the basic system
   
-  Matrix kvcommit;               // commited stiffness matrix in the basic system
-  Vector Secommit;               // commited element end forces in the basic system
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
   
   Matrix *fs;                    // array of section flexibility matrices
   Vector *vs;                    // array of section deformation vectors
   Vector *Ssr;                   // array of section resisting force vectors
   
-  Vector *vscommit;              // array of commited section deformation vectors
+  Vector *vscommit;              // array of committed section deformation vectors
   
   enum {maxNumEleLoads = 100};
   enum {NDM = 2};         // dimension of the problem (2d)

--- a/SRC/element/forceBeamColumn/ForceBeamColumn3d.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn3d.cpp
@@ -735,13 +735,13 @@ void
 
     maxSubdivisions = 10;
 
-    // fmk - modification to get compatable ele forces and deformations 
+    // fmk - modification to get compatible ele forces and deformations 
     //   for a change in deformation dV we try first a newton iteration, if
     //   that fails we try an initial flexibility iteration on first iteration 
     //   and then regular newton, if that fails we use the initial flexiblity
     //   for all iterations.
     //
-    //   if they both fail we subdivide dV & try to get compatable forces
+    //   if they both fail we subdivide dV & try to get compatible forces
     //   and deformations. if they work and we have subdivided we apply
     //   the remaining dV.
 

--- a/SRC/element/forceBeamColumn/ForceBeamColumn3d.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn3d.h
@@ -155,7 +155,7 @@ class ForceBeamColumn3d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation **sections;          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   int    maxIters;               // maximum number of local iterations
@@ -168,14 +168,14 @@ class ForceBeamColumn3d: public Element
   Matrix kv;                     // stiffness matrix in the basic system 
   Vector Se;                     // element resisting forces in the basic system
   
-  Matrix kvcommit;               // commited stiffness matrix in the basic system
-  Vector Secommit;               // commited element end forces in the basic system
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
   
   Matrix *fs;                    // array of section flexibility matrices
   Vector *vs;                    // array of section deformation vectors
   Vector *Ssr;                   // array of section resisting force vectors
   
-  Vector *vscommit;              // array of commited section deformation vectors
+  Vector *vscommit;              // array of committed section deformation vectors
   
   enum {maxNumEleLoads = 100};
   enum {NDM = 3};         // dimension of the problem (3d)

--- a/SRC/element/forceBeamColumn/ForceBeamColumnCBDI2d.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumnCBDI2d.cpp
@@ -813,13 +813,13 @@ ForceBeamColumnCBDI2d::update()
     SsrSubdivide[i] = Ssr[i];
   }
 
-  // fmk - modification to get compatable ele forces and deformations 
+  // fmk - modification to get compatible ele forces and deformations 
   //   for a change in deformation dV we try first a newton iteration, if
   //   that fails we try an initial flexibility iteration on first iteration 
   //   and then regular newton, if that fails we use the initial flexiblity
   //   for all iterations.
   //
-  //   if they both fail we subdivide dV & try to get compatable forces
+  //   if they both fail we subdivide dV & try to get compatible forces
   //   and deformations. if they work and we have subdivided we apply
   //   the remaining dV.
 

--- a/SRC/element/forceBeamColumn/ForceBeamColumnCBDI2d.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumnCBDI2d.h
@@ -169,7 +169,7 @@ class ForceBeamColumnCBDI2d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation **sections;          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   bool CSBDI;
   double rho;                    // mass density per unit length
@@ -183,14 +183,14 @@ class ForceBeamColumnCBDI2d: public Element
   Matrix kv;                     // stiffness matrix in the basic system 
   Vector Se;                     // element resisting forces in the basic system
   
-  Matrix kvcommit;               // commited stiffness matrix in the basic system
-  Vector Secommit;               // commited element end forces in the basic system
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
   
   Matrix *fs;                    // array of section flexibility matrices
   Vector *vs;                    // array of section deformation vectors
   Vector *Ssr;                   // array of section resisting force vectors
   
-  Vector *vscommit;              // array of commited section deformation vectors
+  Vector *vscommit;              // array of committed section deformation vectors
   
   enum {maxNumEleLoads = 100};
   enum {NDM = 2};         // dimension of the problem (2d)

--- a/SRC/element/forceBeamColumn/ForceBeamColumnWarping2d.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumnWarping2d.cpp
@@ -29,7 +29,7 @@
  Shear Wall with Warping
  ---
 Hsiang-Chuan Tsai, James M. Kelly (2004), "Buckling of short beams with warping effect included."
-International Journal of Solids and Structures, 42:239–253
+International Journal of Solids and Structures, 42:239ï¿½253
 
 
 State Determination Algorithm
@@ -720,13 +720,13 @@ ForceBeamColumnWarping2d::update()
 
   maxSubdivisions = 4;
 
-  // fmk - modification to get compatable ele forces and deformations 
+  // fmk - modification to get compatible ele forces and deformations 
   //   for a change in deformation dV we try first a newton iteration, if
   //   that fails we try an initial flexibility iteration on first iteration 
   //   and then regular newton, if that fails we use the initial flexiblity
   //   for all iterations.
   //
-  //   if they both fail we subdivide dV & try to get compatable forces
+  //   if they both fail we subdivide dV & try to get compatible forces
   //   and deformations. if they work and we have subdivided we apply
   //   the remaining dV.
 
@@ -801,7 +801,7 @@ ForceBeamColumnWarping2d::update()
 	    double xL1 = xL-1.0;
 	    double wtL = wt[i]*L;
 
-						    // compute coeficient w
+						    // compute coefficient w
 	const Matrix &ks = sections[i]->getInitialTangent(); 
 	double EI(0), GA(0), GB(0), GC(0), EJ(0);
 	for (int k = 0; k < order; k++) {
@@ -1124,7 +1124,7 @@ void ForceBeamColumnWarping2d::getForceInterpolatMatrix(double xi, Matrix &b, co
   double L = crdTransf->getInitialLength();
   int order      = sections[isec]->getOrder();
   
-  			    // compute coeficient w
+  			    // compute coefficient w
 	const Matrix &ks = sections[isec]->getInitialTangent(); 
 	double EI(0), GA(0), GB(0), GC(0), EJ(0);
 	for (int k = 0; k < order; k++) {
@@ -1994,7 +1994,7 @@ ForceBeamColumnWarping2d::getInitialFlexibility(Matrix &fe)
     double xL1 = xL-1.0;
     double wtL = wt[i]*L;
 
-				    // compute coeficient w
+				    // compute coefficient w
 	const Matrix &ks = sections[i]->getInitialTangent(); 
 	double EI(0), GA(0), GB(0), GC(0), EJ(0);
 	for (int k = 0; k < order; k++) {
@@ -2123,7 +2123,7 @@ ForceBeamColumnWarping2d::getInitialDeformations(Vector &v0)
     double xL1 = xL-1.0;
     double wtL = wt[i]*L;
 
-					    // compute coeficient w
+					    // compute coefficient w
 	const Matrix &ks = sections[i]->getInitialTangent(); 
 	double EI(0), GA(0), GB(0), GC(0), EJ(0);
 	for (int k = 0; k < order; k++) {
@@ -2288,7 +2288,7 @@ ForceBeamColumnWarping2d::Print(OPS_Stream &s, int flag)
     double V = (M1+M2)/L;
 	double R1(0), R2(0);
 
-	// compute coeficient w
+	// compute coefficient w
 	int order      = sections[0]->getOrder();
 	const ID &code = sections[0]->getType();
 	const Matrix &ks0 = sections[0]->getInitialTangent(); 
@@ -2405,7 +2405,7 @@ ForceBeamColumnWarping2d::Print(OPS_Stream &s, int flag)
 	
 		double R1(0), R2(0);
 
-	// compute coeficient w
+	// compute coefficient w
 	int order      = sections[0]->getOrder();
 	const ID &code = sections[0]->getType();
 	const Matrix &ks0 = sections[0]->getInitialTangent(); 
@@ -2826,7 +2826,7 @@ ForceBeamColumnWarping2d::getResponse(int responseID, Information &eleInfo)
 
 		double R1(0), R2(0);
 
-			// compute coeficient w
+			// compute coefficient w
 	double L = crdTransf->getInitialLength();
 	int order      = sections[0]->getOrder();
 	const ID &code = sections[0]->getType();

--- a/SRC/element/forceBeamColumn/ForceBeamColumnWarping2d.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumnWarping2d.h
@@ -155,7 +155,7 @@ class ForceBeamColumnWarping2d: public Element
   BeamIntegration *beamIntegr;
   int numSections;
   SectionForceDeformation **sections;          // array of pointers to sections
-  CrdTransf *crdTransf;        // pointer to coordinate tranformation object 
+  CrdTransf *crdTransf;        // pointer to coordinate transformation object 
   // (performs the transformation between the global and basic system)
   double rho;                    // mass density per unit length
   int    maxIters;               // maximum number of local iterations
@@ -168,14 +168,14 @@ class ForceBeamColumnWarping2d: public Element
   Matrix kv;                     // stiffness matrix in the basic system 
   Vector Se;                     // element resisting forces in the basic system
   
-  Matrix kvcommit;               // commited stiffness matrix in the basic system
-  Vector Secommit;               // commited element end forces in the basic system
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
   
   Matrix *fs;                    // array of section flexibility matrices
   Vector *vs;                    // array of section deformation vectors
   Vector *Ssr;                   // array of section resisting force vectors
   
-  Vector *vscommit;              // array of commited section deformation vectors
+  Vector *vscommit;              // array of committed section deformation vectors
   
   enum {maxNumEleLoads = 100};
   enum {NDM = 2};         // dimension of the problem (2d)

--- a/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
+++ b/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
@@ -131,7 +131,7 @@ TclModelBuilder_addForceBeamColumn(ClientData clientData, Tcl_Interp *interp,
   TCL_Char **argv;
 
   if (Tcl_SplitList(interp, List, &argc, &argv) != TCL_OK) {
-    opserr <<  "WARNING - TclModelBuilder_addForceBeamColumn - problem spliting list\n";
+    opserr <<  "WARNING - TclModelBuilder_addForceBeamColumn - problem splitting list\n";
     return TCL_ERROR;
   }
   Tcl_Free ((char *)List);
@@ -1356,7 +1356,7 @@ TclModelBuilder_addForceBeamColumn(ClientData clientData, Tcl_Interp *interp,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   Tcl_Free((char *)argv);
 	     
   return TCL_OK;

--- a/SRC/element/fourNodeQuad/ConstantPressureVolumeQuad.cpp
+++ b/SRC/element/fourNodeQuad/ConstantPressureVolumeQuad.cpp
@@ -737,7 +737,7 @@ ConstantPressureVolumeQuad::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
 
   for (i=0; i<numberNodes; i++) {

--- a/SRC/element/fourNodeQuad/EnhancedQuad.cpp
+++ b/SRC/element/fourNodeQuad/EnhancedQuad.cpp
@@ -634,7 +634,7 @@ EnhancedQuad::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (i=0; i<numberNodes; i++) {
     const Vector &Raccel = nodePointers[i]->getRV(accel);

--- a/SRC/element/fourNodeQuad/FourNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/FourNodeQuad.cpp
@@ -586,7 +586,7 @@ FourNodeQuad::addInertiaLoadToUnbalance(const Vector &accel)
   
   if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size() ||
       2 != Raccel4.Size()) {
-    opserr << "FourNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "FourNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
   

--- a/SRC/element/fourNodeQuad/FourNodeQuadWithSensitivity.cpp
+++ b/SRC/element/fourNodeQuad/FourNodeQuadWithSensitivity.cpp
@@ -592,7 +592,7 @@ FourNodeQuadWithSensitivity::addInertiaLoadToUnbalance(const Vector &accel)
 
   if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size() ||
       2 != Raccel4.Size()) {
-    opserr << "FourNodeQuadWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+    opserr << "FourNodeQuadWithSensitivity::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
     return -1;
   }
 

--- a/SRC/element/fourNodeQuad/NineNodeMixedQuad.cpp
+++ b/SRC/element/fourNodeQuad/NineNodeMixedQuad.cpp
@@ -606,7 +606,7 @@ NineNodeMixedQuad::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
 
   for (i=0; i<numberNodes; i++) {

--- a/SRC/element/fourNodeQuad/TclFourNodeQuadCommand.cpp
+++ b/SRC/element/fourNodeQuad/TclFourNodeQuadCommand.cpp
@@ -180,7 +180,7 @@ TclModelBuilder_addFourNodeQuad(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -290,7 +290,7 @@ TclModelBuilder_addConstantPressureVolumeQuad(ClientData clientData, Tcl_Interp 
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -400,7 +400,7 @@ TclModelBuilder_addEnhancedQuad(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -542,7 +542,7 @@ TclModelBuilder_addNineNodeMixedQuad(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }
 
@@ -675,6 +675,6 @@ TclModelBuilder_addFourNodeQuadWithSensitivity(ClientData clientData, Tcl_Interp
       return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   return TCL_OK;
 }

--- a/SRC/element/frictionBearing/FPBearingPTV.cpp
+++ b/SRC/element/frictionBearing/FPBearingPTV.cpp
@@ -1663,7 +1663,7 @@ void FPBearingPTV::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/FlatSliderSimple2d.cpp
+++ b/SRC/element/frictionBearing/FlatSliderSimple2d.cpp
@@ -1105,7 +1105,7 @@ void FlatSliderSimple2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/FlatSliderSimple3d.cpp
+++ b/SRC/element/frictionBearing/FlatSliderSimple3d.cpp
@@ -1247,7 +1247,7 @@ void FlatSliderSimple3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/MultiFP2d.h
+++ b/SRC/element/frictionBearing/MultiFP2d.h
@@ -63,7 +63,7 @@ class MultiFP2d : public Element
   // destructor
   ~MultiFP2d();
   
-  // public methods to obtain inforrmation about dof & connectivity
+  // public methods to obtain information about dof & connectivity
   int getNumExternalNodes(void) const;
   const ID &getExternalNodes(void);
   Node **getNodePtrs(void);

--- a/SRC/element/frictionBearing/RJWatsonEQS2d.cpp
+++ b/SRC/element/frictionBearing/RJWatsonEQS2d.cpp
@@ -1159,7 +1159,7 @@ void RJWatsonEQS2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/RJWatsonEQS3d.cpp
+++ b/SRC/element/frictionBearing/RJWatsonEQS3d.cpp
@@ -1323,7 +1323,7 @@ void RJWatsonEQS3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/SingleFPSimple2d.cpp
+++ b/SRC/element/frictionBearing/SingleFPSimple2d.cpp
@@ -1144,7 +1144,7 @@ void SingleFPSimple2d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/SingleFPSimple3d.cpp
+++ b/SRC/element/frictionBearing/SingleFPSimple3d.cpp
@@ -1288,7 +1288,7 @@ void SingleFPSimple3d::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross y
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/frictionBearing/TFP_Bearing.cpp
+++ b/SRC/element/frictionBearing/TFP_Bearing.cpp
@@ -497,7 +497,7 @@ TFP_Bearing::kt3Drma(double *v, double *vp, double *Fr, double A, double *P, dou
     //opserr << "ks: " << ks;
 
     // restrainer contact stiffness
-    double vt=sqrt(v[i]*v[i]+v[z]*v[z]); //local displacment of surface
+    double vt=sqrt(v[i]*v[i]+v[z]*v[z]); //local displacement of surface
     double rt=(dOut[i]-dIn[i])/2.0;  //restrainer distance
     double del=0.1;
 

--- a/SRC/element/frictionBearing/TFP_Bearing.h
+++ b/SRC/element/frictionBearing/TFP_Bearing.h
@@ -60,7 +60,7 @@ class TFP_Bearing : public Element
     ~TFP_Bearing();
 
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/frictionBearing/TFP_Bearing2d.cpp
+++ b/SRC/element/frictionBearing/TFP_Bearing2d.cpp
@@ -395,7 +395,7 @@ TFP_Bearing2d::kt3Drma(double *v, double *vp, double *Fr, double A, double *P, d
     //opserr << "ks: " << ks;
 
     // restrainer contact stiffness
-    double vt=sqrt(v[i]*v[i]+v[z]*v[z]); //local displacment of surface
+    double vt=sqrt(v[i]*v[i]+v[z]*v[z]); //local displacement of surface
     double rt=(dOut[i]-dIn[i])/2.0;  //restrainer distance
     double del=0.1;
 

--- a/SRC/element/frictionBearing/TFP_Bearing2d.h
+++ b/SRC/element/frictionBearing/TFP_Bearing2d.h
@@ -61,7 +61,7 @@ class TFP_Bearing2d : public Element
     ~TFP_Bearing2d();
 
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/frictionBearing/TPB1D.h
+++ b/SRC/element/frictionBearing/TPB1D.h
@@ -67,7 +67,7 @@ class TPB1D : public Element
   
   const char *getClassType(void) const {return "TPB1D";};
   
-  // public methods to obtain inforrmation about dof & connectivity    
+  // public methods to obtain information about dof & connectivity    
   int getNumExternalNodes(void) const;
   const ID &getExternalNodes(void);
   Node **getNodePtrs(void);

--- a/SRC/element/frictionBearing/TclFlatSliderCommand.cpp
+++ b/SRC/element/frictionBearing/TclFlatSliderCommand.cpp
@@ -539,6 +539,6 @@ int TclModelBuilder_addFlatSliderBearing(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the flatSliderBearing and added it to the domain
+    // if get here we have successfully created the flatSliderBearing and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/frictionBearing/TclRJWatsonEQSCommand.cpp
+++ b/SRC/element/frictionBearing/TclRJWatsonEQSCommand.cpp
@@ -601,6 +601,6 @@ int TclModelBuilder_addRJWatsonEqsBearing(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the RJWatsonEqsBearing and added it to the domain
+    // if get here we have successfully created the RJWatsonEqsBearing and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/frictionBearing/TclSingleFPCommand.cpp
+++ b/SRC/element/frictionBearing/TclSingleFPCommand.cpp
@@ -574,6 +574,6 @@ int TclModelBuilder_addSingleFPBearing(ClientData clientData, Tcl_Interp *interp
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the singleFPBearing and added it to the domain
+    // if get here we have successfully created the singleFPBearing and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/frictionBearing/TripleFrictionPendulum.h
+++ b/SRC/element/frictionBearing/TripleFrictionPendulum.h
@@ -65,7 +65,7 @@ public:
     // method to get class type
     const char *getClassType() const {return "TripleFrictionPendulum";};
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes() const;
     const ID &getExternalNodes();
     Node **getNodePtrs();

--- a/SRC/element/generic/TclGenericClientCommand.cpp
+++ b/SRC/element/generic/TclGenericClientCommand.cpp
@@ -214,6 +214,6 @@ int TclModelBuilder_addGenericClient(ClientData clientData, Tcl_Interp *interp, 
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the genericClient and added it to the domain
+    // if get here we have successfully created the genericClient and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/generic/TclGenericCopyCommand.cpp
+++ b/SRC/element/generic/TclGenericCopyCommand.cpp
@@ -126,6 +126,6 @@ int TclModelBuilder_addGenericCopy(ClientData clientData, Tcl_Interp *interp,  i
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the GenericCopy and added it to the domain
+    // if get here we have successfully created the GenericCopy and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/joint/BeamColumnJoint2d.cpp
+++ b/SRC/element/joint/BeamColumnJoint2d.cpp
@@ -407,9 +407,9 @@ BeamColumnJoint2d::setDomain(Domain *theDomain)
 int
 BeamColumnJoint2d::commitState(void)
 {
-	// store commited external nodal displacements
+	// store committed external nodal displacements
 	Uecommit = UeprCommit;
-	// store commited internal nodal displacements
+	// store committed internal nodal displacements
 	UeIntcommit = UeprIntCommit;
 
 	// store material history data.
@@ -459,7 +459,7 @@ BeamColumnJoint2d::update(void)
 		Vector Ue(16);
 		Ue.Zero();
 
-	// determine commited displacements given trial displacements
+	// determine committed displacements given trial displacements
 		getGlobalDispls(Ue);
  
 		// update displacements for the external nodes
@@ -1036,7 +1036,7 @@ double BeamColumnJoint2d::getStepSize(double s0,double s1,Vector uExt,Vector duE
 	Vector kSpr(13); kSpr.Zero();
 	Vector intEq(4); intEq.Zero();
 
-	double r0 = 0.0;            // tolerance chcek for line-search
+	double r0 = 0.0;            // tolerance check for line-search
 	double tolerance = 0.8;     // slack region tolerance set for line-search
     
 	if (s0 != 0.0)

--- a/SRC/element/joint/BeamColumnJoint2d.h
+++ b/SRC/element/joint/BeamColumnJoint2d.h
@@ -187,8 +187,8 @@ class BeamColumnJoint2d : public Element
   double HgtFac;               // distance in between the tension compression couple in the height direction 
   double WdtFac;               // distance in between the tension compression couple in the width direction      
   
-  Vector Uecommit;             // vector of external commited displacements
-  Vector UeIntcommit;          // vector of internal commited displacements   
+  Vector Uecommit;             // vector of external committed displacements
+  Vector UeIntcommit;          // vector of internal committed displacements   
   Vector UeprCommit;           // vector of previous external committed displacements
   Vector UeprIntCommit;        // vector of previous internal committed displacements  
   Matrix BCJoint;       // matrix describing relation between the component deformations and the external and internal deformations

--- a/SRC/element/joint/BeamColumnJoint3d.cpp
+++ b/SRC/element/joint/BeamColumnJoint3d.cpp
@@ -406,9 +406,9 @@ BeamColumnJoint3d::setDomain(Domain *theDomain)
 int
 BeamColumnJoint3d::commitState()
 {
-	// store commited external nodal displacements
+	// store committed external nodal displacements
   Uecommit = UeprCommit;
-  // store commited internal nodal displacements
+  // store committed internal nodal displacements
   UeIntcommit = UeprIntCommit;
 
   // store material history data.
@@ -460,7 +460,7 @@ BeamColumnJoint3d::update()
 	Vector Ue(28);
 	Ue.Zero();
 
-	// determine commited displacements given trial displacements
+	// determine committed displacements given trial displacements
 	this->getGlobalDispls(Ue);
  
 	// update displacements for the external nodes
@@ -1027,7 +1027,7 @@ double BeamColumnJoint3d::getStepSize(double s0,double s1,Vector uExt,Vector duE
 	Vector kSpr(13); kSpr.Zero();
 	Vector intEq(4); intEq.Zero();
 
-	double r0 = 0.0;            // tolerance chcek for line-search
+	double r0 = 0.0;            // tolerance check for line-search
 	double tolerance = 0.8;     // slack region tolerance set for line-search
     
 	if (s0 != 0.0)

--- a/SRC/element/joint/BeamColumnJoint3d.h
+++ b/SRC/element/joint/BeamColumnJoint3d.h
@@ -26,7 +26,7 @@
 // Created: Feb 2003
 // Updated: September 2004
 //
-// Description: This file contains the class defination for beam-column joint.
+// Description: This file contains the class definition for beam-column joint.
 // This element is a 4 noded 24 dof (6 dof at each node) finite area super-element, being a slight
 // variation of the 2d one. The element takes in 13 different material types in order to simulate
 // the inelastic action observed in a reinforced beam column joint. Though it has 6 dof per node 
@@ -185,8 +185,8 @@ class BeamColumnJoint3d : public Element
   double HgtFac;               // distance in between the tension compression couple in the height direction 
   double WdtFac;               // distance in between the tension compression couple in the width direction      
   
-  Vector Uecommit;             // vector of external commited displacements
-  Vector UeIntcommit;          // vector of internal commited displacements   
+  Vector Uecommit;             // vector of external committed displacements
+  Vector UeIntcommit;          // vector of internal committed displacements   
   Vector UeprCommit;           // vector of previous external committed displacements
   Vector UeprIntCommit;        // vector of previous internal committed displacements  
   Matrix BCJoint;       // matrix describing relation between the component deformations and the external and internal deformations

--- a/SRC/element/joint/ElasticTubularJoint.h
+++ b/SRC/element/joint/ElasticTubularJoint.h
@@ -59,7 +59,7 @@ class ElasticTubularJoint : public Element
     ~ElasticTubularJoint();
 
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/joint/Joint2D.cpp
+++ b/SRC/element/joint/Joint2D.cpp
@@ -1541,7 +1541,7 @@ int Joint2D::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theB
   nodeDbTag = data(2);
   dofDbTag = data(3);
   
-  // Receving Springs
+  // Receiving Springs
   for (int i=0 ; i<5 ; i++) {
     fixedEnd[i] = data( i+4 );
     int SpringClass = data( i+9 );

--- a/SRC/element/joint/Joint3D.cpp
+++ b/SRC/element/joint/Joint3D.cpp
@@ -167,7 +167,7 @@ void* OPS_Joint3D()
 				  iNode,jNode,kNode,lNode,mNode,nNode,CenterNodeTag,
 				  *MatX,*MatY,*MatZ, theDomain, LargeDisp);
     
-	// if get here we have sucessfully created the element and added it to the domain
+	// if get here we have successfully created the element and added it to the domain
 	return theJoint3D;
     }
   
@@ -416,7 +416,7 @@ Joint3D::~Joint3D()
 		{
 			int intnodetag = theNodes[6]->getTag();
 			Node *theNode = TheDomain->removeNode( intnodetag );
-			if (theNode != 0) // have to check against eurned node in case node alrady gone!
+			if (theNode != 0) // have to check against eurned node in case node already gone!
 			  delete theNode;
 		}
 	}

--- a/SRC/element/joint/MP_Joint2D.cpp
+++ b/SRC/element/joint/MP_Joint2D.cpp
@@ -93,7 +93,7 @@ MP_Joint2D::MP_Joint2D(Domain *theDomain, int nodeRetain, int nodeConstr,
     return;
   }
   
-  // check the main degree of freedom. Assign auxilary DOF 
+  // check the main degree of freedom. Assign auxiliary DOF 
   if ( MainDOF!= 2 && MainDOF!=3 ) {
     opserr << "MP_Joint2D::MP_Joint2D - Wrong main degree of freedom" ;
     return;
@@ -253,7 +253,7 @@ MP_Joint2D::applyConstraint(double timeStamp)
 		const Vector &crdR = RetainedNode->getCrds();
 		const Vector &crdC = ConstrainedNode->getCrds();
 
-		// get commited displacements of nodes to get updated coordinates
+		// get committed displacements of nodes to get updated coordinates
 		const Vector &dispR = RetainedNode->getDisp();
 		const Vector &dispC = ConstrainedNode->getDisp();
 
@@ -446,7 +446,7 @@ const Matrix &MP_Joint2D::getConstraint(void)
 		const Vector &crdR = RetainedNode->getCrds();
 		const Vector &crdC = ConstrainedNode->getCrds();
 
-		// get commited displacements of nodes to get updated coordinates
+		// get committed displacements of nodes to get updated coordinates
 		const Vector &dispR = RetainedNode->getTrialDisp();
 		const Vector &dispC = ConstrainedNode->getTrialDisp();
 

--- a/SRC/element/joint/MP_Joint2D.h
+++ b/SRC/element/joint/MP_Joint2D.h
@@ -81,7 +81,7 @@ class MP_Joint2D : public MP_Constraint
     int nodeRetained;			// to identify the retained node
     int nodeConstrained;		// to identify  the constrained node
     int MainDOF;				// main degree of freedom for rotation
-    int AuxDOF;					// Auxilary degree of freedom for shear
+    int AuxDOF;					// Auxiliary degree of freedom for shear
     int FixedEnd;				// fixed rotational degree of freedom at the end 
                                 // released = 0 , fixed = 1
     

--- a/SRC/element/joint/MP_Joint3D.cpp
+++ b/SRC/element/joint/MP_Joint3D.cpp
@@ -113,7 +113,7 @@ RotationNode(0), DisplacementNode(0)
   }
   
   
-  // check the main degree of freedom. Assign auxilary DOF 
+  // check the main degree of freedom. Assign auxiliary DOF 
   if ( RotDOF<6 || RotDOF>8 || DispDOF<6 || DispDOF>8 || RotDOF==DispDOF ) {
     opserr << "MP_Joint3D::MP_Joint3D - Wrong degrees of freedom" ;
     return;
@@ -276,7 +276,7 @@ MP_Joint3D::applyConstraint(double timeStamp)
       const Vector &crdRot = RotationNode->getCrds();
       const Vector &crdDsp = DisplacementNode->getCrds();
       
-      // get commited displacements of nodes to get updated coordinates
+      // get committed displacements of nodes to get updated coordinates
       const Vector &dispRet = RetainedNode->getDisp();
       const Vector &dispCon = ConstrainedNode->getDisp();
       const Vector &dispRot = RotationNode->getDisp();
@@ -358,7 +358,7 @@ const Matrix &MP_Joint3D::getConstraint(void)
 	const Vector &crdR = RetainedNode->getCrds();
 	const Vector &crdC = ConstrainedNode->getCrds();
 	
-	// get commited displacements of nodes to get updated coordinates
+	// get committed displacements of nodes to get updated coordinates
 	const Vector &dispR = RetainedNode->getTrialDisp();
 	const Vector &dispC = ConstrainedNode->getTrialDisp();
 	

--- a/SRC/element/joint/TclBeamColumnJointCommand.cpp
+++ b/SRC/element/joint/TclBeamColumnJointCommand.cpp
@@ -426,6 +426,6 @@ int TclModelBuilder_addBeamColumnJoint(ClientData clientData, Tcl_Interp *interp
 		return TCL_ERROR;
 	}      
 
-	//the element succesfully created and added to the domain
+	//the element successfully created and added to the domain
 	return TCL_OK;
 }

--- a/SRC/element/joint/TclJoint2dCommand.cpp
+++ b/SRC/element/joint/TclJoint2dCommand.cpp
@@ -269,7 +269,7 @@ TclModelBuilder_addJoint2D(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the element and added it to the domain
+    // if get here we have successfully created the element and added it to the domain
     return TCL_OK;
   }
   
@@ -561,7 +561,7 @@ TclModelBuilder_addJoint2D(ClientData clientData, Tcl_Interp *interp,
 	return TCL_ERROR;
       }
       
-      // if get here we have sucessfully created the element and added it to the domain
+      // if get here we have successfully created the element and added it to the domain
       return TCL_OK;
     }
   else 

--- a/SRC/element/joint/TclJoint3dCommand.cpp
+++ b/SRC/element/joint/TclJoint3dCommand.cpp
@@ -212,7 +212,7 @@ TclModelBuilder_addJoint3D(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the element and added it to the domain
+    // if get here we have successfully created the element and added it to the domain
     return TCL_OK;
   }
   

--- a/SRC/element/mvlem/MVLEM.h
+++ b/SRC/element/mvlem/MVLEM.h
@@ -112,13 +112,13 @@ class MVLEM : public Element {
   const double c;							// center of rotation
   const int m;							// no. of RC panels
   Vector *theLoad;						// pointer to element load
-  
+
   // calculated element parameters
   double h;								// height of MVLEM element (undeformed configuration)
-  double Lw;								// lenght of MVLEM elemtn, i.e. wall length 
+  double Lw;								// length of MVLEM elemtn, i.e. wall length 
   double A;								// Wall cross-section area
   double NodeMass;						// nodal mass
-  
+
   // caldulated element arrays
   double *x;
   double *b;								// fiber widths

--- a/SRC/element/mvlem/SFI_MVLEM.cpp
+++ b/SRC/element/mvlem/SFI_MVLEM.cpp
@@ -19,16 +19,16 @@
 // for details see referenced publications.
 //
 // References:
-// 1) Kolozvari K., Orakcal K., and Wallace J. W. (2015). ”Modeling of Cyclic 
-// Shear-Flexure Interaction in Reinforced Concrete Structural Walls. I: Theory”, 
+// 1) Kolozvari K., Orakcal K., and Wallace J. W. (2015). ï¿½Modeling of Cyclic 
+// Shear-Flexure Interaction in Reinforced Concrete Structural Walls. I: Theoryï¿½, 
 // ASCE Journal of Structural Engineering, 141(5), 04014135 
 // http://dx.doi.org/10.1061/(ASCE)ST.1943-541X.0001059
-// 2) Kolozvari K., Tran T., Orakcal K., and Wallace, J.W. (2015). ”Modeling 
+// 2) Kolozvari K., Tran T., Orakcal K., and Wallace, J.W. (2015). ï¿½Modeling 
 // of Cyclic Shear-Flexure Interaction in Reinforced Concrete Structural Walls. 
-// II: Experimental Validation”, ASCE Journal of Structural Engineering, 141(5), 
+// II: Experimental Validationï¿½, ASCE Journal of Structural Engineering, 141(5), 
 // 04014136 http://dx.doi.org/10.1061/(ASCE)ST.1943-541X.0001083
-// 3) Kolozvari K. (2013). “Analytical Modeling of Cyclic Shear-Flexure 
-// Interaction in Reinforced Concrete Structural Walls”, PhD Dissertation, 
+// 3) Kolozvari K. (2013). ï¿½Analytical Modeling of Cyclic Shear-Flexure 
+// Interaction in Reinforced Concrete Structural Wallsï¿½, PhD Dissertation, 
 // University of California, Los Angeles.
 
 #include <math.h>
@@ -645,7 +645,7 @@ void SFI_MVLEM::setDomain(Domain *theDomain)
   // Call the DomainComponent class method 
   this->DomainComponent::setDomain(theDomain);
   
-  // Ensure conected nodes have correct number of dof's
+  // Ensure connected nodes have correct number of dof's
   int dofNd1 = theNodes[0]->getNumberDOF();
   int dofNd2 = theNodes[1]->getNumberDOF();	
   if ((dofNd1 != 3) || (dofNd2 != 3)) // 3 DOFS at external nodes
@@ -692,7 +692,7 @@ int SFI_MVLEM::commitState()
   return errCode;
 }
 
-// Revert to last commited state (if convergence is not achieved)
+// Revert to last committed state (if convergence is not achieved)
 int SFI_MVLEM::revertToLastCommit()
 {
   int errCode = 0;
@@ -935,7 +935,7 @@ int SFI_MVLEM::displaySelf(Renderer &theViewer, int displayMode, float fact, con
 		NodePLotCrds(panel,7) = v2(0) + x[panel]+b[panel]/2.0; // x
 		NodePLotCrds(panel,8) = v2(1) +(x[panel]+b[panel]/2.0)*end2Disp(2)*fact; // y
 		NodePLotCrds(panel,9) = v2(2); // z
-		// Local node 4 - top rigth
+		// Local node 4 - top right
 		NodePLotCrds(panel,10) = v2(0) + x[panel]-b[panel]/2.0; // x
 		NodePLotCrds(panel,11) = v2(1) + (x[panel]-b[panel]/2.0)*end2Disp(2)*fact; // y
 		NodePLotCrds(panel,12) = v2(2); // z
@@ -1077,7 +1077,7 @@ int SFI_MVLEM::getResponse(int responseID, Information &eleInfo)
 	}
 }
 
-// Get the element intial element tangent matrix
+// Get the element initial element tangent matrix
 const Matrix & SFI_MVLEM::getInitialStiff(void)
 {
   double Kh=0.0;

--- a/SRC/element/mvlem/SFI_MVLEM.h
+++ b/SRC/element/mvlem/SFI_MVLEM.h
@@ -64,7 +64,7 @@ public:
 	// destructor
 	~SFI_MVLEM();
 
-	// public methods to obtain inforrmation about dof & comectivity
+	// public methods to obtain information about dof & comectivity
 	int getNumExternalNodes(void) const;
 	const ID &getExternalNodes(void);
 	Node **getNodePtrs(void);
@@ -119,14 +119,14 @@ private:
 	NDMaterial **theMaterial;			// array of ND materials
 	Vector *theLoad;					// pointer to element load
 	const double c;						// center of rotation
-	const int m;						// no. of RC panels 
+	const int m;						// no. of RC panels
 
 	// calculated element parameters
 	ID externalNodes;					// contains the id's of end nodes
 	Matrix trans;						// hold the transformation matrix, could use a Vector
 	double h;							// height of SFI_MVLEM element (undeformed configuration)
-	double Lw;							// lenght of SFI_MVLEM elemtn, i.e. wall length 
-	double TotalMass;					// element mass - you dont need this !!!
+	double Lw;							// length of SFI_MVLEM elemtn, i.e. wall length
+	double TotalMass;					// element mass - you don't need this !!!
 	double NodeMass;					// nodal mass
 
 	// caldulated element arrays

--- a/SRC/element/nonlinearBeamColumn/tcl/TclElmtBuilder.cpp
+++ b/SRC/element/nonlinearBeamColumn/tcl/TclElmtBuilder.cpp
@@ -95,7 +95,7 @@ TclModelBuilder_addFrameElement(ClientData clientData, Tcl_Interp *interp,
        
   if (Tcl_SplitList(interp, List, &argc, &argv) != TCL_OK)
   {
-    opserr <<  "WARNING - TclModelBuilder_addFrameElement - problem spliting list\n";
+    opserr <<  "WARNING - TclModelBuilder_addFrameElement - problem splitting list\n";
     return TCL_ERROR;
   }
       
@@ -284,7 +284,7 @@ TclModelBuilder_addFrameElement(ClientData clientData, Tcl_Interp *interp,
 
   Tcl_Free ((char *)argv);
 
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
   
   return TCL_OK;
 }

--- a/SRC/element/nonlinearBeamColumn/tcl/TclElmtBuilder.cpp.jnt
+++ b/SRC/element/nonlinearBeamColumn/tcl/TclElmtBuilder.cpp.jnt
@@ -93,7 +93,7 @@ TclModelBuilder_addFrameElement(ClientData clientData, Tcl_Interp *interp,
        
   if (Tcl_SplitList(interp, List, &argc, &argv) != TCL_OK)
   {
-      interp->result = "WARNING - TclModelBuilder_addFrameElement - problem spliting list";
+      interp->result = "WARNING - TclModelBuilder_addFrameElement - problem splitting list";
       return TCL_ERROR;
   }
       
@@ -441,7 +441,7 @@ TclModelBuilder_addFrameElement(ClientData clientData, Tcl_Interp *interp,
 
   Tcl_Free ((char *)argv);
         
-  // if get here we have sucessfully created the element and added it to the domain
+  // if get here we have successfully created the element and added it to the domain
 
   return TCL_OK;
 }
@@ -633,7 +633,7 @@ int TclModelBuilder_addPatch(ClientData clientData, Tcl_Interp *interp, int argc
       QuadPatch *patch = new QuadPatch(matTag, numSubdivIJ, numSubdivJK, vertexCoords);
       if (!patch)
       {
-         interp->result = "WARNING cannot alocate patch";
+         interp->result = "WARNING cannot allocate patch";
          return TCL_ERROR;
       }
 
@@ -760,7 +760,7 @@ int TclModelBuilder_addPatch(ClientData clientData, Tcl_Interp *interp, int argc
                                        startAng, endAng);
       if (!patch)
       {
-         interp->result = "WARNING cannot alocate patch";
+         interp->result = "WARNING cannot allocate patch";
          return TCL_ERROR;
       }
 
@@ -916,7 +916,7 @@ int TclModelBuilder_addReinfLayer(ClientData clientData, Tcl_Interp *interp, int
                                                    startPt, endPt);
       if (!reinfLayer)
       {
-         interp->result = "WARNING cannot alocate reinfLayer";
+         interp->result = "WARNING cannot allocate reinfLayer";
          return TCL_ERROR;
       }
       //cerr << "\nStraigthReinfLayer: " << *reinfLayer;
@@ -1033,7 +1033,7 @@ int TclModelBuilder_addReinfLayer(ClientData clientData, Tcl_Interp *interp, int
                                                        center, radius, startAng, endAng);
       if (!reinfLayer)
       {
-         interp->result = "WARNING cannot alocate reinfLayer";
+         interp->result = "WARNING cannot allocate reinfLayer";
          return TCL_ERROR;
       }
       //cerr << "\nCircReinfLayer: " << *reinfLayer;

--- a/SRC/element/pyMacro/PY_Macro2D.h
+++ b/SRC/element/pyMacro/PY_Macro2D.h
@@ -39,7 +39,7 @@ class PY_Macro2D : public Element
 
     const char *getClassType(void) const {return "PY_Macro2D";};
 
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/shell/ShellANDeS.cpp
+++ b/SRC/element/shell/ShellANDeS.cpp
@@ -445,7 +445,7 @@ int ShellANDeS::addInertiaLoadToUnbalance(const Vector &accel)
     if (6 != Raccel1.Size() || 6 != Raccel2.Size() || 6 != Raccel3.Size()  )
     {
         // Xiaoyan changed 2 to 3 and added Racce15-18  09/27/00
-        opserr << "ShellANDeS::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+        opserr << "ShellANDeS::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
         return -1;
     }
 
@@ -2259,7 +2259,7 @@ void ShellANDeS::initializeGeometry()
     //Centroid
     x0 = (x1 + x2 + x3) / 3;
 
-    // Local x axis points paralell to side 1-2
+    // Local x axis points parallel to side 1-2
     e1 = x2 - x1;
     e1.Normalize();
 

--- a/SRC/element/shell/ShellDKGQ.cpp
+++ b/SRC/element/shell/ShellDKGQ.cpp
@@ -1044,11 +1044,11 @@ ShellDKGQ::formResidAndTangent( int tang_flag )
 
 	static Vector strain(nstress); //strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][12]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][12]; //shape function - bending part at a gauss point
 
 	static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -1636,7 +1636,7 @@ ShellDKGQ::shape2d( double ss, double tt,
   //  static double sx[2][2] ;  //have been defined before
 
   for ( i = 0; i < 4; i++ ) {
-      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape fuction for 2d isoparametric element
+      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape function for 2d isoparametric element
       shp[0][i] = s[i] * ( 0.5 + t[i]*tt ) ; // derivative to isoparametric coordinates 1
       shp[1][i] = t[i] * ( 0.5 + s[i]*ss ) ; // derivative to isoparametric coordinates 1
   } // end for i

--- a/SRC/element/shell/ShellDKGT.cpp
+++ b/SRC/element/shell/ShellDKGT.cpp
@@ -1045,11 +1045,11 @@ ShellDKGT::formResidAndTangent( int tang_flag )
 
 	static Vector strain(nstress); //strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][9]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][9]; //shape function - bending part at a gauss point
 
 	static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -1558,7 +1558,7 @@ int  ShellDKGT::sendSelf (int commitTag, Channel &theChannel)
 
 int  ShellDKGT::recvSelf (int commitTag, 
 		       Channel &theChannel, 
-		       FEM_ObjectBroker &theBroker)      //idDataºóÃæµÄ±àºÅÊÇÊ²Ã´ÒâË¼
+		       FEM_ObjectBroker &theBroker)      //idDataï¿½ï¿½ï¿½ï¿½Ä±ï¿½ï¿½ï¿½ï¿½Ê²Ã´ï¿½ï¿½Ë¼
 {
   int res = 0;
   

--- a/SRC/element/shell/ShellMITC4Thermal.cpp
+++ b/SRC/element/shell/ShellMITC4Thermal.cpp
@@ -22,7 +22,7 @@
 // $Date: 2011/03/10 22:51:21 $
 // $Source: /usr/local/cvs/OpenSees/SRC/element/shell/ShellMITC4Thermal.cpp,v $
 
-// Written: Leopoldo Tesser, Diego A. Talledo, Véronique Le Corvec
+// Written: Leopoldo Tesser, Diego A. Talledo, Vï¿½ronique Le Corvec
 //
 // Bathe MITC 4 four node shell element with membrane and drill
 // Ref: Dvorkin,Bathe, A continuum mechanics based four node shell
@@ -2145,7 +2145,7 @@ ShellMITC4Thermal::shapefn2d( double ss, double tt ,int i)
 	   case 4:
 		   shpVal = 0.25*(1-ss)*(1+tt);break;
 	   default:
-		   opserr<<"ShellMITC4Thermal::shapefn2d recieved an invalid i: "<<i <<endln ;
+		   opserr<<"ShellMITC4Thermal::shapefn2d received an invalid i: "<<i <<endln ;
 	   }
    return shpVal;
 }

--- a/SRC/element/shell/ShellNLDKGQ.cpp
+++ b/SRC/element/shell/ShellNLDKGQ.cpp
@@ -583,11 +583,11 @@ const Matrix&  ShellNLDKGQ::getInitialStiff( )
 	static Vector dstrain_li(nstress); //linear incr strain
 	static Vector dstrain_nl(3);//geometric nonlinear strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][12]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][12]; //shape function - bending part at a gauss point
 
 	//static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -1241,11 +1241,11 @@ ShellNLDKGQ::formResidAndTangent( int tang_flag )
 	static Vector dstrain_li(nstress); //linear incr strain
 	static Vector dstrain_nl(3);//geometric nonlinear strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][12]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][12]; //shape function - bending part at a gauss point
 
 	static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -1990,7 +1990,7 @@ ShellNLDKGQ::shape2d( double ss, double tt,
  // static double sx[2][2] ;  //have been defined before
 
   for ( i = 0; i < 4; i++ ) {
-      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape fuction for 2d isoparametric element
+      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape function for 2d isoparametric element
       shp[0][i] = s[i] * ( 0.5 + t[i]*tt ) ; // derivative to isoparametric coordinates 1
       shp[1][i] = t[i] * ( 0.5 + s[i]*ss ) ; // derivative to isoparametric coordinates 2
   } // end for i

--- a/SRC/element/shell/ShellNLDKGQThermal.cpp
+++ b/SRC/element/shell/ShellNLDKGQThermal.cpp
@@ -600,11 +600,11 @@ const Matrix&  ShellNLDKGQThermal::getInitialStiff( )
 	static Vector dstrain_li(nstress); //linear incr strain
 	static Vector dstrain_nl(3);//geometric nonlinear strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][12]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][12]; //shape function - bending part at a gauss point
 
 	//static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -1462,11 +1462,11 @@ ShellNLDKGQThermal::formResidAndTangent( int tang_flag )
 	static Vector dstrain_li(nstress); //linear incr strain
 	static Vector dstrain_nl(3);//geometric nonlinear strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][12]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][12]; //shape function - bending part at a gauss point
 
 	static Vector residJ(ndf); //nodeJ residual, global coordinates
 
@@ -2276,7 +2276,7 @@ ShellNLDKGQThermal::shape2d( double ss, double tt,
  // static double sx[2][2] ;  //have been defined before
 
   for ( i = 0; i < 4; i++ ) {
-      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape fuction for 2d isoparametric element
+      shp[2][i] = ( 0.5 + s[i]*ss )*( 0.5 + t[i]*tt ) ; //shape function for 2d isoparametric element
       shp[0][i] = s[i] * ( 0.5 + t[i]*tt ) ; // derivative to isoparametric coordinates 1
       shp[1][i] = t[i] * ( 0.5 + s[i]*ss ) ; // derivative to isoparametric coordinates 2
   } // end for i
@@ -2332,7 +2332,7 @@ ShellNLDKGQThermal::shapefn2d( double ss, double tt ,int i)
 	   case 4:
 		   shpVal = 0.25*(1-ss)*(1+tt);break;
 	   default:
-		   opserr<<"ShellNLDKGQThermal::shapefn2d recieved an invalid i: "<<i <<endln ;
+		   opserr<<"ShellNLDKGQThermal::shapefn2d received an invalid i: "<<i <<endln ;
 	   }
    return shpVal;
 }

--- a/SRC/element/shell/ShellNLDKGT.cpp
+++ b/SRC/element/shell/ShellNLDKGT.cpp
@@ -1189,11 +1189,11 @@ ShellNLDKGT::formResidAndTangent( int tang_flag )
 	static Vector dstrain_li(nstress); //linear incr strain
 	static Vector dstrain_nl(3);//geometric nonlinear strain
 
-	static double shp[3][numnodes]; //shape fuction 2d at a gauss point
+	static double shp[3][numnodes]; //shape function 2d at a gauss point
 
 	static double shpDrill[4][numnodes]; //shape function drilling dof at a gauss point
 
-	static double shpBend[6][9]; //shape fuction - bending part at a gauss point
+	static double shpBend[6][9]; //shape function - bending part at a gauss point
 
 	static Vector residJ(ndf); //nodeJ residual, global coordinates
 

--- a/SRC/element/surfaceLoad/SurfaceLoad.h
+++ b/SRC/element/surfaceLoad/SurfaceLoad.h
@@ -58,7 +58,7 @@ class SurfaceLoad : public Element
     SurfaceLoad();
     ~SurfaceLoad();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/surfaceLoad/TriSurfaceLoad.h
+++ b/SRC/element/surfaceLoad/TriSurfaceLoad.h
@@ -57,7 +57,7 @@ class TriSurfaceLoad : public Element
     TriSurfaceLoad();
     ~TriSurfaceLoad();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
+++ b/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
@@ -572,7 +572,7 @@ FourNodeTetrahedron::addLoad(ElementalLoad *theLoad, double loadFactor)
       appliedB[2] += loadFactor * b[2];
     return 0;
   } else if (type == LOAD_TAG_SelfWeight) {
-      // added compatability with selfWeight class implemented for all continuum elements, C.McGann, U.W.
+      // added compatibility with selfWeight class implemented for all continuum elements, C.McGann, U.W.
       applyLoad = 1;
       appliedB[0] += loadFactor*data(0)*b[0];
       appliedB[1] += loadFactor*data(1)*b[1];
@@ -612,7 +612,7 @@ FourNodeTetrahedron::addInertiaLoadToUnbalance(const Vector &accel)
   int tangFlag = 1 ;
   formInertiaTerms( tangFlag ) ;
 
-  // store computed RV fro nodes in resid vector
+  // store computed RV for nodes in resid vector
   int count = 0;
   for (i=0; i<numberNodes; i++) 
   {

--- a/SRC/element/triangle/Tri31.cpp
+++ b/SRC/element/triangle/Tri31.cpp
@@ -198,7 +198,7 @@ int OPS_Tri31(Domain& theDomain, const ID& elenodes, ID& eletags)
 			   *theMaterial, theType, thk,
 			   dData[0], dData[1], dData[2], dData[3]);
 	if (theEle == 0) {
-	    opserr<<"WARING: run out of memory for creating element\n";
+	    opserr<<"WARNING: run out of memory for creating element\n";
 	    return -1;
 	}
 	if (theDomain.addElement(theEle) == false) {
@@ -641,7 +641,7 @@ Tri31::addInertiaLoadToUnbalance(const Vector &accel)
 	const Vector &Raccel3 = theNodes[2]->getRV(accel);
 
 	if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size()) {
-		opserr << "Tri31::addInertiaLoadToUnbalance matrix and vector sizes are incompatable\n";
+		opserr << "Tri31::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
 	    return -1;
 	}
 

--- a/SRC/element/truss/CorotTruss.h
+++ b/SRC/element/truss/CorotTruss.h
@@ -56,7 +56,7 @@ class CorotTruss : public Element
 
     const char *getClassType(void) const {return "CorotTruss";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/CorotTruss2.h
+++ b/SRC/element/truss/CorotTruss2.h
@@ -50,7 +50,7 @@ class CorotTruss2 : public Element
 
     const char *getClassType(void) const {return "CorotTruss2";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/CorotTrussSection.h
+++ b/SRC/element/truss/CorotTrussSection.h
@@ -56,7 +56,7 @@ class CorotTrussSection : public Element
 
     const char *getClassType(void) const {return "CorotTrussSection";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/N4BiaxialTruss.h
+++ b/SRC/element/truss/N4BiaxialTruss.h
@@ -47,7 +47,7 @@ class N4BiaxialTruss : public Element
 
     const char *getClassType(void) const {return "N4BiaxialTruss";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/Truss.cpp
+++ b/SRC/element/truss/Truss.cpp
@@ -672,7 +672,7 @@ Truss::addInertiaLoadToUnbalance(const Vector &accel)
 #ifdef _G3DEBUG    
   if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
     opserr <<"Truss::addInertiaLoadToUnbalance " <<
-      "matrix and vector sizes are incompatable\n";
+      "matrix and vector sizes are incompatible\n";
     return -1;
   }
 #endif
@@ -724,7 +724,7 @@ Truss::addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool somethingR
 #ifdef _G3DEBUG    
     if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
       opserr << "Truss::addInertiaLoadToUnbalance " <<
-	"matrix and vector sizes are incompatable\n";
+	"matrix and vector sizes are incompatible\n";
       return -1;
     }
 #endif
@@ -758,7 +758,7 @@ Truss::addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool somethingR
 #ifdef _G3DEBUG    
     if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
       opserr << "Truss::addInertiaLoadToUnbalance " <<
-	"matrix and vector sizes are incompatable\n";
+	"matrix and vector sizes are incompatible\n";
       return -1;
     }
 #endif

--- a/SRC/element/truss/Truss.h
+++ b/SRC/element/truss/Truss.h
@@ -32,7 +32,7 @@
 //
 // Description: This file contains the class definition for Truss. A Truss object
 // provides the abstraction of the small deformation bar element. Each truss
-// object is assocaited with a material object. This Truss element will work
+// object is associated with a material object. This Truss element will work
 // in 1d, 2d or 3d problems.
 //
 // What: "@(#) Truss.h, revA"
@@ -59,7 +59,7 @@ class Truss : public Element
 
     const char *getClassType(void) const {return "Truss";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/Truss.tex
+++ b/SRC/element/truss/Truss.tex
@@ -4,7 +4,7 @@
 \noindent {\bf Files}   \\
 \indent \#include $<\tilde{ }$/element/truss/Truss.h$>$  \\
 
-\noindent {\bf Class Decleration}  \\
+\noindent {\bf Class Declaration}  \\
 \indent class Truss: public Element \\
 
 \noindent {\bf Class Hierarchy} \\

--- a/SRC/element/truss/Truss2.cpp
+++ b/SRC/element/truss/Truss2.cpp
@@ -688,7 +688,7 @@ int
 #ifdef _G3DEBUG    
 	if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
 		opserr <<"Truss2::addInertiaLoadToUnbalance " <<
-			"matrix and vector sizes are incompatable\n";
+			"matrix and vector sizes are incompatible\n";
 		return -1;
 	}
 #endif
@@ -739,7 +739,7 @@ int
 #ifdef _G3DEBUG    
 		if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
 			opserr << "Truss2::addInertiaLoadToUnbalance " <<
-				"matrix and vector sizes are incompatable\n";
+				"matrix and vector sizes are incompatible\n";
 			return -1;
 		}
 #endif
@@ -773,7 +773,7 @@ int
 #ifdef _G3DEBUG    
 		if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
 			opserr << "Truss2::addInertiaLoadToUnbalance " <<
-				"matrix and vector sizes are incompatable\n";
+				"matrix and vector sizes are incompatible\n";
 			return -1;
 		}
 #endif

--- a/SRC/element/truss/Truss2.h
+++ b/SRC/element/truss/Truss2.h
@@ -48,7 +48,7 @@ class Truss2 : public Element
 
     const char *getClassType(void) const {return "Truss2";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/truss/TrussSection.cpp
+++ b/SRC/element/truss/TrussSection.cpp
@@ -673,7 +673,7 @@ TrussSection::addInertiaLoadToUnbalance(const Vector &accel)
 #ifdef _G3DEBUG    
   if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
     opserr <<"TrussSection::addInertiaLoadToUnbalance " <<
-      "matrix and vector sizes are incompatable\n";
+      "matrix and vector sizes are incompatible\n";
     return -1;
   }
 #endif
@@ -1622,7 +1622,7 @@ TrussSection::addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool som
 #ifdef _G3DEBUG    
     if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
       opserr << "Truss::addInertiaLoadToUnbalance " <<
-	"matrix and vector sizes are incompatable\n";
+	"matrix and vector sizes are incompatible\n";
       return -1;
     }
 #endif
@@ -1656,7 +1656,7 @@ TrussSection::addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool som
 #ifdef _G3DEBUG    
     if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
       opserr << "Truss::addInertiaLoadToUnbalance " <<
-	"matrix and vector sizes are incompatable\n";
+	"matrix and vector sizes are incompatible\n";
       return -1;
     }
 #endif

--- a/SRC/element/truss/TrussSection.h
+++ b/SRC/element/truss/TrussSection.h
@@ -32,7 +32,7 @@
 //
 // Description: This file contains the class definition for Truss. A Truss 
 // object provides the abstraction of the small deformation bar element. 
-// Each truss object is assocaited with a section object. This Truss element 
+// Each truss object is associated with a section object. This Truss element 
 // will work in 1d, 2d or 3d problems.
 //
 // What: "@(#) Truss.h, revA"
@@ -59,7 +59,7 @@ class TrussSection : public Element
 
     const char *getClassType(void) const {return "TrussSection";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/twoNodeLink/TclTwoNodeLinkCommand.cpp
+++ b/SRC/element/twoNodeLink/TclTwoNodeLinkCommand.cpp
@@ -315,6 +315,6 @@ int TclModelBuilder_addTwoNodeLink(ClientData clientData,
         return TCL_ERROR;
     }
     
-    // if get here we have sucessfully created the twoNodeLink and added it to the domain
+    // if get here we have successfully created the twoNodeLink and added it to the domain
     return TCL_OK;
 }

--- a/SRC/element/twoNodeLink/TwoNodeLink.cpp
+++ b/SRC/element/twoNodeLink/TwoNodeLink.cpp
@@ -248,7 +248,7 @@ TwoNodeLink::TwoNodeLink(int tag, int dim, int Nd1, int Nd2,
     dir = new ID(numDir);
     if (dir == 0)  {
         opserr << "TwoNodeLink::TwoNodeLink() - "
-            << "failed to creat direction array\n";
+            << "failed to create direction array\n";
         exit(-1);
     }
     
@@ -890,7 +890,7 @@ int TwoNodeLink::recvSelf(int commitTag, Channel &rChannel,
     dir = new ID(numDir);
     if (dir == 0)  {
         opserr << "TwoNodeLink::recvSelf() - "
-            << "failed to creat direction array\n";
+            << "failed to create direction array\n";
         return -1;
     }
     rChannel.recvID(0, commitTag, *dir);
@@ -1280,7 +1280,7 @@ void TwoNodeLink::setUp()
         exit(-1);
     }
     
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     static Vector z(3);
     z(0) = x(1)*y(2) - x(2)*y(1);

--- a/SRC/element/updatedLagrangianBeamColumn/Elastic2DGNL.h
+++ b/SRC/element/updatedLagrangianBeamColumn/Elastic2DGNL.h
@@ -81,7 +81,7 @@ class Elastic2dGNL : public UpdatedLagrangianBeam2D
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * Warnings are generally issued if the standard implementation of a
  * method may not be possible.  Further analysis may lead to incorrect
- * solution, eventhough it may be possible to continue.
+ * solution, even though it may be possible to continue.
  *           
  * Warnings
  * --------

--- a/SRC/element/updatedLagrangianBeamColumn/InelasticYS2DGNL.cpp
+++ b/SRC/element/updatedLagrangianBeamColumn/InelasticYS2DGNL.cpp
@@ -555,7 +555,7 @@ void InelasticYS2DGNL::forceBalance(Vector &eleforce, int algo)
 			break;
 		}
 		default:
-			opserr << "InelasticYS2DGNL::forceBalance - unkown algo\n";
+			opserr << "InelasticYS2DGNL::forceBalance - unknown algo\n";
 			break;
 	}
 

--- a/SRC/element/zeroLength/CoupledZeroLength.h
+++ b/SRC/element/zeroLength/CoupledZeroLength.h
@@ -59,7 +59,7 @@ class CoupledZeroLength : public Element {
     
     const char *getClassType(void) const {return "CoupledZeroLength";};
     
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/zeroLength/TclZeroLength.cpp
+++ b/SRC/element/zeroLength/TclZeroLength.cpp
@@ -118,7 +118,7 @@ TclModelBuilder_addZeroLength(ClientData clientData, Tcl_Interp *interp,
 	argi++;
     }
 
-    if (argi == argc) { // check we encounterd the -dirn flag
+    if (argi == argc) { // check we encountered the -dirn flag
       opserr << "WARNING no -dirn flag encountered " <<
 	"- element ZeroLength eleTag? iNode? jNode? " <<
 	"-mat matID1? ... -dir dirMat1? .. " <<
@@ -235,7 +235,7 @@ TclModelBuilder_addZeroLength(ClientData clientData, Tcl_Interp *interp,
     while (argi < argc) {
 	if (strcmp(argv[argi],"-orient") == 0) {
 	    if (argc < (argi+7)) {
-	      opserr << "WARNING not enough paramaters after -orient flag for ele " << eleTag <<
+	      opserr << "WARNING not enough parameters after -orient flag for ele " << eleTag <<
 		"- element ZeroLength eleTag? iNode? jNode? " <<
 		"-mat matID1? ... -dir dirMat1? .. " <<
 		"<-orient x1? x2? x3? y1? y2? y3?>\n";	      
@@ -424,7 +424,7 @@ TclModelBuilder_addZeroLengthSection(ClientData clientData, Tcl_Interp *interp,
     while (argi < argc) {
       if (strcmp(argv[argi],"-orient") == 0) {
 	if (argc < (argi+7)) {
-	  opserr << "WARNING not enough paramaters after -orient flag for ele " <<
+	  opserr << "WARNING not enough parameters after -orient flag for ele " <<
 	    eleTag << "- element zeroLengthSection eleTag? iNode? jNode? secTag? " <<
 	    "<-orient x1? x2? x3? y1? y2? y3?>\n";			
 	  return TCL_ERROR;		
@@ -828,7 +828,7 @@ TclModelBuilder_addZeroLengthND(ClientData clientData, Tcl_Interp *interp,
     if (argi < argc) {
 	if (strcmp(argv[argi],"-orient") == 0) {
 	    if (argc < (argi+7)) {
-		opserr << "WARNING not enough paramaters after -orient flag for ele "  << 
+		opserr << "WARNING not enough parameters after -orient flag for ele "  << 
 		  eleTag << "- element zeroLengthND eleTag? iNode? jNode? " <<
 		  "NDTag? <1DTag?> <-orient x1? x2? x3? y1? y2? y3?>\n";	
 		return TCL_ERROR;		
@@ -990,7 +990,7 @@ TclModelBuilder_addZeroLengthRocking(ClientData clientData, Tcl_Interp *interp,
     while (argi < argc) {
         if (strcmp(argv[argi],"-orient") == 0) {
             if (argc < (argi+7)) {
-                opserr << "WARNING not enough paramaters after -orient flag for ele " << eleTag <<
+                opserr << "WARNING not enough parameters after -orient flag for ele " << eleTag <<
                 "- element ZeroLengthRocking eleTag? iNode? jNode? " <<
                 "kr? radius? theta0? kappa? <-orient x1? x2? x3? y1? y2? y3?>\n";	      
                 return TCL_ERROR;
@@ -1027,7 +1027,7 @@ TclModelBuilder_addZeroLengthRocking(ClientData clientData, Tcl_Interp *interp,
             
         } else if (strcmp(argv[argi],"-xi") == 0) {
             if (argc < (argi+2)) {
-                opserr << "WARNING not enough paramaters after -xi flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -xi flag for ele " << eleTag << endln;
                 return TCL_ERROR;
             } else {
                 argi++;
@@ -1040,7 +1040,7 @@ TclModelBuilder_addZeroLengthRocking(ClientData clientData, Tcl_Interp *interp,
             
         } else if (strcmp(argv[argi],"-dTol") == 0) {
             if (argc < (argi+2)) {
-                opserr << "WARNING not enough paramaters after -dTol flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -dTol flag for ele " << eleTag << endln;
                 return TCL_ERROR;
             } else {
                 argi++;
@@ -1053,7 +1053,7 @@ TclModelBuilder_addZeroLengthRocking(ClientData clientData, Tcl_Interp *interp,
 
         } else if (strcmp(argv[argi],"-vTol") == 0) {
             if (argc < (argi+2)) {
-                opserr << "WARNING not enough paramaters after -vTol flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -vTol flag for ele " << eleTag << endln;
                 return TCL_ERROR;
             } else {
                 argi++;

--- a/SRC/element/zeroLength/ZeroLength.cpp
+++ b/SRC/element/zeroLength/ZeroLength.cpp
@@ -1514,7 +1514,7 @@ ZeroLength::setUp( int Nd1, int Nd2,
     if ( x.Size() != 3 || yp.Size() != 3 )
 	opserr << "FATAL ZeroLength::setUp - incorrect dimension of orientation vectors\n";
 
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     Vector z(3);
     z(0) = x(1)*yp(2) - x(2)*yp(1);

--- a/SRC/element/zeroLength/ZeroLength.h
+++ b/SRC/element/zeroLength/ZeroLength.h
@@ -108,7 +108,7 @@ class ZeroLength : public Element
 
     const char *getClassType(void) const {return "ZeroLength";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/zeroLength/ZeroLength.tex
+++ b/SRC/element/zeroLength/ZeroLength.tex
@@ -52,7 +52,7 @@ and {\em x}.
 \indent // Destructor \\
 \indent {\em    ~ZeroLength();} \\ \\
 
-\indent    // public methods to obtain inforrmation about dof \& connectivity \\
+\indent    // public methods to obtain information about dof \& connectivity \\
 \indent {\em    int getNumExternalNodes(void) const;} \\
 \indent {\em    const ID \&getExternalNodes(void);} \\
 \indent {\em    int getNumDOF(void);} \\	
@@ -149,7 +149,7 @@ Initialize element and define data structures.
 \\
 
 \indent {\em    int commitState(void);} \\
-Commit state of element by commiting state of materials.
+Commit state of element by committing state of materials.
 Return 0 if successful, !0 otherwise.
 \\
 
@@ -159,7 +159,7 @@ Return 0 if successful, !0 otherwise.
 \\
 
 \indent {\em    int revertToStart(void);} \\        
-Revert state of element to initial sate by reverting to initial state of materials.
+Revert state of element to initial state by reverting to initial state of materials.
 Return 0 if successful, !0 otherwise.
 \\
 

--- a/SRC/element/zeroLength/ZeroLengthContact2D.h
+++ b/SRC/element/zeroLength/ZeroLengthContact2D.h
@@ -70,7 +70,7 @@
 
  |			   Department of Civil and Environmental Engineering            |
 
- +			   Univeristy of California, Berkeley, CA 94720, USA            +
+ +			   University of California, Berkeley, CA 94720, USA            +
 
  |                                                                          |
 

--- a/SRC/element/zeroLength/ZeroLengthContact3D.h
+++ b/SRC/element/zeroLength/ZeroLengthContact3D.h
@@ -41,7 +41,7 @@
  +             Authors: Gang Wang  AND  Professor Nicholas Sitar            +
  |                                                                          |
  |			   Department of Civil and Environmental Engineering            |
- +			   Univeristy of California, Berkeley, CA 94720, USA            +
+ +			   University of California, Berkeley, CA 94720, USA            +
  |                                                                          |
  |             Email: wang@ce.berkeley.edu (G.W.)                           |
  +                                                                          +

--- a/SRC/element/zeroLength/ZeroLengthContactNTS2D.h
+++ b/SRC/element/zeroLength/ZeroLengthContactNTS2D.h
@@ -32,7 +32,7 @@
  +        Authors: Roozbeh Geraili Mikola  AND   Nicholas Sitar               +
  |                                                                            |
  |		  Department of Civil and Environmental Engineering                   |
- +		  Univeristy of California, Berkeley, CA 94720, USA                   +
+ +		  University of California, Berkeley, CA 94720, USA                   +
  |                                                                            |
  |        Email: Roozbeh Geraili Mikola  (roozbehg@berkeley.edu)              |
  |               Nicholas Sitar          (sitar@ce.berkeley.edu)              |
@@ -72,7 +72,7 @@
 
   References:
     [1] P. Wriggers, V.T. Vu and E. Stein, Finite-element formulation of large deformation 
-	    impact–contact problems with friction, Comput. Struct. 37 (1990), pp. 319–331.
+	    impactï¿½contact problems with friction, Comput. Struct. 37 (1990), pp. 319ï¿½331.
     [2] Peter Wriggers. Computational Contact Mechanics. John Wiley & Sons Ltd. Chichester, 2002.
 
 */

--- a/SRC/element/zeroLength/ZeroLengthImpact3D.cpp
+++ b/SRC/element/zeroLength/ZeroLengthImpact3D.cpp
@@ -89,7 +89,7 @@ OPS_ZeroLengthImpact3D(void)
 
   numData = 1;
   if (OPS_GetDoubleInput(&numData, &dData[0]) != 0) {
-    opserr << "WARNING ZeroLengthImpact3D intial gap input " << eleTag << endln;
+    opserr << "WARNING ZeroLengthImpact3D initial gap input " << eleTag << endln;
     return 0;
   }
 

--- a/SRC/element/zeroLength/ZeroLengthImpact3D.h
+++ b/SRC/element/zeroLength/ZeroLengthImpact3D.h
@@ -55,7 +55,7 @@ class ZeroLengthImpact3D : public Element
     ~ZeroLengthImpact3D();
 
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);
@@ -131,7 +131,7 @@ class ZeroLengthImpact3D : public Element
     static Vector resid;   // for force residual vector
     static Matrix zeroMatrix;
 
-	double initGap; //intial gap
+	double initGap; //initial gap
 	double Kn1; //normal stiffness before yielding
 	double Kn2; //normal stiffness after yielding
 	double Delta_y; //yielding displacement

--- a/SRC/element/zeroLength/ZeroLengthInterface2D.h
+++ b/SRC/element/zeroLength/ZeroLengthInterface2D.h
@@ -36,7 +36,7 @@
  +        Authors: Roozbeh Geraili Mikola  AND  Professor Nicholas Sitar      +
  |                                                                            |
  |		  Department of Civil and Environmental Engineering                   |
- +		  Univeristy of California, Berkeley, CA 94720, USA                   +
+ +		  University of California, Berkeley, CA 94720, USA                   +
  |                                                                            |
  |        Email: roozbehg@berkeley.edu                                        |
  +                                                                            +
@@ -52,7 +52,7 @@
  +----+----+----+----+----+----+----+----+----+----+----+----+----+----+------*/
 
 /*
- element zeroLengthInterface2D eleTag? -sNdNum sNdNum? -mNdNum mNdNum? –dof sdof? mdof? -Nodes Nodes? Kn? Kt? phi? 
+ element zeroLengthInterface2D eleTag? -sNdNum sNdNum? -mNdNum mNdNum? ï¿½dof sdof? mdof? -Nodes Nodes? Kn? Kt? phi? 
 
  Description: This file contains the class definition for ZeroLengthContact2D.
 
@@ -72,7 +72,7 @@
   References:
 
 [1] P. Wriggers, V.T. Vu and E. Stein, Finite-element formulation of large deformation
-    impact–contact problems with friction, Comput. Struct. 37 (1990), pp. 319–331.
+    impactï¿½contact problems with friction, Comput. Struct. 37 (1990), pp. 319ï¿½331.
 [2] Peter Wriggers. Computational Contact Mechanics. John Wiley & Sons Ltd. Chichester, 2002.
 
 

--- a/SRC/element/zeroLength/ZeroLengthND.cpp
+++ b/SRC/element/zeroLength/ZeroLengthND.cpp
@@ -932,7 +932,7 @@ ZeroLengthND::setUp(int Nd1, int Nd2, const Vector &x, const Vector &yp)
 		opserr << "ZeroLengthND -- incorrect dimension of orientation vectors\n";
 	exit(-1);
 	}
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     static Vector z(3);
     z(0) = x(1)*yp(2) - x(2)*yp(1);

--- a/SRC/element/zeroLength/ZeroLengthND.h
+++ b/SRC/element/zeroLength/ZeroLengthND.h
@@ -74,7 +74,7 @@ class ZeroLengthND : public Element
     ZeroLengthND();    
     ~ZeroLengthND();
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/zeroLength/ZeroLengthRocking.cpp
+++ b/SRC/element/zeroLength/ZeroLengthRocking.cpp
@@ -111,7 +111,7 @@ void* OPS_ZeroLengthRocking()
 	numdata = 1;
         if (strcmp(flag,"-orient") == 0) {
             if (OPS_GetNumRemainingInputArgs() < 6) {
-                opserr << "WARNING not enough paramaters after -orient flag for ele " << eleTag <<
+                opserr << "WARNING not enough parameters after -orient flag for ele " << eleTag <<
 		    "- element ZeroLengthRocking eleTag? iNode? jNode? " <<
 		    "kr? radius? theta0? kappa? <-orient x1? x2? x3? y1? y2? y3?>\n";	      
                 return 0;
@@ -145,7 +145,7 @@ void* OPS_ZeroLengthRocking()
             
         } else if (strcmp(flag,"-xi") == 0) {
             if (OPS_GetNumRemainingInputArgs() < 1) {
-                opserr << "WARNING not enough paramaters after -xi flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -xi flag for ele " << eleTag << endln;
                 return 0;
             } else {
 		if (OPS_GetDoubleInput(&numdata, &xi) < 0) {
@@ -156,7 +156,7 @@ void* OPS_ZeroLengthRocking()
             
         } else if (strcmp(flag,"-dTol") == 0) {
             if (OPS_GetNumRemainingInputArgs() < 1) {
-                opserr << "WARNING not enough paramaters after -dTol flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -dTol flag for ele " << eleTag << endln;
                 return 0;
             } else {
 		if (OPS_GetDoubleInput(&numdata, &dTol) < 0) {
@@ -167,7 +167,7 @@ void* OPS_ZeroLengthRocking()
 
         } else if (strcmp(flag,"-vTol") == 0) {
             if (OPS_GetNumRemainingInputArgs() < 1) {
-                opserr << "WARNING not enough paramaters after -vTol flag for ele " << eleTag << endln;
+                opserr << "WARNING not enough parameters after -vTol flag for ele " << eleTag << endln;
                 return 0;
             } else {
 		if (OPS_GetDoubleInput(&numdata, &vTol) < 0) {
@@ -875,7 +875,7 @@ ZeroLengthRocking::setUp( int Nd1, int Nd2,
     if ( x.Size() != 3 || yp.Size() != 3 )
 	opserr << "FATAL ZeroLengthRocking::setUp - incorrect dimension of orientation vectors\n";
 
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     Vector z(3);
     z(0) = x(1)*yp(2) - x(2)*yp(1);

--- a/SRC/element/zeroLength/ZeroLengthRocking.h
+++ b/SRC/element/zeroLength/ZeroLengthRocking.h
@@ -70,7 +70,7 @@ class ZeroLengthRocking : public Element
 
     const char *getClassType(void) const {return "ZeroLengthRocking";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/zeroLength/ZeroLengthSection.cpp
+++ b/SRC/element/zeroLength/ZeroLengthSection.cpp
@@ -699,7 +699,7 @@ ZeroLengthSection::setUp(int Nd1, int Nd2, const Vector &x, const Vector &yp)
       opserr << "ZeroLengthSection::setUp -- incorrect dimension of orientation vectors\n";
 			
 
-    // establish orientation of element for the tranformation matrix
+    // establish orientation of element for the transformation matrix
     // z = x cross yp
     static Vector z(3);
     z(0) = x(1)*yp(2) - x(2)*yp(1);

--- a/SRC/element/zeroLength/ZeroLengthSection.h
+++ b/SRC/element/zeroLength/ZeroLengthSection.h
@@ -61,7 +61,7 @@ class ZeroLengthSection : public Element
 
     const char *getClassType(void) const {return "ZeroLengthSection";};
 
-    // public methods to obtain inforrmation about dof & connectivity    
+    // public methods to obtain information about dof & connectivity    
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/SRC/element/zeroLength/ZeroLengthSection.tex
+++ b/SRC/element/zeroLength/ZeroLengthSection.tex
@@ -40,7 +40,7 @@ and {\em x}.
 \indent {\em    ZeroLengthSection();} \\ \\
 \indent // Destructor \\
 \indent {\em    ~ZeroLengthSection();} \\ \\
-\indent    // public methods to obtain inforrmation about dof \& connectivity \\
+\indent    // public methods to obtain information about dof \& connectivity \\
 \indent {\em    int getNumExternalNodes(void) const;} \\
 \indent {\em    const ID \&getExternalNodes(void);} \\
 \indent {\em    int getNumDOF(void);} \\	
@@ -122,7 +122,7 @@ nodal displacements and section deformations.
 \\
 
 \indent {\em    int commitState(void);} \\
-Commit state of element by commiting state of the section.
+Commit state of element by committing state of the section.
 Return 0 if successful, !0 otherwise.
 \\
 
@@ -132,7 +132,7 @@ Return 0 if successful, !0 otherwise.
 \\
 
 \indent {\em    int revertToStart(void);} \\        
-Revert state of element to initial sate by reverting to initial state of the section.
+Revert state of element to initial state by reverting to initial state of the section.
 Return 0 if successful, !0 otherwise.
 \\
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../opensees-word-whitelist.txt --skip="./OTHER"