### PR TITLE
Typo fixes for EXAMPLES/

### DIFF
--- a/EXAMPLES/DatastarExamples/README
+++ b/EXAMPLES/DatastarExamples/README
@@ -16,4 +16,4 @@ The examples in this directory can be run interactivily or or as batch jobs.
 
       llsubmit submit1
 
-for further infomation of how to run files on datastar, i suggest you read the on-line documentation.
+For further information of how to run files on datastar, I suggest you read the online documentation.

--- a/EXAMPLES/ExamplePython/Example2.1.py
+++ b/EXAMPLES/ExamplePython/Example2.1.py
@@ -50,7 +50,7 @@ ops.uniaxialMaterial("Steel01", 3, fy, E, 0.01)
 
 # Define cross-section for nonlinear columns
 # ------------------------------------------
-# set some paramaters
+# set some parameters
 colWidth = 15.0
 colDepth = 24.0 
 cover = 1.5

--- a/EXAMPLES/ExamplePython/Example3.1.py
+++ b/EXAMPLES/ExamplePython/Example3.1.py
@@ -66,7 +66,7 @@ ops.uniaxialMaterial("Steel01", 3, fy, E, 0.01)
 
 # Define cross-section for nonlinear columns
 # ------------------------------------------
-# set some paramaters
+# set some parameters
 colWidth = 15.0
 colDepth = 24.0 
 cover = 1.5
@@ -104,7 +104,7 @@ eleType = "forceBeamColumn"
 ops.element(eleType, 1, 1, 3, 1, 1)
 ops.element(eleType, 2, 2, 4, 1, 1)
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 # Geometry of column elements
 #                tag 

--- a/EXAMPLES/ExamplePython/Example3.2.py
+++ b/EXAMPLES/ExamplePython/Example3.2.py
@@ -67,7 +67,7 @@ ops.uniaxialMaterial("Steel01", 3, fy, E, 0.01)
 
 # Define cross-section for nonlinear columns
 # ------------------------------------------
-# set some paramaters
+# set some parameters
 colWidth = 15.0
 colDepth = 24.0 
 cover = 1.5
@@ -105,7 +105,7 @@ eleType = "forceBeamColumn"
 ops.element(eleType, 1, 1, 3, 1, 1)
 ops.element(eleType, 2, 2, 4, 1, 1)
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 # Geometry of column elements
 #                tag 
@@ -272,7 +272,7 @@ if (ok != 0):
 
         currentDisp = ops.nodeDisp(3, 1)
         
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if (ok == 0):
     print("\nPushover analysis completed SUCCESSFULLY\n")
 else:

--- a/EXAMPLES/ExamplePython/Example3.3.py
+++ b/EXAMPLES/ExamplePython/Example3.3.py
@@ -11,7 +11,7 @@
 # 
 # Example Objectives
 # -----------------
-#  Nonlinear dynamic analyis using Portal Frame Example 1 as staring point
+#  Nonlinear dynamic analysis using Portal Frame Example 1 as staring point
 #  Using Tcl Procedures 
 #
 # 
@@ -70,7 +70,7 @@ ops.uniaxialMaterial("Steel01", 3, fy, E, 0.01)
 
 # Define cross-section for nonlinear columns
 # ------------------------------------------
-# set some paramaters
+# set some parameters
 colWidth = 15.0
 colDepth = 24.0 
 cover = 1.5
@@ -108,7 +108,7 @@ eleType = "forceBeamColumn"
 ops.element(eleType, 1, 1, 3, 1, 1)
 ops.element(eleType, 2, 2, 4, 1, 1)
 
-# Define beam elment
+# Define beam element
 # ------------------
 # Geometric transformation for beams
 #                tag 
@@ -306,7 +306,7 @@ while ((ok == 0) and (tCurrent < tFinal)):
     
     tCurrent = ops.getTime()
 
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if (ok == 0):
     print("\nTransient analysis completed SUCCESSFULLY\n")
 else:

--- a/EXAMPLES/ExamplePython/Example4.1.py
+++ b/EXAMPLES/ExamplePython/Example4.1.py
@@ -310,7 +310,7 @@ while ((ok == 0) and (controlDisp < maxU)):
         ops.test("NormDispIncr", 1.0e-8, 10, 0)
         ops.algorithm("Newton")
 
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if (ok == 0):
     print("\nPushover analysis completed SUCCESSFULLY\n")
 else:

--- a/EXAMPLES/ExamplePython/Example5.1.py
+++ b/EXAMPLES/ExamplePython/Example5.1.py
@@ -301,6 +301,6 @@ ok = ops.analyze(2000, 0.01)
 if (ok != 0):
     print("analysis FAILED")
 else:
-    print("analysis SUCCESSFULL")
+    print("analysis SUCCESSFUL")
 
 ops.wipe()

--- a/EXAMPLES/ExamplePython/MomentCurvature.py
+++ b/EXAMPLES/ExamplePython/MomentCurvature.py
@@ -1,6 +1,6 @@
 # A procedure for performing section analysis (only does
 # moment-curvature, but can be easily modified to do any mode
-# of section reponse.
+# of section response.
 #
 # Written: Andreas Schellenberg (andreas.schellenberg@gmail.com)
 # Date: June 2017

--- a/EXAMPLES/ExampleScripts/ArcLength01.tcl
+++ b/EXAMPLES/ExampleScripts/ArcLength01.tcl
@@ -66,7 +66,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.001
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -114,7 +114,7 @@ set eleType forceBeamColumn
 element $eleType  1   1   3   $np    1       1 
 element $eleType  2   2   4   $np    1       1 
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements

--- a/EXAMPLES/ExampleScripts/Cube_tcl/README
+++ b/EXAMPLES/ExampleScripts/Cube_tcl/README
@@ -52,7 +52,7 @@ shear are all disabled.
 It  should  be  noted  that by default, all these commands will
 render  results  at  step  0,  which  is  the  end  of applying
 isotropic  compression and the start of shearing. The displaced
-mesh only shows displacements occured during shearing stage. To
+mesh only shows displacements occurred during shearing stage. To
 show  the  total  displacement,  one  needs to activate [Sett.]
 button  inside  "Lights and other options" category which is at
 the top of the right window.
@@ -65,7 +65,7 @@ be  -1.  To adjust the animation speed, one can use the spinner
 To  change  the  view  angle, one simple way is to select among
 [XY],  [YZ]  and [XZ] views. One can also use mouse to drag the
 plot  in  order  to  view  at any angle. Specifically, dragging
-mouse  horzontally at the center region of the left window will
+mouse  horizontally at the center region of the left window will
 rotate the plot along Y-axis, dragging vertically at the center
 region  of  the  left  window  will  rotate  along  X-axis, and
 dragging  vertically  at the area close to the window sides but

--- a/EXAMPLES/ExampleScripts/DynamicShell.tcl
+++ b/EXAMPLES/ExampleScripts/DynamicShell.tcl
@@ -72,7 +72,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     set tCurrent [getTime]
 }
 
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if {$ok == 0} {
    puts "Transient analysis completed SUCCESSFULLY";
 } else {

--- a/EXAMPLES/ExampleScripts/DynamicShell2.tcl
+++ b/EXAMPLES/ExampleScripts/DynamicShell2.tcl
@@ -75,7 +75,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     set tCurrent [getTime]
 }
 
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if {$ok == 0} {
    puts "Transient analysis completed SUCCESSFULLY";
 } else {

--- a/EXAMPLES/ExampleScripts/Example2.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example2.1.tcl
@@ -21,7 +21,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 

--- a/EXAMPLES/ExampleScripts/Example3.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example3.1.tcl
@@ -72,7 +72,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -123,7 +123,7 @@ element $eleType  6   4   6   $np    1       1
 element $eleType  8   5   7   $np    1       1 
 element $eleType  9   6   8   $np    1       1 
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements

--- a/EXAMPLES/ExampleScripts/Example3.3.tcl
+++ b/EXAMPLES/ExampleScripts/Example3.3.tcl
@@ -11,7 +11,7 @@
 # 
 # Example Objectives
 # -----------------
-#  Nonlinear dynamic analyis using Portal Frame Example 1 as staring point
+#  Nonlinear dynamic analysis using Portal Frame Example 1 as staring point
 #  Using Tcl Procedures 
 #
 # 
@@ -164,7 +164,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     set tCurrent [getTime]
 }
 
-# Print a message to indicate if analysis succesfull or not
+# Print a message to indicate if analysis successful or not
 if {$ok == 0} {
    puts "Transient analysis completed SUCCESSFULLY";
 } else {

--- a/EXAMPLES/ExampleScripts/Example5.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example5.1.tcl
@@ -270,7 +270,7 @@ set ok [analyze   2000   0.01]
 if {$ok != 0} {
     puts "analysis FAILED"
 } else {
-    puts "analysis SUCCESSFULL"
+    puts "analysis SUCCESSFUL"
 }
 
 wipe

--- a/EXAMPLES/ExampleScripts/MomentCurvature.tcl
+++ b/EXAMPLES/ExampleScripts/MomentCurvature.tcl
@@ -1,6 +1,6 @@
 # A procedure for performing section analysis (only does
 # moment-curvature, but can be easily modified to do any mode
-# of section reponse.
+# of section response.
 #
 # MHS
 # October 2000

--- a/EXAMPLES/ExampleScripts/RCFrame1.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrame1.tcl
@@ -212,7 +212,7 @@ while {$ok == 0 && $currentDisp < $maxU} {
 }
 
 if {$ok == 0} {
-   puts "analysis SUCCESSFULL";
+   puts "analysis SUCCESSFUL";
 } else {
    puts "analysis FAILED";    
 }

--- a/EXAMPLES/ExampleScripts/RCFrame4.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrame4.tcl
@@ -181,7 +181,7 @@ eigen 4
 # create the analysis object
 analysis Transient
 
-#type "Starting Tansient Analysis .. hang on"
+#type "Starting Transient Analysis .. hang on"
 
 #        numSteps   dt
 analyze    1000    0.01

--- a/EXAMPLES/ExampleScripts/RCFrame5.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrame5.tcl
@@ -46,7 +46,7 @@ set period 2.5;
 set mag 5.0;
 set w [expr 2.0 * $PI / $period]
 
-#inital velocity condition for uniform exciation = -udotg
+#initial velocity condition for uniform excitation = -udotg
 set vel0 [expr -1.0 * $mag * $w]
 
 # ground motion 
@@ -207,7 +207,7 @@ eigen 4
 # create the analysis object
 analysis Transient
 
-#type "Starting Tansient Analysis .. hang on"
+#type "Starting Transient Analysis .. hang on"
 
 
 #        numSteps   dt

--- a/EXAMPLES/ExampleScripts/RCFrameDisplay.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrameDisplay.tcl
@@ -1,7 +1,7 @@
 # a window showing the displaced shape
 recorder display g3 10 10 300 300 -wipe
 
-# next three commmands define viewing system, all values in global coords
+# next three commands define viewing system, all values in global coords
 vrp 288.0 150.0 0    # point on the view plane in global coord, center of local viewing system
 vup 0 1 0            # dirn defining up direction of view plane
 vpn 0 0 1            # direction of outward normal to view plane

--- a/EXAMPLES/ExampleScripts/Rigid.tcl
+++ b/EXAMPLES/ExampleScripts/Rigid.tcl
@@ -59,7 +59,7 @@ foreach rigidConstraint {no yes} {
 	    # Define cross-section for nonlinear columns
 	    # ------------------------------------------
 	    
-	    # set some paramaters
+	    # set some parameters
 	    set colWidth 15
 	    set colDepth 24 
 	    

--- a/EXAMPLES/ExamplesForTesting/MY0a.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0a.ops
@@ -164,7 +164,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -177,7 +177,7 @@ analysis Static
 #analyze the structure
 analyze $numAnalysisSteps
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MY0b.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0b.ops
@@ -164,7 +164,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -177,7 +177,7 @@ analysis Static
 #analyze the structure
 analyze $numAnalysisSteps
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MY0c.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0c.ops
@@ -164,7 +164,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -177,7 +177,7 @@ analysis Static
 #analyze the structure
 analyze $numAnalysisSteps
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MY1a.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1a.ops
@@ -174,7 +174,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -199,7 +199,7 @@ analyze $numSteps $deltaT [expr $deltaT/64] $deltaT 5
 set endT [clock seconds]
 puts "Execution time: [expr $endT-$startT] seconds."
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MY1b.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1b.ops
@@ -174,7 +174,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -199,7 +199,7 @@ analyze $numSteps $deltaT [expr $deltaT/64] $deltaT 5
 set endT [clock seconds]
 puts "Execution time: [expr $endT-$startT] seconds."
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MY1c.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1c.ops
@@ -174,7 +174,7 @@ recorder Element 1 -time -file stress3 material 3 stress
 recorder Element 1 -time -file strain3 material 3 strain
 recorder Element 1 -time -file stress4 material 4 stress
 recorder Element 1 -time -file strain4 material 4 strain
-if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure ouput
+if { $matOpt == 2 || $matOpt == 3 } {   ;#excess pore pressure output
   recorder Element 1 -time -file press1 material 1 pressure
   recorder Element 1 -time -file press2 material 2 pressure
   recorder Element 1 -time -file press3 material 3 pressure
@@ -199,7 +199,7 @@ analyze $numSteps $deltaT [expr $deltaT/64] $deltaT 5
 set endT [clock seconds]
 puts "Execution time: [expr $endT-$startT] seconds."
 
-wipe  #flush ouput stream
+wipe  #flush output stream
 
 
 

--- a/EXAMPLES/ExamplesForTesting/MomentCurvature.ops
+++ b/EXAMPLES/ExamplesForTesting/MomentCurvature.ops
@@ -1,6 +1,6 @@
 # A procedure for performing section analysis (only does
 # moment-curvature, but can be easily modified to do any mode
-# of section reponse.
+# of section response.
 #
 # MHS
 # October 2000

--- a/EXAMPLES/ExamplesForTesting/README.NOW
+++ b/EXAMPLES/ExamplesForTesting/README.NOW
@@ -1,4 +1,4 @@
-This directory containes input files used during testing of OpenSees. Do not
+This directory contains input files used during testing of OpenSees. Do not
 edit or commit new files here before you have emailed Frank
 (fmk@ce.berkeley.edu) or Boris (jeremic@ucdavis.edu).
 

--- a/EXAMPLES/ExamplesForTesting/Test.20node_upU_1elementfix.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.20node_upU_1elementfix.ops
@@ -56,7 +56,7 @@ node 20 1.0 0.0 1.0
 # Boundary conditions. 
 # Each node has seven DOF. Three for solid displacement, three for 
 # fluid displacement, and one for pore pressure. The displacement
-# at the bottom of the element is fixed, and coresponding pore pressure 
+# at the bottom of the element is fixed, and corresponding pore pressure 
 # should be added.
 # ####################################################################
 #

--- a/EXAMPLES/ExamplesForTesting/Test.Example2.1.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example2.1.ops
@@ -21,7 +21,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.1.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.1.ops
@@ -65,7 +65,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -110,7 +110,7 @@ set np 5
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.2.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.2.ops
@@ -74,7 +74,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -119,7 +119,7 @@ set np 5
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.3.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.3.ops
@@ -11,7 +11,7 @@
 # 
 # Example Objectives
 # -----------------
-#  Nonlinear dynamic analyis using Portal Frame Example 1 as staring point
+#  Nonlinear dynamic analysis using Portal Frame Example 1 as staring point
 #  Using Tcl Procedures 
 #
 # 
@@ -73,7 +73,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -118,7 +118,7 @@ set np 5
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements
@@ -349,7 +349,7 @@ if {$ok != 0} {
 }
 
 if {$ok == 0} {
-   puts "Transient analysis completed succesfully";
+   puts "Transient analysis completed successfully";
 } else {
    puts "Transient analysis completed failed";    
 }

--- a/EXAMPLES/ExamplesForTesting/Test.MomentCurvature.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.MomentCurvature.ops
@@ -1,6 +1,6 @@
 # A procedure for performing section analysis (only does
 # moment-curvature, but can be easily modified to do any mode
-# of section reponse.
+# of section response.
 #
 # MHS
 # October 2000

--- a/EXAMPLES/ExamplesForTesting/Test.RCFrame5.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.RCFrame5.ops
@@ -46,7 +46,7 @@ set period 2.5;
 set mag 5.0;
 set w [expr 2.0 * $PI / $period]
 
-#inital velocity condition for uniform exciation = -udotg
+#initial velocity condition for uniform excitation = -udotg
 set vel0 [expr -1.0 * $mag * $w]
 
 # ground motion 
@@ -205,7 +205,7 @@ eigen 4
 # create the analysis object
 analysis Transient
 
-#type "Starting Tansient Analysis .. hang on"
+#type "Starting Transient Analysis .. hang on"
 
 
 #        numSteps   dt

--- a/EXAMPLES/ExamplesForTesting/Test.RCFrameDisplay.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.RCFrameDisplay.ops
@@ -1,7 +1,7 @@
 # a window showing the displaced shape
 #recorder display g3 10 10 300 300 -wipe
 
-# next three commmands define viewing system, all values in global coords
+# next three commands define viewing system, all values in global coords
 vrp 288.0 150.0 0    # point on the view plane in global coord, center of local viewing system
 vup 0 1 0            # dirn defining up direction of view plane
 vpn 0 0 1            # direction of outward normal to view plane

--- a/EXAMPLES/Makefile
+++ b/EXAMPLES/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.def
 
-# the example dircetories that 
+# the example directories that 
 
 EXAMPLE1 = $(FE)/../EXAMPLES/Example1
 PLANE_FRAME = $(FE)/../EXAMPLES/PlaneFrame

--- a/EXAMPLES/MaterialModels/MediumClayEPmodelVM.tcl
+++ b/EXAMPLES/MaterialModels/MediumClayEPmodelVM.tcl
@@ -3,7 +3,7 @@
 # rho = 1.5 ton/m^3 
 # Young's modulus = 169200 kpa, 
 # Possion Ratio = 0.406, 
-# shear strenght k (=f(Cu)) = 37kpa  
+# shear strength k (=f(Cu)) = 37kpa  
 
 # Aug. 12, 2002  Feng Xiong
 # 														 Boris Jeremic (@ucdavis.edu)

--- a/EXAMPLES/MaterialModels/SteelEPmodelVM.tcl
+++ b/EXAMPLES/MaterialModels/SteelEPmodelVM.tcl
@@ -3,7 +3,7 @@
 # rho = 1.7 ton/m^3
 # Young's modulus = 210000 kpa, 
 # Possion ratio = 0.28 
-# shear strenght k (=f(Cu)) = 20kpa  
+# shear strength k (=f(Cu)) = 20kpa  
 
 # Aug. 12, 2002  Feng Xiong
 # 														 Boris Jeremic (@ucdavis.edu)

--- a/EXAMPLES/README
+++ b/EXAMPLES/README
@@ -25,8 +25,8 @@ The example subdirectories include:
 			procedure
                 RCFrameDisplay.tcl - commands for opening a window
 	                used to display the RCFrame1-5 examples
-	        RigidFrame3D.tcl - a nonlinear EQ analysis of a 3d fframe
-                        with elastic columns and nonlinear beams with rigid 
+	        RigidFrame3D.tcl - a nonlinear EQ analysis of a 3d frame
+                        with elastic columns and nonlinear beams with rigid
                         diaphragm constraints
 		genPlaneFrame.tcl - defines node and element generating
 			TCL procedure
@@ -44,20 +44,19 @@ The example subdirectories include:
 
 
         TclModelBuilder: contains the files outlined in the document
-		'Adding an Element to g3'. 
+		'Adding an Element to g3'.
 
                 myG3 - an executable.
                 myCommands.C - contains procedure for adding new commands to g3
                 TclPlaneTruss.h/.C - an example of a tcl model builder
                 MyTruss.h/.C - files to add the new truss member
 		example1.tcl, example2.tcl - the two tcl scripts
-		     presented in the cocument 'Adding an Element to g3'
+		     presented in the document 'Adding an Element to g3'
 
-		examples - a dircetory containg some more scripts
+		examples - a directory containing some more scripts
 
                 to load a script in the running interpreter type
                     source testX.tcl
-                
-                typing 'make' builds the executable myG3
-                typing 'make wipe' remove myG3 and .o files  
 
+                typing 'make' builds the executable myG3
+                typing 'make wipe' remove myG3 and .o files

--- a/EXAMPLES/ShadowTruss/ActorTruss.cpp
+++ b/EXAMPLES/ShadowTruss/ActorTruss.cpp
@@ -152,7 +152,7 @@ ActorTruss::setDomain(void)
     static Vector coords(4);
     this->recvVector(coords);
 
-    // determin transformation & length
+    // determine transformation & length
     double dx = coords(2)-coords(0);
     double dy = coords(3)-coords(1);
     

--- a/EXAMPLES/ShadowTruss/ShadowTruss.cpp
+++ b/EXAMPLES/ShadowTruss/ShadowTruss.cpp
@@ -317,7 +317,7 @@ ShadowTruss::addInertiaLoadToUnbalance(const Vector &accel)
 #ifdef _G3DEBUG    
   if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
     opserr <<"Truss::addInertiaLoadToUnbalance " <<
-      "matrix and vector sizes are incompatable\n";
+      "matrix and vector sizes are incompatible\n";
     return -1;
   }
 #endif
@@ -366,7 +366,7 @@ ShadowTruss::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theB
 int
 ShadowTruss::displaySelf(Renderer &theViewer, int displayMode, float fact)
 {
-    // check setDomain() was successfull
+    // check setDomain() was successful
     if (L == 0.0)
        return 0;
 

--- a/EXAMPLES/ShadowTruss/ShadowTruss.h
+++ b/EXAMPLES/ShadowTruss/ShadowTruss.h
@@ -59,7 +59,7 @@ class ShadowTruss : public Element, public Shadow
     // destructor
     ~ShadowTruss();
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/EXAMPLES/TclPlaneTruss/MyTruss.cpp
+++ b/EXAMPLES/TclPlaneTruss/MyTruss.cpp
@@ -320,7 +320,7 @@ MyTruss::addInertiaLoadToUnbalance(const Vector &accel)
 #ifdef _G3DEBUG    
   if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
     opserr <<"Truss::addInertiaLoadToUnbalance " <<
-      "matrix and vector sizes are incompatable\n";
+      "matrix and vector sizes are incompatible\n";
     return -1;
   }
 #endif
@@ -465,7 +465,7 @@ MyTruss::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroke
 int
 MyTruss::displaySelf(Renderer &theViewer, int displayMode, float fact)
 {
-    // check setDomain() was successfull
+    // check setDomain() was successful
     if (L == 0.0)
        return 0;
 

--- a/EXAMPLES/TclPlaneTruss/MyTruss.h
+++ b/EXAMPLES/TclPlaneTruss/MyTruss.h
@@ -62,7 +62,7 @@ class MyTruss : public Element
     // destructor
     ~MyTruss();
     
-    // public methods to obtain inforrmation about dof & connectivity
+    // public methods to obtain information about dof & connectivity
     int getNumExternalNodes(void) const;
     const ID &getExternalNodes(void);
     Node **getNodePtrs(void);

--- a/EXAMPLES/TclPlaneTruss/TclPlaneTruss.cpp
+++ b/EXAMPLES/TclPlaneTruss/TclPlaneTruss.cpp
@@ -28,7 +28,7 @@
 //
 // Description: This file contains the class implementation for TclPlaneTruss
 // TclPlaneTruss is a class for building a Plane Frame model in an interpreted
-// enviroment. The constructor is used to add new commands to the interpreter,
+// environment. The constructor is used to add new commands to the interpreter,
 // these commands are also defined in this file.
 //
 // What: "@(#) TclPlaneTruss.C, revA"
@@ -254,7 +254,7 @@ TclPlaneTruss_addNode(ClientData clientData, Tcl_Interp *interp, int argc,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 
@@ -318,7 +318,7 @@ TclPlaneTruss_addTruss(ClientData clientData, Tcl_Interp *interp, int argc,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 
@@ -387,7 +387,7 @@ TclPlaneTruss_addMyTruss(ClientData clientData, Tcl_Interp *interp, int argc,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 
@@ -451,7 +451,7 @@ TclPlaneTruss_addfTruss(ClientData clientData, Tcl_Interp *interp, int argc,
     return TCL_ERROR;
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 
@@ -633,7 +633,7 @@ TclPlaneTruss_addSP(ClientData clientData, Tcl_Interp *interp, int argc,
     }
   }
 
-  // if get here we have sucessfully created the node and added it to the domain
+  // if get here we have successfully created the node and added it to the domain
   return TCL_OK;
 }
 
@@ -726,7 +726,7 @@ TclPlaneTruss_addNodalLd(ClientData clientData, Tcl_Interp *interp, int argc,
     return TCL_ERROR;
   }  
   
-  // if get here we have sucessfully created the node and added it 
+  // if get here we have successfully created the node and added it 
   return TCL_OK;
 }
 

--- a/EXAMPLES/TeraGridExamples/README
+++ b/EXAMPLES/TeraGridExamples/README
@@ -2,12 +2,11 @@
 
 The examples in this directory can be as batch jobs on TeraGrid. To
 run a job you need to login to tg-login.teragrid.org and you need
-   to submit your job from the command line using qsub and the submit files provided. 
+   to submit your job from the command line using qsub and the submit files provided.
    For example to run Example1.tcl you need to:
      a)  edit submit1 (replacing the path to OpenSees and the location of the TeraGridExamples directory).
-     b)  at the command line prompt type: 
+     b)  at the command line prompt type:
 
       qsub submit1
 
-For further infomation of how to run files on TeraGrid, i suggest you read the on-line documentation.
-
+For further information of how to run files on TeraGrid, I suggest you read the online documentation.

--- a/EXAMPLES/verification/NewmarkIntegrator.tcl
+++ b/EXAMPLES/verification/NewmarkIntegrator.tcl
@@ -25,7 +25,7 @@ set integratorCmds {"Newmark Average Acceleration" "integrator Newmark 0.5 0.25"
 
 # procedure to build a linear model
 #   input args: K - desired stiffness
-#               periodStruct - desired structre period (used to compute mass)
+#               periodStruct - desired structure period (used to compute mass)
 #               dampRatio (zeta) - desired damping ratio
 proc buildModel {k m dampRatio yieldDisp} {
 

--- a/EXAMPLES/verification/PortalFrame2d.tcl
+++ b/EXAMPLES/verification/PortalFrame2d.tcl
@@ -170,7 +170,7 @@ analyze 1
 set ok 0
 
 #
-# print pretty output of comparsions
+# print pretty output of comparisons
 #
 
 #               SAP2000   SeismoStruct

--- a/EXAMPLES/verification/SmallEigen.tcl
+++ b/EXAMPLES/verification/SmallEigen.tcl
@@ -11,14 +11,14 @@
 # M=[[11.1 0 0];[0 22.2 0];[0 0 33.3]]
 # eig(K,M)
 
-puts "SmallEigen.tcl: Small 3 dof 2 spring model: checking eigen results of smallest and larget values"
-puts "  using masses defined through node and mass command, results compared for eaxct against Matlab\n"
+puts "SmallEigen.tcl: Small 3 dof 2 spring model: checking eigen results of smallest and largest values"
+puts "  using masses defined through node and mass command, results compared for exact against Matlab\n"
 
 set exactResults {0.139300647653736 1.05865310768512  4.9582024008173}
 
 wipe
 model Basic -ndm 1 -ndf 1
-node 1 0 
+node 1 0
 node 2 0 -mass 11.1
 node 3 0 -mass 22.2
 node 4 0 -mass 33.3
@@ -73,10 +73,10 @@ for {set i 0} {$i<$numEigen} {incr i 1} {
 wipe
 wipe
 model Basic -ndm 1 -ndf 1
-node 1 0 
-node 2 0 
-node 3 0 
-node 4 0 
+node 1 0
+node 2 0
+node 3 0
+node 4 0
 uniaxialMaterial Elastic 1 30
 uniaxialMaterial Elastic 2 20
 uniaxialMaterial Elastic 3 10

--- a/EXAMPLES/verification/sdofTransient.tcl
+++ b/EXAMPLES/verification/sdofTransient.tcl
@@ -18,7 +18,7 @@ set tol 1.0e-2
 
 # procedure to build a linear model
 #   input args: K - desired stiffness
-#               periodStruct - desired structre period (used to compute mass)
+#               periodStruct - desired structure period (used to compute mass)
 #               dampRatio (zeta) - desired damping ratio
 
 proc buildModel {K periodStruct dampRatio} {


### PR DESCRIPTION
Found via `codespell -q 3 -I ../opensees-word-whitelist.txt --skip="./OTHER"