### PR TITLE
add OPS_updateMaterialStage command in APIs

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -177,6 +177,7 @@ int OPS_LimitCurve();
 
 /* OpenSeesNDMaterialCommands.cpp */
 int OPS_NDMaterial();
+int OPS_updateMaterialStage();
 
 /* OpenSeesFrictionModelCommands.cpp */
 int OPS_FrictionModel();

--- a/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
@@ -1,9 +1,13 @@
-                                                                        
+
 // Description: command to create nD material
 
 #include <NDMaterial.h>
 #include <elementAPI.h>
 #include <map>
+#include <MatParameter.h>
+#include <string.h>
+#include <Domain.h>
+
 
 void* OPS_ElasticIsotropicMaterial();
 void* OPS_PlateFiberMaterial();
@@ -56,11 +60,11 @@ void* OPS_PM4Sand();
 
 namespace {
 
-    struct char_cmp { 
-	bool operator () (const char *a,const char *b) const 
+    struct char_cmp {
+	bool operator () (const char *a,const char *b) const
 	    {
 		return strcmp(a,b)<0;
-	    } 
+	    }
     };
 
     typedef std::map<const char *, void *(*)(void), char_cmp> OPS_ParsingFunctionMap;
@@ -143,7 +147,7 @@ namespace {
 	nDMaterialsMap.insert(std::make_pair("BeamFiberMaterial", &OPS_BeamFiberMaterial));
 	nDMaterialsMap.insert(std::make_pair("BeamFiber", &OPS_BeamFiberMaterial));
 	nDMaterialsMap.insert(std::make_pair("PM4Sand", &OPS_BeamFiberMaterial));
-	
+
 	return 0;
     }
 }
@@ -163,7 +167,7 @@ OPS_NDMaterial()
     }
 
     const char* matType = OPS_GetString();
-    
+
     OPS_ParsingFunctionMap::const_iterator iter = nDMaterialsMap.find(matType);
     if (iter == nDMaterialsMap.end()) {
 	opserr<<"WARNING material type " << matType << " is unknown\n";
@@ -184,4 +188,73 @@ OPS_NDMaterial()
 
     return 0;
 
+}
+
+int
+OPS_updateMaterialStage()
+{
+
+    if (OPS_GetNumRemainingInputArgs() < 4) {
+	opserr << "WARNING insufficient number of UpdateMaterialStage arguments\n";
+	opserr << "Want: updateMaterialStage -material matTag? -stage value? -parameter paramTag?\n";
+	return -1;
+    }
+
+    const char* opt1 = OPS_GetString();
+    if (strcmp(opt1,"-material") != 0) {
+	opserr << "WARNING updateMaterialStage: Only accept parameter '-material' for now\n";
+	return -1;
+    }
+
+    int materialTag;
+    int numdata = 1;
+
+    if (OPS_GetIntInput(&numdata, &materialTag) < 0) {
+	opserr << "WARNING MYSstage: invalid material tag\n";
+	return -1;
+    }
+
+    const char* opt2 = OPS_GetString();
+    if (strcmp(opt2,"-stage") != 0) {
+	opserr << "WARNING updateMaterialStage: Only accept parameter '-stage' for now\n";
+	return -1;
+    }
+
+    int value;
+    double valueD;
+    int res = OPS_GetIntInput(&numdata, &value);
+    if (res < 0) {
+	res = OPS_GetDoubleInput(&numdata, &valueD);
+	if (res < 0) {
+	    opserr << "WARNING updateMaterialStage: could not read value\n";
+	    return -1;
+	}
+    }
+
+    Domain* theDomain = OPS_GetDomain();
+    int parTag = theDomain->getNumParameters();
+    parTag++;
+    if (OPS_GetNumRemainingInputArgs() > 1) {
+	const char* opt3 = OPS_GetString();
+	if (strcmp(opt3,"-parameter") == 0) {
+	    if (OPS_GetIntInput(&numdata, &parTag) < 0) {
+		opserr << "WARNING updateMaterialStage: invalid parameter tag\n";
+		return -1;
+	    }
+	}
+    }
+
+    MatParameter *theParameter = new MatParameter(parTag, materialTag, opt2);
+
+    if (theDomain->addParameter(theParameter) == false) {
+	opserr << "WARNING could not add updateMaterialStage - MaterialStageParameter to domain\n";
+	return -1;
+    }
+
+    if (res == 0) {
+	res = theDomain->updateParameter(parTag, valueD);
+	theDomain->removeParameter(parTag);
+    }
+
+    return res;
 }

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1469,6 +1469,15 @@ static PyObject *Py_ops_randomVariable(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_updateMaterialStage(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_updateMaterialStage() < 0) return NULL;
+
+    return wrapper->getResults();
+}
+
 /////////////////////////////////////////////////
 ////////////// Add Python commands //////////////
 /////////////////////////////////////////////////
@@ -1623,6 +1632,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("sensSectionForce", &Py_ops_sensSectionForce);
     addCommand("sensNodePressure", &Py_ops_sensNodePressure);
     addCommand("randomVariable", &Py_ops_randomVariable);
+    addCommand("updateMaterialStage", &Py_ops_updateMaterialStage);
 
     PyMethodDef method = {NULL,NULL,0,NULL};
     methodsOpenSees.push_back(method);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1284,6 +1284,15 @@ static int Tcl_ops_randomVariable(ClientData clientData, Tcl_Interp *interp, int
     return TCL_OK;
 }
 
+static int Tcl_ops_updateMaterialStage(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_updateMaterialStage() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 //////////////////////////////////////////////
 ////////////// Add Tcl commands //////////////
 //////////////////////////////////////////////
@@ -1438,4 +1447,5 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"sensSectionForce", &Tcl_ops_sensSectionForce);
     addCommand(interp,"sensNodePressure", &Tcl_ops_sensNodePressure);
     addCommand(interp,"randomVariable", &Tcl_ops_randomVariable);
+    addCommand(interp,"updateMaterialStage", &Tcl_ops_updateMaterialStage);
 }


### PR DESCRIPTION
Add OPS_updateMaterialStage command in APIs, and in Python and in Tcl through multi-interpreter interface. This command is used in geotechnical modeling to maintain elastic nDMaterial response during the application of gravity loads. The material is then updated to allow for plastic strains during additional static loads or earthquakes. 