### PR TITLE
Misc. source comment typo fixes in SRC/material/uniaxial

### DIFF
--- a/SRC/material/uniaxial/AxialSpHD.h
+++ b/SRC/material/uniaxial/AxialSpHD.h
@@ -90,16 +90,16 @@ class AxialSpHD : public UniaxialMaterial
   double bth;   // reduction rate after tensile hardening point (ratio to sce)
   double bcy;   // reduction rate after compressive yield point (ratio to sce, 0.0 <= bcy <= 1.0)
   double fcr;   // reversal point stress (fcy <= fcr <= 0.0)
-  double ath;   // tensile hardening point strain (ratio to tensile yeild strain, 1.0 <= ath)
+  double ath;   // tensile hardening point strain (ratio to tensile yield strain, 1.0 <= ath)
 
   // data for calculation
   double ste;   // tensile modulus
   double sty;   // tensile modulus after yield point
   double stp;
   double sth;   // tensile modulus after hardening point
-  double scy;   // compressive modulus after yeild point
-  double uty;   // tensile yeild strain
-  double ucy;   // compressive yeild strain
+  double scy;   // compressive modulus after yield point
+  double uty;   // tensile yield strain
+  double ucy;   // compressive yield strain
   double ucr;   // reversal point strain
   double utr;   // strain (related to reversal point)
   double ftr;   // stress (related to reversal point)

--- a/SRC/material/uniaxial/BWBN.h
+++ b/SRC/material/uniaxial/BWBN.h
@@ -65,7 +65,7 @@ class BWBN : public UniaxialMaterial
     double deltaShi;
     double lamda;
     
-    // History variables (trial and commited)
+    // History variables (trial and committed)
     double Tstrain, Cstrain;
     double Tz, Cz;
     double Te, Ce;

--- a/SRC/material/uniaxial/BarSlipMaterial.h
+++ b/SRC/material/uniaxial/BarSlipMaterial.h
@@ -27,7 +27,7 @@
 // Created: January 2002
 // Updated: September 2004
 //
-// Description: This file contains the class defination for 
+// Description: This file contains the class definition for 
 // bar-slip material. The file generates the 4 point envelope for both positive 
 // and negative loading and is basically a wrapper for the Pinching4 material at it's outset.
 // Updates: new damage calculations and user interfaces
@@ -106,7 +106,7 @@ private:
 	double fc;   // compressive strength of concrete
 	
 	// steel properties
-	double fy;    // yeild strength of steel
+	double fy;    // yield strength of steel
 	double Es;    // modulus of elasticity of steel
 	double fu;    // ultimate strength of steel
 	double Eh;    // modulus of hardening of steel
@@ -118,9 +118,9 @@ private:
 
 		// bond strengths
 	double tauET;  // bond strength of steel that is elastic and carries tensile load
-	double tauYT;  // bond strength of steel that has yeilded in tension
+	double tauYT;  // bond strength of steel that has yielded in tension
 	double tauEC;  // bond strength of steel that is elastic and carries compression load
-	double tauYC;  // bond strength of steel that has yeilded in compression
+	double tauYC;  // bond strength of steel that has yielded in compression
 	double tauR;   // residual bond strength of steel
 
 	// unloading-reloading parameters 
@@ -139,7 +139,7 @@ private:
 	Matrix eN;
 
 	//**************************************************************************
-	// Trial Set varables
+	// Trial Set variables
 	double Tstrain; double Ttangent; double Tstress;
 
 	// Converged Material History parameters

--- a/SRC/material/uniaxial/Bond_SP01.cpp
+++ b/SRC/material/uniaxial/Bond_SP01.cpp
@@ -27,7 +27,7 @@
 // Revision:		Jian Zhao, University of Wisconsin, Milwaukee 		04/2006
 // Revision:		Jian Zhao, University of Wisconsin, Milwaukee. Fixed the jump in the negative direction
 //
-// Description: This file contains the class defination for Uniaxial material Bond_SP01. 
+// Description: This file contains the class definition for Uniaxial material Bond_SP01. 
 // Bond_SP01: Strain penetration of fully anchored rebars w/o bond damage.
 
 
@@ -90,8 +90,8 @@ Bond_SP01::Bond_SP01
   
   
   // Set parameters for bar stress-slip envelope 
-  Cr = 1.01;						//% need to be large than 1 pretty arbitary
-  Ks = pow(R,Kz/2.5);		//% pretty arbitary
+  Cr = 1.01;						//% need to be large than 1 pretty arbitrary
+  Ks = pow(R,Kz/2.5);		//% pretty arbitrary
   slvrg = pow(12.0/30.0,1/0.4)*0.04;			//%the slip corresponding to the virgin friction in local bond-slip model
   
   // Assume symmetric envelope. This needs to be changed later because end-bearing participate when under compression
@@ -116,8 +116,8 @@ UniaxialMaterial(tag,MAT_TAG_Bond_SP01),
 
 	
 	// Set bar stress-slip envelope  (yield point)
-	Cr = 1.01;				//% need to be large than 1 pretty arbitary
-	Ks = pow(R,Kz/2.5);		//% pretty arbitary
+	Cr = 1.01;				//% need to be large than 1 pretty arbitrary
+	Ks = pow(R,Kz/2.5);		//% pretty arbitrary
 	slvrg = pow(12.0/30.0,1/0.4)*0.04;			//%the slip corresponding to the virgin friction in local bond-slip model
 
 	// Assume symmetric envelope 
@@ -225,7 +225,7 @@ void Bond_SP01::determineTrialState (double ts, double dslip)
 		return;
 	}
 
-	if (Tloading == 0)						//the inital step when loading/unloading is not determined
+	if (Tloading == 0)						//the initial step when loading/unloading is not determined
 	{
 		Tload = getEnvelopeStress(ts);
 		if (dslip > 0.0)					//positive change in slip --> loading (Tloading = 1)
@@ -233,7 +233,7 @@ void Bond_SP01::determineTrialState (double ts, double dslip)
 			Tloading = 1;
 			CminHSlip = -slvrg;				//avoid divided by zero later in determine reloading path
 		}
-		else								//negtive change in slip --> unloading (Tloading = -1)
+		else								//negative change in slip --> unloading (Tloading = -1)
 		{
 			Tloading = -1;
 			CmaxHSlip = slvrg;				//avoid divided by zero later in determine reloading path

--- a/SRC/material/uniaxial/Bond_SP01.h
+++ b/SRC/material/uniaxial/Bond_SP01.h
@@ -26,7 +26,7 @@
 // Written: 		Jian Zhao, Iowa State University 		04/2004
 // Revision:		Jian Zhao, University of Wisconsin, Milwaukee 		04/2006
 //
-// Description: This file contains the class defination for Uniaxial material Bond_SP01. 
+// Description: This file contains the class definition for Uniaxial material Bond_SP01. 
 //		Bond_SP01: Strain penetration of rebars at footings w/o bond damage.
 /* *********************************************************************** **
 ** Nonlinear material model with Menegoto-Pinto type functions to define   **

--- a/SRC/material/uniaxial/BoucWenMaterial.cpp
+++ b/SRC/material/uniaxial/BoucWenMaterial.cpp
@@ -45,7 +45,7 @@ void* OPS_BoucWenMaterial()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 10) {
-	opserr << "WARNING: Insufficient arguements\n";
+	opserr << "WARNING: Insufficient arguments\n";
 	opserr << "Want: uniaxialMaterial BoucWen tag? alpha? ko? n? gamma?" << endln 
 	       << " beta? Ao? deltaA? deltaNu? deltaEta?" << endln;
 	return 0;

--- a/SRC/material/uniaxial/BoucWenMaterial.h
+++ b/SRC/material/uniaxial/BoucWenMaterial.h
@@ -98,7 +98,7 @@ class BoucWenMaterial : public UniaxialMaterial
     double deltaNu;
     double deltaEta;
 
-    // History variables (trial and commited)
+    // History variables (trial and committed)
     double Tstrain, Cstrain;
 	double Tz, Cz;
 	double Te, Ce;

--- a/SRC/material/uniaxial/BoucWenOriginal.cpp
+++ b/SRC/material/uniaxial/BoucWenOriginal.cpp
@@ -45,7 +45,7 @@ void* OPS_BoucWenOriginal()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 4) {
-        opserr << "WARNING: Insufficient arguements\n";
+        opserr << "WARNING: Insufficient arguments\n";
         opserr << "Want: uniaxialMaterial BoucWenOriginal tag E fy alphaL" << endln;
         return 0;
     }

--- a/SRC/material/uniaxial/CFSSSWP.cpp
+++ b/SRC/material/uniaxial/CFSSSWP.cpp
@@ -656,7 +656,7 @@ getIndexNeg(Vector v,double value)
 	    envlpNegStrain(6) = 1e+6*strain4n;
 	    envlpNegStress(6) = (k2>0.0)? envlpNegStress(5)+k1*(envlpNegStrain(6) - envlpNegStrain(5)):envlpNegStress(5)*1.1;
        
-         // define crtical material properties
+         // define critical material properties
          kElasticPos = envlpPosStress(1)/envlpPosStrain(1);      
          kElasticNeg = envlpNegStress(1)/envlpNegStrain(1);
  

--- a/SRC/material/uniaxial/CFSWSWP.cpp
+++ b/SRC/material/uniaxial/CFSWSWP.cpp
@@ -745,7 +745,7 @@ static int getIndexNeg(Vector v,double value)
 	    envlpNegStrain(6) = 1e+6*strain4n;
 	    envlpNegStress(6) = (k2>0.0)? envlpNegStress(5)+k1*(envlpNegStrain(6) - envlpNegStrain(5)):envlpNegStress(5)*1.1;
        
-         // define crtical material properties
+         // define critical material properties
          kElasticPos = envlpPosStress(1)/envlpPosStrain(1);      
          kElasticNeg = envlpNegStress(1)/envlpNegStrain(1);
  

--- a/SRC/material/uniaxial/CableMaterial.cpp
+++ b/SRC/material/uniaxial/CableMaterial.cpp
@@ -137,7 +137,7 @@ CableMaterial::setTrialStrain(double strain, double strainRate)
   if (trialStrain < - Ps/E*10.0) 
     trialStress =  0.0; 
 
-  // if stress is in between then do itterations -- Bisection
+  // if stress is in between then do iterations -- Bisection
   dP = U_bound - L_bound;
     
   while (abs(dP)/U_bound > 0.00000001 && i < 100) {

--- a/SRC/material/uniaxial/Cast.cpp
+++ b/SRC/material/uniaxial/Cast.cpp
@@ -25,7 +25,7 @@
 // Created: 04/2011
 //
 // Description: This file contains the class implementation of Cast. 
-// This Cast is a material model tha descibes the Cast Fuse brace
+// This Cast is a material model that describes the Cast Fuse brace
 // Developed by Gray et al. (2010).
 // this model is based on:
 // 1. Modified Menegotto-Pinto Steel Model with Filippou Isotropic Hardening
@@ -290,7 +290,7 @@ double  epsmaxr = epsmaxrP;
     kon = 1;
 
 	// MG: This variable is used to evaluate if the strain is enough since the
-	// previous reveral to consider an increase in strain hardening
+	// previous reversal to consider an increase in strain hardening
 	double yieldcheck = (eps - epsr)/(epss0 - epsr);
 
     epsr = epsP;
@@ -305,7 +305,7 @@ double  epsmaxr = epsmaxrP;
 	// MG: This is redundant
     // epsmin = min(epsP, epsmin);
 
-	// MG: This stores the min strain that was used to calcualte the strain
+	// MG: This stores the min strain that was used to calculate the strain
 	// hardening before this load reversal.  In the case where there
 	// is a quick double back we won't consider strain hardening
 	// epsminr = epsmin;
@@ -338,7 +338,7 @@ double  epsmaxr = epsmaxrP;
     kon = 2;
 
 	// MG: This variable is used to evaluate if strain the strain is enough since the
-	// previous reveral to consider strain hardening
+	// previous reversal to consider strain hardening
 	double yieldcheck = (eps - epsr)/(epss0 - epsr);
 
     epsr = epsP;
@@ -355,7 +355,7 @@ double  epsmaxr = epsmaxrP;
 	// MG: This is redundant
     // epsmax = max(epsP, epsmax);
 
-	// MG: This stores the max strain that was used to calcualte the strain
+	// MG: This stores the max strain that was used to calculate the strain
 	// hardening before this load reversal.  In the case where there
 	// is a quick double back we won't consider strain hardening
 	// epsmaxr = epsmax;
@@ -391,7 +391,7 @@ double  epsmaxr = epsmaxrP;
   sig = sig*(sigs0-sigr);
  
   sig = sig+sigr;
-  // MG: This vaiable is used in the tangent calc when post-yield stiffening is considered	
+  // MG: This variable is used in the tangent calc when post-yield stiffening is considered	
   double sign = 1;
 
   if ((eps-epsr) < 0){
@@ -400,7 +400,7 @@ double  epsmaxr = epsmaxrP;
 	  sign = 1;
   }
   
-  // MG: Checks which quadrant we are in and then consideres post-yield stiffneing when appropriate
+  // MG: Checks which quadrant we are in and then considers post-yield stiffening when appropriate
   // this is not technically correct but it fixes the problem that occurs when there is a load
   // reversal in the elastic rebound
 

--- a/SRC/material/uniaxial/Cast.h
+++ b/SRC/material/uniaxial/Cast.h
@@ -26,7 +26,7 @@
 // Created: 04/2011
 //
 // Description: This file contains the class implementation of Cast. 
-// This Cast is a material model tha descibes the Cast Fuse brace
+// This Cast is a material model that describes the Cast Fuse brace
 // Developed by Gray et al. (2010).
 // this model is based on:
 // 1. Modified Menegotto-Pinto Steel Model with Filippou Isotropic Hardening

--- a/SRC/material/uniaxial/Concrete01WithSITC.h
+++ b/SRC/material/uniaxial/Concrete01WithSITC.h
@@ -28,7 +28,7 @@
 // Modified by: Won Lee
 // Created: 10/3/05
 // Modified from Concrete01.h (see details below)
-// Desctiption: This file contains the class definition for Concrete01WithSITC
+// Description: This file contains the class definition for Concrete01WithSITC
 // Description: Concrete01 model modified to include SITC effect (ref. Prof. 
 //	John Stanton of Univ. of Washington).  Use modified rules from his paper to include this 
 //	effect (J.F. Stanton and H.D. McNiven, "The Development of a Mathematical

--- a/SRC/material/uniaxial/Concrete02Thermal.cpp
+++ b/SRC/material/uniaxial/Concrete02Thermal.cpp
@@ -354,7 +354,7 @@ Concrete02Thermal::getElongTangent(double TempT, double& ET, double& Elong, doub
 	 // epsc0 = epsc0T*strainRatio;
 	 // epscu = epscuT*strainRatio;
 
-  // caculation of thermal elongation
+  // calculation of thermal elongation
 	  if (Temp <= 1) {
 		  ThermalElongation = (Temp - 0) * 9.213e-6;
 	  }
@@ -378,7 +378,7 @@ Concrete02Thermal::getElongTangent(double TempT, double& ET, double& Elong, doub
  // } 
 
 ///PK COOLING PART FOR DESCENDING BRANCH OF A FIRE//// 
-  // If temperature is less that previous commited temp then we have cooling taking place
+  // If temperature is less that previous committed temp then we have cooling taking place
   if (Temp < TempP) {
    
 //opserr << "cooling " << Temp << " " << TempP << endln;

--- a/SRC/material/uniaxial/Concrete05.cpp
+++ b/SRC/material/uniaxial/Concrete05.cpp
@@ -878,7 +878,7 @@ int Concrete05::setTrialStrain (double strain, double strainRate)
 
 			  }	// if (Crule==1.0)	// or 5.0 or 7.0
 
-			  else if (Crule==77.0)	{			// Continue on transiton 77 [Rules 77,1,5]
+			  else if (Crule==77.0)	{			// Continue on transition 77 [Rules 77,1,5]
 
 //				  opserr << "esrestn" << esrestn << "\n";
 //				  opserr << "espln" << espln << "\n";
@@ -898,7 +898,7 @@ int Concrete05::setTrialStrain (double strain, double strainRate)
 	  
 			  }	// if (Crule==77.0)
 
-			  else if (Crule==13.0)	{			// Continue on transiton 13 [Rules 13,7,1,5]
+			  else if (Crule==13.0)	{			// Continue on transition 13 [Rules 13,7,1,5]
 				  
 				  if (Tstrain>=Teunn)	{	// Rule 13
 					  r13f(Ted,Teunn,fnewn,Enewn);

--- a/SRC/material/uniaxial/Concrete07.cpp
+++ b/SRC/material/uniaxial/Concrete07.cpp
@@ -25,7 +25,7 @@
 // Written: Jon Waugh, Iowa State University
 // Created: 10/2006
 //
-// Description: This file contains the class defination for Uniaxial material Concrete07 
+// Description: This file contains the class definition for Uniaxial material Concrete07
 //				A implementation of the Chang & Mander Concrrete model from 1994.
 
 #include <Concrete07.h>
@@ -43,7 +43,7 @@ void* OPS_Concrete07()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 9) {
-	opserr << "WARNING: Insufficient arguements\n";
+	opserr << "WARNING: Insufficient arguments\n";
 	opserr << "Want: uniaxialMaterial Concrete07 tag? ";
 	opserr << "fpc? epsc0? Ec? fpt? epst0? xcrp? xcrn? r?\n";
 	return 0;
@@ -91,7 +91,7 @@ Concrete07::Concrete07 (int tag, double FPC, double EPSC0, double EC, double FPT
 
 	e0 = 0;
 
-	// Set all history adn state variables to initial values
+	// Set all history and state variables to initial values
 	this->revertToStart();
 }
 
@@ -196,7 +196,7 @@ void Concrete07::calculateStressTransition(double& fc, double& Et, double ec, do
 	fa = EI*(ea - eI)+fI;
 	fb = EF*(eb - eF)+fF;
 
-	// Deterine if the strain is above or below the breakpoint and calculate the stress and stiffness accordingly
+	// Determine if the strain is above or below the breakpoint and calculate the stress and stiffness accordingly
 
 	if (eI < eF)
 	{
@@ -276,7 +276,7 @@ void Concrete07::calculateStressTransition(double& fc, double& Et, double ec, do
 
 void Concrete07::calculate13Stress(double &fc, double &Et, double ec, double eI, double eF, double fF, double EF)
 {
-	double A;				// Equation paramter
+	double A;				// Equation parameter
 	double R(0);			// Equation Parameter
 	double ESEC;			// Secant Modulus
 	double fI = 0;			// Initial Stress
@@ -489,9 +489,9 @@ void Concrete07::determineTrialState(double dStrain)
 			{
 				if (Trule == 71)				// we are on the transition curve for reloading from a partial unloading in compression
 				{
-					double eron;			// strain at which reversal occured in a partial unloading
-					double fron;			// stress at which reversal occured in a parial unloading
-										
+					double eron;			// strain at which reversal occurred in a partial unloading
+					double fron;			// stress at which reversal occurred in a partial unloading
+
 					eron = TReloadStrain;
 					fron = TReloadStress;
 
@@ -505,8 +505,8 @@ void Concrete07::determineTrialState(double dStrain)
 
 				else if (Trule == 11)				// we are on the transition curve for parital reloading after a partial unloading
 				{
-					double er = TReloadStrain;	// strain when reversal occurred. 
-					double fr = TReloadStress;	// stress when reversal occured.
+					double er = TReloadStrain;	// strain when reversal occurred.
+					double fr = TReloadStress;	// stress when reversal occurred.
 					double Eplp;				// Modulus at plastic point in tension
 					double fb;					// target stress on rule 10
 					double eb;					// target strain on rule 10;
@@ -584,7 +584,7 @@ void Concrete07::determineTrialState(double dStrain)
 
 				else if (Trule == 811 && Tstrain > TUnloadStrain)
 				{
-					double Enewps;			// stiffness at strain reloading from tension evelope after unloading
+					double Enewps;			// stiffness at strain reloading from tension envelope after unloading
 					double erop;			// strain at last reversal;
 					double frop;			// stress at last reversal;
 
@@ -603,8 +603,8 @@ void Concrete07::determineTrialState(double dStrain)
 
 				else if (Trule == 11)
 				{
-					double er = TReloadStrain;	// strain when reversal occurred. 
-					double fr = TReloadStress;	// stress when reversal occured.
+					double er = TReloadStrain;	// strain when reversal occurred.
+					double fr = TReloadStress;	// stress when reversal occurred.
 					double Eplp;				// Modulus at plastic point in tension
 					double fb;					// target stress on rule 10
 					double eb;					// target strain on rule 10;
@@ -653,9 +653,9 @@ void Concrete07::determineTrialState(double dStrain)
 
 			else if (Trule == 71)				// we are on the transition curve for reloading from a partial unloading in compression
 			{
-				double eron;			// strain at which reversal occured in a partial unloading
-				double fron;			// stress at which reversal occurded in a parial unloading
-				double Enewns;			// stiffness at strain unloading from compression evelope after reloading
+				double eron;			// strain at which reversal occurred in a partial unloading
+				double fron;			// stress at which reversal occurred in a partial unloading
+				double Enewns;			// stiffness at strain unloading from compression envelope after reloading
 
 				eron = TReloadStrain;
 				fron = TReloadStress;
@@ -671,7 +671,7 @@ void Concrete07::determineTrialState(double dStrain)
 
 			else if (Trule == 15)
 			{
-				double ea = T13Strain;			// Strain at unloadins on rule 13
+				double ea = T13Strain;			// Strain at unloading on rule 13
 				double fa = T13Stress;			// Stress at unloading on rule 13
 				double er = TReloadStrain;		// Strain at last reloading
 				double fr = TReloadStress;		// Stress at last reloading
@@ -854,10 +854,10 @@ void Concrete07::determineTrialState(double dStrain)
 			{
 				Tloading = -1;
 
-				double er = Cstrain;	// strain when reversal occured. 
-				double fr = Cstress;	// stress when reversal occured.
-				double eron;			// strain at which reversal occured in a partial unloading
-				double fron;			// stress at which reversal occured in a parial unloading
+				double er = Cstrain;	// strain when reversal occurred.
+				double fr = Cstress;	// stress when reversal occurred.
+				double eron;			// strain at which reversal occurred in a partial unloading
+				double fron;			// stress at which reversal occurred in a partial unloading
 
 				eron = TReloadStrain;
 				fron = TReloadStress;
@@ -920,11 +920,11 @@ void Concrete07::determineTrialState(double dStrain)
 
 			else if (Trule == 10 || Trule == 11)
 			{
-				// Paritial reloading in compression zone
+				// Partial reloading in compression zone
 				Tloading = -1;
 
-				double er = Cstrain;	// strain when reversal occurred. 
-				double fr = Cstress;	// stress when reversal occured.
+				double er = Cstrain;	// strain when reversal occurred.
+				double fr = Cstress;	// stress when reversal occurred.
 				double Eplp;			// Modulus at plastic point in tension
 				double Epln;			// Modulus at plastic point in compression
 				double fa;				// target stress on rule 9
@@ -975,7 +975,7 @@ void Concrete07::determineTrialState(double dStrain)
 
 			}
 
-			else							// Unloading after cracking of the concrete has occured.
+			else							// Unloading after cracking of the concrete has occurred.
 			{
 
 				Tloading = -1;
@@ -992,8 +992,8 @@ void Concrete07::determineTrialState(double dStrain)
 				}
 
 
-				double er = Cstrain;	// strain when reversal occurred. 
-				double fr = Cstress;	// stress when reversal occured.
+				double er = Cstrain;	// strain when reversal occurred.
+				double fr = Cstress;	// stress when reversal occurred.
 				TUnloadStiffness = Ctangent;
 				TUnloadStrain = er;
 				TUnloadStress = fr;
@@ -1030,11 +1030,11 @@ void Concrete07::determineTrialState(double dStrain)
 
 	if (Tloading < 0)					// Previously where unloading the concrete
 	{
-		if (dStrain > 0.0)				// We are continueing to unload the concrete
+		if (dStrain > 0.0)				// We are continuing to unload the concrete
 		{
 			if (Tstrain > eunp && !Tcracked)
 			{
-				
+
 				envelope(x, Tstress, Ttangent, 1);
 
 				TmaxStrain = Tstrain;
@@ -1047,7 +1047,7 @@ void Concrete07::determineTrialState(double dStrain)
 			{
 				if (Trule == 81)
 				{
-					double Enewps;			// stiffness at strain reloading from tension evelope after unloading
+					double Enewps;			// stiffness at strain reloading from tension envelope after unloading
 					double erop;			// strain at last reversal;
 					double frop;			// stress at last reversal;
 
@@ -1183,8 +1183,8 @@ void Concrete07::determineTrialState(double dStrain)
 
 				if (Trule == 711 && Tstrain < TReloadStrain)
 				{
-					double eron;			// strain at which reversal occured in a partial unloading
-					double fron;			// stress at which reversal occured in a parial unloading
+					double eron;			// strain at which reversal occurred in a partial unloading
+					double fron;			// stress at which reversal occurred in a partial unloading
 
 					eron = TReloadStrain;
 					fron = TReloadStress;
@@ -1236,7 +1236,7 @@ void Concrete07::determineTrialState(double dStrain)
 			}
 		}
 
-		if (dStrain < 0.0)				// Previosuly unloading, now reloading
+		if (dStrain < 0.0)				// Previously unloading, now reloading
 		{
 			// We need to determine what rule we are on
 
@@ -1303,8 +1303,8 @@ void Concrete07::determineTrialState(double dStrain)
 
 				double eron = Cstrain;
 				double fron = Cstress;
-				double Enewns;			// stiffness at strain unloading from compression evelope after reloading
-				
+				double Enewns;			// stiffness at strain unloading from compression envelope after reloading
+
 				TReloadStrain = eron;
 				TReloadStress = fron;
 				Enewns = (funn-fron)/(eunn-eron);
@@ -1334,8 +1334,8 @@ void Concrete07::determineTrialState(double dStrain)
 			{
 				Tloading = 1;
 
-				double eron;			// strain at which reversal occured in a partial unloading
-				double fron;			// stress at which reversal occured in a parial unloading
+				double eron;			// strain at which reversal occurred in a partial unloading
+				double fron;			// stress at which reversal occurred in a partial unloading
 
 				eron = TReloadStrain;
 				fron = TReloadStress;
@@ -1366,12 +1366,12 @@ void Concrete07::determineTrialState(double dStrain)
 			{
 				Tloading = 1;
 
-				double Enewps;			// stiffness at strain reloading from tension evelope after unloading
+				double Enewps;			// stiffness at strain reloading from tension envelope after unloading
 				double erop;			// strain at last reversal;
 				double frop;			// stress at last reversal;
 				double Eplp;			// Modulus at plastic point in tension
 				double Enewn;			// reloading stiffness in compression;
-				
+
 				if (eunn == 0 && funn == 0)
 				{
 					double Edum;
@@ -1435,8 +1435,8 @@ void Concrete07::determineTrialState(double dStrain)
 
 				Tloading = 1;
 
-				double er = Cstrain;	// strain when reversal occurred. 
-				double fr = Cstress;	// stress when reversal occured.
+				double er = Cstrain;	// strain when reversal occurred.
+				double fr = Cstress;	// stress when reversal occurred.
 				double Eplp;			// Modulus at plastic point in tension
 				double fb;				// target stress on rule 10
 				double eb;				// target strain on rule 10;
@@ -1832,7 +1832,7 @@ int Concrete07::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& t
 
 	if ( res < 0)
 	{
-		opserr << "Concrete07::recvSelf() - failed to recieve data\n";
+		opserr << "Concrete07::recvSelf() - failed to receive data\n";
 		this->setTag(0);
 	}
 

--- a/SRC/material/uniaxial/Concrete07.h
+++ b/SRC/material/uniaxial/Concrete07.h
@@ -25,7 +25,7 @@
 // Written: Jon Waugh, Iowa State University
 // Created: 11/2005
 //
-// Description: This file contains the class defination for Uniaxial material Concrete07 
+// Description: This file contains the class definition for Uniaxial material Concrete07 
 //				A simplified form of Chang & Mander Concrrete model from 1994.
 
 #ifndef Concrete07_h
@@ -138,7 +138,7 @@ class Concrete07 : public UniaxialMaterial
 	  // Calculates trial state variables based on the trail strain
       void determineTrialState (double dStrain);
 
-	  // Determines is a strain reversal has occured based on the trial strain
+	  // Determines is a strain reversal has occurred based on the trial strain
 	  void detectStrainReversal (double dStrain);
 
 	  // Calculates the value of y(x) and z(x)

--- a/SRC/material/uniaxial/ConcreteCM.cpp
+++ b/SRC/material/uniaxial/ConcreteCM.cpp
@@ -177,7 +177,7 @@ Crule(0.0), Cstrain(0.0), Cstress(0.0), Ctangent(0.0)
 
 }
 
-// Constructor for optional gradual gap closure: mon=0 (default), Gap=0 or 1 (optinal user-generated input, see Eplpf member function)
+// Constructor for optional gradual gap closure: mon=0 (default), Gap=0 or 1 (optional user-generated input, see Eplpf member function)
 ConcreteCM::ConcreteCM
 (int tag, double FPCC, double EPCC, double EC, double RC, double XCRN, double FT, double ET, double RT, double XCRP, int GAP, int DUMMY)
 :UniaxialMaterial(tag, MAT_TAG_ConcreteCM),
@@ -1344,7 +1344,7 @@ int ConcreteCM::setTrialStrain (double strain, double strainRate)
 
 				}	// if (Crule==1.0)	// or 5.0 or 7.0
 
-				else if (Crule==77.0)	{			// Continue on transiton 77 [Rules 77,1,5]
+				else if (Crule==77.0)	{			// Continue on transition 77 [Rules 77,1,5]
 
 					if (Tstrain>esrestn)	{		// Rule 77
 
@@ -1367,7 +1367,7 @@ int ConcreteCM::setTrialStrain (double strain, double strainRate)
 
 				}	// if (Crule==77.0)
 
-				else if (Crule==13.0)	{			// Continue on transiton 13 [Rules 13,7,1,5]
+				else if (Crule==13.0)	{			// Continue on transition 13 [Rules 13,7,1,5]
 
 					if (Tstrain>=Teunn)	{	// Rule 13
 

--- a/SRC/material/uniaxial/ConcreteD.h
+++ b/SRC/material/uniaxial/ConcreteD.h
@@ -64,12 +64,12 @@ class ConcreteD : public UniaxialMaterial
 	double etap;
 //State Parameters
 	int	   CLoadState;  //load state 0 loading,1 unloading,2 reloading
-	double CStrain;     // last commited strain
-    double CStress;     // last commited stress
-    double CTangent;    // last commited tangent
-	double CSecant;     // last commited secant
-	double CDc;         // last commited damage parameter in compression
-	double CDt;         // last commited damage parameter in tenssion
+	double CStrain;     // last committed strain
+    double CStress;     // last committed stress
+    double CTangent;    // last committed tangent
+	double CSecant;     // last committed secant
+	double CDc;         // last committed damage parameter in compression
+	double CDt;         // last committed damage parameter in tenssion
 	double CDcp;
 	double CDtp;
 	double CEpp;        // last coomited plastic strain

--- a/SRC/material/uniaxial/ConcreteECThermal.cpp
+++ b/SRC/material/uniaxial/ConcreteECThermal.cpp
@@ -380,7 +380,7 @@ ConcreteECThermal::getElongTangent(double TempT, double& ET, double& Elong, doub
 	 // epsc0 = epsc0T*strainRatio;
 	 // epscu = epscuT*strainRatio;
 
-  // caculation of thermal elongation
+  // calculation of thermal elongation
 	  if (Temp <= 1) {
 		  ThermalElongation = (Temp - 0) * 9.213e-6;
 	  }

--- a/SRC/material/uniaxial/ConfinedConcrete01.cpp
+++ b/SRC/material/uniaxial/ConfinedConcrete01.cpp
@@ -30,7 +30,7 @@
 // Unloading and reloanding curve: stress-strain model proposed by D. Karsan, and J. Jirsa in 
 //                                 "Behavior of concrete under compressive loadings"
 //                                 Journal of the Structural Division, ASCE, Vol. 95, No. ST12, December, 1969
-// Tensile evelope strenght:       model has not tensile strenght
+// Tensile envelope strength:      model has no tensile strength
 //                                 
 
 
@@ -64,7 +64,7 @@ stRatio: fc/f'c
 epscuOption: 0-direct input of epscu
     1-Scott
     2-gamma
-epscu: input dependant upon epscuOption
+epscu: input dependent upon epscuOption
 nuOption: 0-constant
 		  1-variable, upper bound 0.5
           2-variable, no upper bound 
@@ -81,7 +81,7 @@ phis[]: transverse bar diameter or wrapping thickness
 S[] : spacing of transverse reinforcement
 fyh[]: yield strength of transverse reinforcement
 mueps[]: ductility factor of transverse reinforcement
-Es0[]: intial elastic modulus of transverse reinforcement
+Es0[]: initial elastic modulus of transverse reinforcement
 haRatio[]: hardening ratio of transverse reinforcement
 wrappingArea: full area of wrap (unrolled)
 
@@ -1710,7 +1710,7 @@ OPS_ConfinedConcrete01Material()
        0-direct input of epscu
        1-Scott
        2-gamma
-    4.  epscu: input dependant upon epscuOption
+    4.  epscu: input dependent upon epscuOption
     5.  nuOption: 0-constant
 			  1-variable, upper bound 0.5
 			  2-variable, no upper bound 
@@ -1737,7 +1737,7 @@ OPS_ConfinedConcrete01Material()
     11. S[] : spacing of transverse reinforcement
     12. fyh[]: yield strength of transverse reinforcement
     13. mueps[]: ductility factor of transverse reinforcement
-    14. Es0[]: intial elastic modulus of transverse reinforcement
+    14. Es0[]: initial elastic modulus of transverse reinforcement
     15. haRatio[]: hardening ratio of transverse reinforcement
 
     ---TCL Command Reference----------------------------
@@ -1781,7 +1781,7 @@ OPS_ConfinedConcrete01Material()
   int epscuOption; //0-direct input of epscu
   // 1-Scott
   // 2-gamma
-  double epscu; // input dependant upon epscuOption
+  double epscu; // input dependent upon epscuOption
   int nuOption = 0;	// 0-constant
   // 1-variable, upper bound 0.5
   // 2-variable, no upper bound 

--- a/SRC/material/uniaxial/ConfinedConcrete01.h
+++ b/SRC/material/uniaxial/ConfinedConcrete01.h
@@ -33,7 +33,7 @@
 // Unloading and reloanding curve: stress-strain model proposed by D. Karsan, and J. Jirsa in 
 //                                 "Behavior of concrete under compressive loadings"
 //                                 Journal of the Structural Division, ASCE, Vol. 95, No. ST12, December, 1969
-// Tensile evelope strenght:       model has not tensile strenght
+// Tensile envelope strength:      model has no tensile strength
 //                                 
 
 

--- a/SRC/material/uniaxial/ContinuumUniaxial.cpp
+++ b/SRC/material/uniaxial/ContinuumUniaxial.cpp
@@ -254,7 +254,7 @@ ContinuumUniaxial::sendSelf(int commitTag, Channel &theChannel)
 {
   int res = 0;
 
-  // put tag and assocaited materials class and database tags into an id and send it
+  // put tag and associated materials class and database tags into an id and send it
   static ID idData(3);
   idData(0) = this->getTag();
   idData(1) = theMaterial->getClassTag();
@@ -299,7 +299,7 @@ ContinuumUniaxial::recvSelf(int commitTag, Channel &theChannel,
 {
   int res = 0;
 
-  // recv an id containg the tag and associated materials class and db tags
+  // recv an id containing the tag and associated materials class and db tags
   static ID idData(3);
   res = theChannel.sendID(this->getDbTag(), commitTag, idData);
   if (res < 0) {

--- a/SRC/material/uniaxial/DoddRestr.h
+++ b/SRC/material/uniaxial/DoddRestr.h
@@ -100,14 +100,14 @@ class DoddRestr : public UniaxialMaterial
 
 //	Committed Response quantities
 
-    double Cstrain;     // last commited strain
-    double Cstress;     // last commited stress
+    double Cstrain;     // last committed strain
+    double Cstress;     // last committed stress
     double Ctangent;    // last committed  tangent
 
 
 //	Committed History Variables
 
-    double Cepso;     // last commited shrinkage strain
+    double Cepso;     // last committed shrinkage strain
     double Ch1;     // last committed h1
     double Ch2;    // last committed h2
 	double Ctn;	   // last committed "time for shrinkage calculation"!		

--- a/SRC/material/uniaxial/ElasticMaterialThermal.cpp
+++ b/SRC/material/uniaxial/ElasticMaterialThermal.cpp
@@ -94,7 +94,7 @@ OPS_ElasticMaterialThermal(void)
       return 0;
 	}
 	}
- //opserr<< "receieved alpha"<<dData[1]<<endln;
+ //opserr<< "received alpha"<<dData[1]<<endln;
 
   // Parsing was successful, allocate the material
   theMaterial = new ElasticMaterialThermal(iData[0], dData1[0], dData1[1], dData2[0], dData2[1], softindex);
@@ -140,7 +140,7 @@ ThermalElongation(0),Temp(0)
 			redfactors[i] = ConcreteRedfactors[i];
 	}
 	else {
-		opserr << "ElasticMaterialThermal " << this->getTag() << " recieves an invalid softening index" << endln;
+		opserr << "ElasticMaterialThermal " << this->getTag() << " receives an invalid softening index" << endln;
 	}
 		
 }

--- a/SRC/material/uniaxial/ElasticPPMaterial.h
+++ b/SRC/material/uniaxial/ElasticPPMaterial.h
@@ -80,8 +80,8 @@ class ElasticPPMaterial : public UniaxialMaterial
     double trialStrain;	     // current trial strain
     double trialStress;      // current trial stress
     double trialTangent;     // current trial tangent
-    double commitStrain;     // last commited strain
-    double commitStress;     // last commited stress
+    double commitStrain;     // last committed strain
+    double commitStress;     // last committed stress
     double commitTangent;    // last committed  tangent
 };
 

--- a/SRC/material/uniaxial/FRPConfinedConcrete02.cpp
+++ b/SRC/material/uniaxial/FRPConfinedConcrete02.cpp
@@ -390,7 +390,7 @@ FRPConfinedConcrete02::setTrialStrain(double strain, double strainRate)
 					if (m_gamare > 0.7 && m_betaun > 0.7) // Eq.30 (Lam and Teng 2009)
 						m_ne +=1;
 				}
-				Compr_GetPlasticStrain(); // calulate new m_epspl
+				Compr_GetPlasticStrain(); // calculate new m_epspl
 			}
 			m_loadingflag = TAG_UNLOADING; // Set current loading type
 		}

--- a/SRC/material/uniaxial/FatigueMaterial.cpp
+++ b/SRC/material/uniaxial/FatigueMaterial.cpp
@@ -479,7 +479,7 @@ FatigueMaterial::commitState(void)
     // Flag failure if we have reached that point
     if (DI >= Dmax )  {
       // Most likely will not fail at this point, more 
-      // likely at the psuedo peak. But this step is
+      // likely at the pseudo peak. But this step is
       // is important for accumulating damage
       Cfailed = true;
       opserr << "FatigueMaterial: material tag " << this->getTag() << " failed at peak\n";
@@ -844,7 +844,7 @@ FatigueMaterial::recvSelf(int cTag, Channel &theChannel,
 }
 
 //Printing of current damage.  NOTE:  The damage that is returned
-//  is damage at the psuedo peak, DL, ( if not at a peak when the 
+//  is damage at the pseudo peak, DL, ( if not at a peak when the 
 //  print function  is called). The generic print will print both 
 //  the damage recorded at the last peak, along with current damage
 

--- a/SRC/material/uniaxial/FatigueMaterial.h
+++ b/SRC/material/uniaxial/FatigueMaterial.h
@@ -123,10 +123,10 @@ class FatigueMaterial : public UniaxialMaterial
   // For recording strain ranges (SRXX) and Number of Cycles (NCXX)
   double SR1;  // Committed strain range at peak
   double NC1;  // Committed number of cycles at SR1 (i.e. 1.0 or 0.5)
-  double SR2;  // Committed strain range 2 at PSUEDO peak - there are potentially two ranges
-  double NC2;  // Committed number of cycles at SR2 2 (at PSUEDO peak) - there are potentially two ranges
-  double SR3;  // Committed strain range 3 at PSUEDO peak - there are potentially two ranges
-  double NC3;  // Committed number of cycles at SR2 3 (at PSUEDO peak) - there are potentially two ranges
+  double SR2;  // Committed strain range 2 at PSEUDO peak - there are potentially two ranges
+  double NC2;  // Committed number of cycles at SR2 2 (at PSEUDO peak) - there are potentially two ranges
+  double SR3;  // Committed strain range 3 at PSEUDO peak - there are potentially two ranges
+  double NC3;  // Committed number of cycles at SR2 3 (at PSEUDO peak) - there are potentially two ranges
   
 };
 

--- a/SRC/material/uniaxial/GNGMaterial.cpp
+++ b/SRC/material/uniaxial/GNGMaterial.cpp
@@ -70,10 +70,10 @@
 #include <OPS_Stream.h>
 
 //External Procedure
-//This is the all importat extenal procedure that the interpreter will parse when it 
-//comes accross your element on the command line. You need to parse the command line, 
-//create a material using the command line arguments you parsed and then return this 
-//material. The name of the procedure must be OPS_YourClassName (no exceptions). If this 
+//This is the all important external procedure that the interpreter will parse when it 
+//comes across your element on the command line. You need to parse the command line,
+//create a material using the command line arguments you parsed and then return this
+//material. The name of the procedure must be OPS_YourClassName (no exceptions). If this
 //procedure is missing or the name is incorrect, your material will fail to load.
 
 //NOTE: parsing the command line is easy with some other procedures that are defined in 
@@ -399,11 +399,11 @@ GNGMaterial::getCopy(void)
 }
 
 //Methods Dealing With Databases/Parallel Processing
-//There are two methods provided which are required if the user wishes to use the 
-//database or parallel procesing features of the OpenSees applications. If neither 
-//are to be used, the developer need simply return a negative value in both methods. 
-//The idea is that the material must pack up it's information using Vector and ID 
-//objects and send it off to a Channel object. On the flip side, the receiving blank 
+//There are two methods provided which are required if the user wishes to use the
+//database or parallel processing features of the OpenSees applications. If neither
+//are to be used, the developer need simply return a negative value in both methods.
+//The idea is that the material must pack up it's information using Vector and ID
+//objects and send it off to a Channel object. On the flip side, the receiving blank
 //element must receive the same Vector and ID data, unpack it and set the variables.
 
 int 

--- a/SRC/material/uniaxial/HyperbolicGapMaterial.cpp
+++ b/SRC/material/uniaxial/HyperbolicGapMaterial.cpp
@@ -63,7 +63,7 @@ OPS_HyperbolicGapMaterial()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 6) {
-        opserr << "WARNING: Insufficient arguements\n";
+        opserr << "WARNING: Insufficient arguments\n";
         return 0;
     }
 

--- a/SRC/material/uniaxial/KikuchiAikenHDR.cpp
+++ b/SRC/material/uniaxial/KikuchiAikenHDR.cpp
@@ -216,7 +216,7 @@ KikuchiAikenHDR::KikuchiAikenHDR(int tag, int tp, double ar, double hr,
   }
   
 
-  // intitialize
+  // initialize
   initialStiff = (this->calcGeq)(trgStrain)*Cg*Ar/Hr;
 
 

--- a/SRC/material/uniaxial/KikuchiAikenHDR.h
+++ b/SRC/material/uniaxial/KikuchiAikenHDR.h
@@ -167,7 +167,7 @@ class KikuchiAikenHDR : public UniaxialMaterial
   static double compABisection(double heq, double u, double min, double max, double lim, double tol);
 
 
-  //formulae to caluculate parameters
+  //formulae to calculate parameters
   double (*calcGeq)(double gm);
   double (*calcHeq)(double gm);
   double (*calcU)(double gm);

--- a/SRC/material/uniaxial/KikuchiAikenLRB.cpp
+++ b/SRC/material/uniaxial/KikuchiAikenLRB.cpp
@@ -733,7 +733,7 @@ KikuchiAikenLRB::compQ2MasingDerivertive(double u, double a, double b, double c,
   return alpha*u*keq*(2*a*exp(-a*(x1-x2))+b*exp(-c*(x1-x2))-b*c*(x1-x2)*exp(-c*(x1-x2)));
 }
 
-//bisection method to caluculate parameter "a"
+//bisection method to calculate parameter "a"
 double
 KikuchiAikenLRB::compABisection(double heq, double u, double min, double max, double tol, double lim)
 {

--- a/SRC/material/uniaxial/MultiLinear.cpp
+++ b/SRC/material/uniaxial/MultiLinear.cpp
@@ -97,10 +97,10 @@ MultiLinear::MultiLinear(int tag, const Vector &s, const Vector &e)
     }
   }
 
-  data(0,0) = -e(0);      // neg yeild strain
-  data(0,1) = e(0);       // pos yeild strain
+  data(0,0) = -e(0);      // neg yield strain
+  data(0,1) = e(0);       // pos yield strain
   data(0,2) = -s(0);      // neg yield stress
-  data(0,3) = s(0);       // pos yeild stress
+  data(0,3) = s(0);       // pos yield stress
   data(0,4) = s(0)/e(0); // slope
   data(0,5) = e(0);      // dist - (0-1)/2
 
@@ -165,7 +165,7 @@ MultiLinear::setTrialStrain(double strain, double strainRate)
       tSlope = numSlope-1;
     tStress = data(tSlope,2) + (tStrain-data(tSlope,0))*data(tSlope,4);
     tTangent = data(tSlope,4);    
-  } else { // serach pos side of data
+  } else { // search pos side of data
     tSlope = 1;
     while (tSlope < numSlope && tStrain > data(tSlope,1))
       tSlope++;

--- a/SRC/material/uniaxial/PY/PySimple1.cpp
+++ b/SRC/material/uniaxial/PY/PySimple1.cpp
@@ -335,7 +335,7 @@ void PySimple1::getNearField(double ylast, double dy, double dy_old)
 	//
 	TNF_y = ylast + dy;
 
-	// Postive loading
+	// Positive loading
 	//
 	if(NFdy >= 0.0){
 		// Check if elastic using y < yinr

--- a/SRC/material/uniaxial/PY/PySimple2.cpp
+++ b/SRC/material/uniaxial/PY/PySimple2.cpp
@@ -302,7 +302,7 @@ void PySimple2::getNearField(double ylast, double dy, double dy_old)
 	//
 	TNF_y = ylast + dy;
 
-	// Postive loading
+	// Positive loading
 	//
 	if(NFdy >= 0.0){
 		// Check if elastic using y < yinr

--- a/SRC/material/uniaxial/PY/PySimple3.cpp
+++ b/SRC/material/uniaxial/PY/PySimple3.cpp
@@ -174,7 +174,7 @@ PySimple3::setTrialStrain (double y, double yRate)
       P1 = Cp+ke*dy+((dashpot/tstep1)*dy)-((dashpot/tstep2)*dyELast);	
     }
   if (signdy!=0 && signdy != TLastYieldDir && sign(P1-Cp)!=signdy) {
-    P1 = Cp+(0.000001*signdy);	//this ensures that when the displacement reverses, the load does not continue in the previous direction. This would only occur in unusual situations where deceleration yielding or perhaps a load reversal had also occured during the previous step.	
+    P1 = Cp+(0.000001*signdy);	//this ensures that when the displacement reverses, the load does not continue in the previous direction. This would only occur in unusual situations where deceleration yielding or perhaps a load reversal had also occurred during the previous step.	
   }	
   Tp = P1;
   // 	Ttangent
@@ -226,7 +226,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  else {TpinUse = CpinLast;}				
 	  TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	  TdyE    = TyeTotal-CyeTotalUse;
-	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	  if(dy==0.0 && TdyE == 0.0){
 	    Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	  }
@@ -254,11 +254,11 @@ PySimple3::setTrialStrain (double y, double yRate)
       // viscoelastic force to decrease relative to Cp (this can only occur if the decrease in dashpot force is large
       // relative to the increase in force in the elastic component, so with a relatively large dashpot coeff. and large 
       // deceleration). This is somewhat counterituitive, because you would expect continuing to displace in the same
-      // dir. would keep increasing the load, but a large loss of damper force could cause the cummulative load to drop.
+      // dir. would keep increasing the load, but a large loss of damper force could cause the cumulative load to drop.
       // If this drop is large enough, yielding could occur in the opposite direction of displacement, so the previous 
       // if statements for re-assigning Tpin and Tyin won't work because they rely on sign(dy). Instead, need to use
       // the term sign(P1-Cp), where P1 is the viscoelastic predictor guess.
-      //	If sign(P1-Cp) and signdy have opposite signs, this condition has occured...
+      //	If sign(P1-Cp) and signdy have opposite signs, this condition has occurred...
 	
       if(signP != signdy && signP != 0 && dy == 0.0 && signP != CLastYieldDir)
 	// special case for dy = zero
@@ -269,7 +269,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  //Compute the change in viscoelastic displacement that occurs when the decrease in dashpot force causes P
 	  //	to drop from the current P to the yield surface. First compute time this takes by proportioning forces:
 	  TLastYieldDir = signP;
-	  pn1_a = TpinUse;									//lower bracket is current commited value of p
+	  pn1_a = TpinUse;									//lower bracket is current committed value of p
 	  pn1_b = (1.0-0.5*PYtolerance)*signP*pult;			//upper bracket is pult, but with opposite sign
 	  //...then don't change anything, just send in the regular values...
 	  CpUse = TpinUse;
@@ -280,7 +280,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  bump=Cp-TpinUse;
 	}
       else if(signP != signdy && signP != 0 && signP != CLastYieldDir)
-	//	Decleration yielding for a non-zero dy case, still flip the search direction:
+	//	Declaration yielding for a non-zero dy case, still flip the search direction:
 	{
 	  TpinUse = Cpalpha - pyield*signdy;
 	  Tyin = Cy + (TpinUse-Cp)/(-1.0*((Tp-Cp)/dy));
@@ -298,7 +298,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      TpinUse = Cpalpha + pyield*signdy;
 	      Tyin = Cy + (TpinUse-Cp)/((Tp-Cp)/dy);
 	    }
-	  pn1_a = Cp;											//lower bracket is current commited value of p
+	  pn1_a = Cp;											//lower bracket is current committed value of p
 	  if(signP == 0)
 	    {
 	      pn1_b = (1.0-0.5*PYtolerance)*CLastYieldDir*pult;			//upper bracket is pult
@@ -311,7 +311,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	}
 	
       // Bumping routine and update backstress
-      //If decleration yielding occured, bumped values have already been computed and this loop will not be entered.
+      //If declaration yielding occurred, bumped values have already been computed and this loop will not be entered.
       if((pn1_a < TpinUse && pn1_b > TpinUse) || (pn1_a > TpinUse && pn1_b < TpinUse)) // test to see if brackets are on opposite sides of yield surface
 	{
 	  pn1_a = TpinUse;
@@ -355,7 +355,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  Tp = pn1_a;
 	  TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	  TdyE    = TyeTotal-CyeTotalUse;
-	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	  if(dy==0.0 && TdyE == 0.0){
 	    Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	  }
@@ -368,7 +368,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  else{
 	    Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 	  }
-	  //check if decleration cause a decrease in force
+	  //check if declaration cause a decrease in force
 	  signP = sign(Tp-Cp);
 	  if(signP != signdy)
 	    {
@@ -386,7 +386,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  Tp = pn1_b;
 	  TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	  TdyE    = TyeTotal-CyeTotalUse;
-	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	  //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	  if(dy==0.0 && TdyE == 0.0){
 	    Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	  }
@@ -399,7 +399,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	  else{
 	    Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 	  }
-	  //check if decleration cause in decrease in force
+	  //check if declaration cause in decrease in force
 	  signP = sign(Tp-Cp);
 	  if(signP != signdy)
 	    {
@@ -424,7 +424,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      Tp = (1.0-0.5*PYtolerance)*TLastYieldDir*pult;	//keep consistent with other cases to avoid tiny fluctuations near the yield surface
 	      TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	      TdyE    = TyeTotal-CyeTotalUse;
-	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	      if(dy==0.0 && TdyE == 0.0){
 		Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	      }
@@ -437,7 +437,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      else{
 		Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 	      }
-	      //check if decleration cause in decrease in force
+	      //check if declaration cause in decrease in force
 	      signP = sign(Tp-Cp);
 	      if(signP != signdy)
 		{
@@ -468,7 +468,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      Tp = pn1_3;
 	      TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	      TdyE    = TyeTotal-CyeTotalUse;
-	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	      if(dy==0.0 && TdyE == 0.0){
 		Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	      }
@@ -481,7 +481,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      else{
 		Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 	      }
-	      //check if decleration causes in decrease in force
+	      //check if declaration causes in decrease in force
 	      signP = sign(Tp-Cp);
 	      if(signP != signdy)
 		{
@@ -502,7 +502,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      Tp = pn1_4;
 	      TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 	      TdyE    = TyeTotal-CyeTotalUse;
-	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+	      //for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 	      if(dy==0.0 && TdyE == 0.0){
 		Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 	      }
@@ -515,7 +515,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 	      else{
 		Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 	      }
-	      //check if decleration cause in decrease in force
+	      //check if declaration cause in decrease in force
 	      signP = sign(Tp-Cp);
 	      if(signP != signdy)
 		{
@@ -570,7 +570,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 		}
 		TyeTotal = (Tp-CpUse+ke*CyeTotalUse+dashpot*CyeTotalUse/tstep1+dashpot*dyELastUse/tstep2)/(ke+dashpot/tstep1);
 		TdyE    = TyeTotal-CyeTotalUse;
-		//for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occured)
+		//for tangent, consider entire increment (i.e. not just the post-bump behavior if first yield occurred)
 		if(dy==0.0 && TdyE == 0.0){
 		  Ttangent = 	1.0/((1.0/(ke)) + (1.0/(C*ke*((Tp-pult*sign(signdy))/(TpinUse-Tp)))));
 		}
@@ -583,7 +583,7 @@ PySimple3::setTrialStrain (double y, double yRate)
 		else{
 		  Ttangent = 	1.0/((1.0/(ke+dashpot*((1.0/tstep1)-(dyELast/(tstep2*TdyE))))) + (1.0/(C*ke*((Tp-pult*sign(Tp-Cp))/(TpinUse-Tp)))));
 		}
-		//check if decleration cause in decrease in force
+		//check if declaration cause in decrease in force
 		signP = sign(Tp-Cp);
 		if(signP != signdy)
 		  {

--- a/SRC/material/uniaxial/PY/QzSimple1.cpp
+++ b/SRC/material/uniaxial/PY/QzSimple1.cpp
@@ -297,7 +297,7 @@ void QzSimple1::getNearField(double zlast, double dz, double dz_old)
 	//
 	TNF_z = zlast + dz;
 
-	// Postive loading
+	// Positive loading
 	//
 	if(NFdz >= 0.0){
 		// Check if elastic using z < zinr

--- a/SRC/material/uniaxial/PY/QzSimple2.cpp
+++ b/SRC/material/uniaxial/PY/QzSimple2.cpp
@@ -297,7 +297,7 @@ void QzSimple2::getNearField(double zlast, double dz, double dz_old)
 	//
 	TNF_z = zlast + dz;
 
-	// Postive loading
+	// Positive loading
 	//
 	if(NFdz >= 0.0){
 		// Check if elastic using z < zinr

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -49,7 +49,7 @@ void* OPS_Pinching4Material()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata!=40 && numdata!=29) {
-	opserr << "WARNING: Insufficient arguements\n";
+	opserr << "WARNING: Insufficient arguments\n";
 	return 0;
     }
 
@@ -615,7 +615,7 @@ void Pinching4Material::SetEnvelope(void)
 	envlpNegStrain(5) = 1e+6*strain4n;
 	envlpNegStress(5) = (k2>0.0)? stress4n+k2*(envlpNegStrain(5) - strain4n):stress4n*1.1;
 	
-	// define crtical material properties
+	// define critical material properties
 	kElasticPos = envlpPosStress(1)/envlpPosStrain(1);	
 	kElasticNeg = envlpNegStress(1)/envlpNegStrain(1);
 

--- a/SRC/material/uniaxial/Pinching4Material.h
+++ b/SRC/material/uniaxial/Pinching4Material.h
@@ -26,7 +26,7 @@
 // Created: December 2001
 // Updated: September 2004
 //
-// Description: This file contains the class defination for 
+// Description: This file contains the class definition for 
 // Pinching material which is defined by 4 points on the positive and 
 // negative envelopes and a bunch of damage parameters. The material accounts for
 // 3 types of damage rules : Strength degradation, Stiffness degradation, 

--- a/SRC/material/uniaxial/ReinforcingSteel.cpp
+++ b/SRC/material/uniaxial/ReinforcingSteel.cpp
@@ -257,7 +257,7 @@ ReinforcingSteel::updateHardeningLoactionParams()
   // ultimate stress in natural stress-strain
   fsup=Esup-(esup-eshp)*Esup; 
   
-  // strain hardedned slope, yield plateu slope, and intersect
+  // strain hardedned slope, yield plateau slope, and intersect
   Eshp=Esh*pow(1.0+eshLoc,2.0)+fshp - Esup;
   Eypp=(fshp-fyp)/(eshp-eyp);
   fint = fyp-Eypp*eyp;
@@ -394,7 +394,7 @@ ReinforcingSteel::getInitialTangent(void) {
   return Esp;
 }
 
-/***************** path dependent bahavior methods ***********/
+/***************** path dependent behavior methods ***********/
 int 
 ReinforcingSteel::commitState(void) {
 #ifdef HelpDebugMat
@@ -560,8 +560,8 @@ ReinforcingSteel::getCopy(void)
   theCopy->esup         = esup;  // Natural Strain at Peak Stress
   theCopy->fsup         = fsup;  // Natural Peak Stress
   theCopy->Esup         = Esup;  // Natural Peak Stress Moduus
-  theCopy->Eypp         = Eypp;  // Natural Yield Plateu Modulus
-  theCopy->fint         = fint;  // Natural yield plateu intersect
+  theCopy->Eypp         = Eypp;  // Natural Yield Plateau Modulus
+  theCopy->fint         = fint;  // Natural yield plateau intersect
   theCopy->eyp          = eyp;   // Natural yield strain
   theCopy->fyp          = fyp;   // Natural yield stress
 
@@ -1374,7 +1374,7 @@ ReinforcingSteel::Rule1(int res)
   return res;
 }
 
-// Rule 2: Compresion Envelope Branch
+// Rule 2: Compression Envelope Branch
 int
 ReinforcingSteel::Rule2(int res)
 {
@@ -1478,7 +1478,7 @@ ReinforcingSteel::Rule2(int res)
 int
 ReinforcingSteel::Rule3(int res)
 {
-  if (TStrain-CStrain > 0.0) {	// reversal from brance 
+  if (TStrain-CStrain > 0.0) {	// reversal from branch 
 	if(Temin > CStrain-Teo_n) Temin=CStrain-Teo_n;
 
 	Tea=CStrain;

--- a/SRC/material/uniaxial/ReinforcingSteel.h
+++ b/SRC/material/uniaxial/ReinforcingSteel.h
@@ -103,8 +103,8 @@ class ReinforcingSteel : public UniaxialMaterial
   double esup;  // natural Strain at Peak Stress
   double fsup;  // natural Peak Stress
   double Esup;  // natural peak stress Modulus
-  double Eypp;  // natural Yield Plateu Modulus
-  double fint;  // natural Stress yield plateu intersect
+  double Eypp;  // natural Yield Plateau Modulus
+  double fint;  // natural Stress yield plateau intersect
   double eyp;   // natural strain at yield
   double fyp;   // natural yield stress
 
@@ -142,7 +142,7 @@ class ReinforcingSteel : public UniaxialMaterial
   double RC2;
   double RC3;
 
-  // Menegotto-Pinto Equation paramenters
+  // Menegotto-Pinto Equation parameters
   double TR;
   double Tfch;
   double TQ;
@@ -158,7 +158,7 @@ class ReinforcingSteel : public UniaxialMaterial
   double rE1;
   double rE2;
 
-  // Converged Menegotto-Pinto Equation paramenters
+  // Converged Menegotto-Pinto Equation parameters
   double CR[LastRule_RS/2+1];
   double Cfch[LastRule_RS/2+1];
   double CQ[LastRule_RS/2+1];

--- a/SRC/material/uniaxial/SAWSMaterial.cpp
+++ b/SRC/material/uniaxial/SAWSMaterial.cpp
@@ -144,7 +144,7 @@ int
 SAWSMaterial::setTrialStrain(double strain, double strainRate)
 {
 
-  // Set the initial parameters from the commited stage
+  // Set the initial parameters from the committed stage
   DISPL  = strain;
   LPATH  = cLPATH;
   LPPREV = cLPPREV;

--- a/SRC/material/uniaxial/STEELDR.f
+++ b/SRC/material/uniaxial/STEELDR.f
@@ -136,7 +136,7 @@ c
 
 c	---------------------------------
 
-c     Check whether low-cycle fatigue induced rupture has occured:
+c     Check whether low-cycle fatigue induced rupture has occurred:
 c
       if(d(14).gt.1.d-8.and.
      *hr(30).lt.-99.d0) then

--- a/SRC/material/uniaxial/SelfCenteringMaterial.cpp
+++ b/SRC/material/uniaxial/SelfCenteringMaterial.cpp
@@ -44,7 +44,7 @@ void* OPS_SelfCenteringMaterial()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 5) {
-	opserr << "WARNING: Insufficient arguements\n";
+	opserr << "WARNING: Insufficient arguments\n";
 	opserr << "Want: uniaxialMaterial SelfCentering tag? k1? k2? ";
 	opserr << "ActF? beta? <SlipDef? BearDef? rBear?>" << endln;
 	return 0;

--- a/SRC/material/uniaxial/ShearPanelMaterial.cpp
+++ b/SRC/material/uniaxial/ShearPanelMaterial.cpp
@@ -630,7 +630,7 @@ void ShearPanelMaterial::SetEnvelope(void)
 	envlpNegStrain(5) = 1e+6*strain4n;
 	envlpNegStress(5) = (k2>0.0)? stress4n+k2*(envlpNegStrain(5) - strain4n):stress4n*1.1;
 	
-	// define crtical material properties
+	// define critical material properties
 	kElasticPos = envlpPosStress(1)/envlpPosStrain(1);	
 	kElasticNeg = envlpNegStress(1)/envlpNegStrain(1);
 

--- a/SRC/material/uniaxial/ShearPanelMaterial.h
+++ b/SRC/material/uniaxial/ShearPanelMaterial.h
@@ -25,7 +25,7 @@
 // Written: NM (nmitra@u.washington.edu) 
 // Created: December 2005
 //
-// Description: This file contains the class defination for 
+// Description: This file contains the class definition for 
 // shear-panel material. The file is similar to the Pinching4 material but has a 
 // new strength damage calculations.
 

--- a/SRC/material/uniaxial/StainlessECThermal.cpp
+++ b/SRC/material/uniaxial/StainlessECThermal.cpp
@@ -164,7 +164,7 @@ StainlessECThermal::StainlessECThermal(int tag, int grade, double Fy, double E, 
 #ifdef _DEBUG
 		 // opserr << "  CstrainINI:  " << Cstrain << "  CStressINI: " << Cstress << endln;
 #endif
-		  // need to initiliase Tstrian? Tstress?? or they will be assigned in the setTrial(), setTrialStrain()anyway	  
+		  // need to initialise Tstrian? Tstress?? or they will be assigned in the setTrial(), setTrialStrain()anyway	  
 	  }
 	  else
 		  epsini = 0.0;
@@ -237,11 +237,11 @@ double StainlessECThermal::determineYieldSurface(double sigini)  // Added by Mia
 
 	else if (fabsSigini = fyT)
 	{
-		if (sigini > 0)   // positve/tensile inital stress
+		if (sigini > 0)   // positive/tensile initial stress
 		{
 			epsini = 0.02;
 		}
-		else {//negative/compressive inital stress
+		else {//negative/compressive initial stress
 			epsini = -0.02;
 		}
 	}
@@ -606,7 +606,7 @@ StainlessECThermal::getElongTangent(double TempT, double &ET, double &Elong, dou
 #ifdef _DEBUG
 	//opserr<<", TempT:"<<TempT<< " fy: "<< fy <<" E0T:  "<< E0<<endln;
 #endif
-// caculation of thermal elongation
+// calculation of thermal elongation
 ///*
   if (TempT <= 1)
 	{

--- a/SRC/material/uniaxial/StainlessECThermal.h
+++ b/SRC/material/uniaxial/StainlessECThermal.h
@@ -145,7 +145,7 @@ class StainlessECThermal : public UniaxialMaterial
     // Calculates the trial state variables based on the trial strain
     void determineTrialState (double dStrain);
 	//
-	// determine the yield surface for the residual/inital stress, convert inital stress to inital strain
+	// determine the yield surface for the residual/initial stress, convert initial stress to initial strain
 	double determineYieldSurface(double sigini);
 	//
     // Determines if a load reversal has occurred based on the trial strain

--- a/SRC/material/uniaxial/Steel02Thermal.cpp
+++ b/SRC/material/uniaxial/Steel02Thermal.cpp
@@ -19,7 +19,7 @@
 ** ****************************************************************** */
  
 //This file contains the definition of material Steel02Thermal, which is
-// modified from Steel02 by adding fuctions for considering temperature
+// modified from Steel02 by adding functions for considering temperature
 // dependent material properties
 
 //Modified by:  Jian Zhang(j.zhang@ed.ac.uk)---------07,2010// 
@@ -496,7 +496,7 @@ Steel02Thermal::getElongTangent(double TempT, double&ET, double&Elong, double Te
       opserr << "the temperature is invalid\n"; 
   } 
 
-  // caculation of thermal elongation of reinforcing steel. JZ
+  // calculation of thermal elongation of reinforcing steel. JZ
  //opserr<<TempT<<endln;
 	  if (TempT <= 1) {
 		  ThermalElongation = TempT * 1.2164e-5;

--- a/SRC/material/uniaxial/SteelECThermal.cpp
+++ b/SRC/material/uniaxial/SteelECThermal.cpp
@@ -293,7 +293,7 @@ void SteelECThermal::determineTrialState (double dStrain)
 	  double BT = pow(CT*(EpsiYT-EpsiPT)*E0+CT*CT, 0.5);
 	  double AT = pow((EpsiYT-EpsiPT)*(EpsiYT-EpsiPT+CT/E0),0.5);
 	
-	  //Calculating the POSITIVE stress accoring to EC3
+	  //Calculating the POSITIVE stress according to EC3
       double fabsTstrain = fabs(Tstrain);
 	 // opserr<<"fabsTstrain is: "<< fabsTstrain <<" at Temp "<<Ttemp<<endln;
 	 // opserr<<"EpsiPT: "<<EpsiPT<< " fp: "<< fp <<" E0: "<<E0<<endln;
@@ -480,7 +480,7 @@ SteelECThermal::getElongTangent(double TempT, double &ET, double &Elong, double 
 	//opserr<<", TempT:"<<TempT<< " fy: "<< fy<< " fp: "<< fp <<" E0T:  "<< E0<<endln;
 #endif
 
-  // caculation of thermal elongation of reinforcing steel. JZ
+  // calculation of thermal elongation of reinforcing steel. JZ
 ///*	
 	if (TempT <= 1) {
 		  ThermalElongation = TempT * 1.2164e-5;

--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -1233,7 +1233,7 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
     else if (strcmp(argv[1], "Concrete07") == 0) {
       // Check to see if there are enough arquements
       if (argc < 11) {
-	opserr << "WARNING: Insufficient arguements\n";
+	opserr << "WARNING: Insufficient arguments\n";
 	printCommand(argc, argv);
 	opserr << "Want: uniaxialMaterial Concrete07 tag? fpc? epsc0? Ec? fpt? epst0? xcrp? xcrn? r?\n";
 	return TCL_ERROR;

--- a/SRC/material/uniaxial/UniaxialMaterial.cpp
+++ b/SRC/material/uniaxial/UniaxialMaterial.cpp
@@ -421,7 +421,7 @@ UniaxialMaterial::commitSensitivity(double strainSensitivity, int gradIndex, int
 double
 UniaxialMaterial::getInitialTangent (void)
 {
-	opserr << "UniaxialMaterial::getInitialTangent() -- this mehtod " << endln
+	opserr << "UniaxialMaterial::getInitialTangent() -- this method " << endln
 		<< " is not implemented for the selected material. " << endln;
 	return 0.0;
 }

--- a/SRC/material/uniaxial/ViscousDamper.cpp
+++ b/SRC/material/uniaxial/ViscousDamper.cpp
@@ -210,8 +210,8 @@ ViscousDamper::setTrialStrain(double strain, double strainRate)
     
     double dStrain = (strain - Tstrain);
     
-    if ((fd0 > 0) && (Tstress < 0)) {  //from negtive to positive
-      Tpugr = Tstrain + dStrain * fabs(fd0)/fabs(fd0 - Tstress);  // aproximate displacement for gap initiation
+    if ((fd0 > 0) && (Tstress < 0)) {  //from negative to positive
+      Tpugr = Tstrain + dStrain * fabs(fd0)/fabs(fd0 - Tstress);  // approximate displacement for gap initiation
       Tnugr = 0.;
       
       if (fabs(strain-Tpugr) < LGap) {
@@ -221,7 +221,7 @@ ViscousDamper::setTrialStrain(double strain, double strainRate)
     
     if ((fd0 < 0) && (Tstress > 0)) {  //from positive to negative
       
-      Tnugr = Tstrain + dStrain * fabs(fd0)/fabs(fd0 - Tstress);  // aproximate displacement for gap initiation
+      Tnugr = Tstrain + dStrain * fabs(fd0)/fabs(fd0 - Tstress);  // approximate displacement for gap initiation
       Tpugr = 0.;
       
       if (fabs(strain-Tnugr) < LGap) {
@@ -231,7 +231,7 @@ ViscousDamper::setTrialStrain(double strain, double strainRate)
     
     // After gap inititon
     
-    if  ((fabs(Tpugr) > 0.) && (Tstress == 0)) {   //from negtive to positive
+    if  ((fabs(Tpugr) > 0.) && (Tstress == 0)) {   //from negative to positive
       
       if ((strain > Tpugr) && ((strain-Tpugr) < LGap)) {
 	fd0 = 0.;

--- a/SRC/material/uniaxial/limitState/LimitStateMaterial.cpp
+++ b/SRC/material/uniaxial/limitState/LimitStateMaterial.cpp
@@ -40,7 +40,7 @@
 // Option only available for 3 point specification. Behaves 
 // same as HystereticMaterial if no limit curve specified.
 //
-// All code specific to LimitStateMaterial seperated by ////////////////
+// All code specific to LimitStateMaterial separated by ////////////////
 
 #include <stdlib.h>
 
@@ -779,7 +779,7 @@ LimitStateMaterial::commitState(void)
 		////////////////////
 		// Check state of element relative to the limit state surface.
 		// Note that steps should be kept small to minimize error
-		// caused by commited state being far beyond limit state surface
+		// caused by committed state being far beyond limit state surface
 		int stateFlag = theCurve->checkElementState(Cstress);
 
 		// If beyond limit state surface for first time,
@@ -791,7 +791,7 @@ LimitStateMaterial::commitState(void)
 
 			// display warning if Cstrain = max strain experienced.
 			if (Cstrain != CrotMax && Cstrain != CrotMin) {
-//				g3ErrorHandler->warning("WARNING LimitStateMaterial - failure occured while not at peak in displacement",
+//				g3ErrorHandler->warning("WARNING LimitStateMaterial - failure occurred while not at peak in displacement",
 //						"History variables may not be correct. Need to reset history variables in commitState");
 			}
 
@@ -880,7 +880,7 @@ LimitStateMaterial::revertToStart(void)
 	Ttangent = E1p;
 
 	/////////////////
-	// set commited stateFlag to prior to failure
+	// set committed stateFlag to prior to failure
 	CstateFlag = 0;
 	// set axial load loss to zero
 	Ploss = 0.0;
@@ -1280,7 +1280,7 @@ LimitStateMaterial::getNewBackbone(int flag)
 		}
 		
 		// set new third corner point
-		if (flag == 3 && curveType == 1) { //if comming off surface
+		if (flag == 3 && curveType == 1) { //if coming off surface
 			if (Cstress > 0.0) {
 				mom3p = 10*mom2p;
 				//rot3p = rot2p + (mom3p-mom2p)/Eelasticp;

--- a/SRC/material/uniaxial/limitState/LimitStateMaterial.h
+++ b/SRC/material/uniaxial/limitState/LimitStateMaterial.h
@@ -36,7 +36,7 @@
 // Option only available for 3 point specification. Behaves 
 // same as HystereticMaterial if no limit curve specified.
 //
-// All code specific to LimitStateMaterial seperated by ////////////////
+// All code specific to LimitStateMaterial separated by ////////////////
 
 #ifndef LimitStateMaterial_h
 #define LimitStateMaterial_h

--- a/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.h
+++ b/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.h
@@ -29,7 +29,7 @@
 //
 // Description: This file contains the class definition for 
 // ShearCurve. Defines the curve used by LimitStateMaterial  
-// to determine if shear failure has occured according to empirical 
+// to determine if shear failure has occurred according to empirical 
 // drift capacity model by Elwood (2002).
 
 

--- a/SRC/material/uniaxial/snap/Bilinear.cpp
+++ b/SRC/material/uniaxial/snap/Bilinear.cpp
@@ -119,7 +119,7 @@ Bilinear::Bilinear(int tag, Vector inputParam  ,DamageModel *strength,DamageMode
 	
 	if ( capDispPos < fyieldPos/elstk || capDispNeg > fyieldNeg/elstk )
     {
-		opserr << "Error: Bilinear::Bilinear  : Capping brach must be located outside the yield criteria\n" << "\a";
+		opserr << "Error: Bilinear::Bilinear  : Capping branch must be located outside the yield criteria\n" << "\a";
 		ErrorFlag =1;
     }
 	

--- a/SRC/material/uniaxial/snap/CloughHenry.h
+++ b/SRC/material/uniaxial/snap/CloughHenry.h
@@ -20,7 +20,7 @@
                                                                         
 // CloughHenry.h: based on Clough.h/.cpp, slight modification
 //
-// Orginal Clough Written: Arash Altoontash,
+// Original Clough Written: Arash Altoontash,
 // Modification: fmk
 //
 // Purpose: This file contains the implementation for the CloughHenry class.

--- a/SRC/material/uniaxial/snap/PinchingDamage.cpp
+++ b/SRC/material/uniaxial/snap/PinchingDamage.cpp
@@ -686,7 +686,7 @@ int PinchingDamage::setTrialStrain( double d, double strainRate)
 		flagDeg = 0;
 	}
 	
-	// Relationship between basic variables and hstory array for next cycle
+	// Relationship between basic variables and history array for next cycle
 	hsTrial[0] = d;
 	hsTrial[1] = f;
 	hsTrial[2] = ek;


### PR DESCRIPTION
Typos found via `codespell`
I made the commit a little more manageable to review. 