### PR TITLE
  Adding JSON print options to some materials and elements.

### DIFF
--- a/SRC/element/truss/N4BiaxialTruss.cpp
+++ b/SRC/element/truss/N4BiaxialTruss.cpp
@@ -1164,6 +1164,14 @@ N4BiaxialTruss::Print(OPS_Stream &s, int flag)
 		s << endln;
 		s << this->getTag()+1 << "  " << strain2 << "  ";
 		s << force2 << endln;
+	} else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		s << "\t\t\t{";
+		s << "\"name\": " << this->getTag() << ", ";
+		s << "\"type\": \"N4BiaxialTruss\", ";
+		s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << ", " << connectedExternalNodes(2) << ", " << connectedExternalNodes(3) << "], ";
+		s << "\"A\": " << A << ", ";
+		s << "\"massperlength\": " << rho << ", ";
+		s << "\"material\": \"" << theMaterial_1->getTag() << "\"}";
 	}
 }
 

--- a/SRC/element/truss/Truss2.cpp
+++ b/SRC/element/truss/Truss2.cpp
@@ -1107,7 +1107,7 @@ void
         s << "\t\t\t{";
         s << "\"name\": " << this->getTag() << ", ";
         s << "\"type\": \"Truss2\", ";
-        s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
+        s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << ", " << connectedExternalOtherNodes(0) << ", " << connectedExternalOtherNodes(1) << "], ";
         s << "\"A\": " << A << ", ";
         s << "\"massperlength\": " << rho << ", ";
         s << "\"material\": \"" << theMaterial->getTag() << "\"}";

--- a/SRC/element/twoNodeLink/TwoNodeLink.cpp
+++ b/SRC/element/twoNodeLink/TwoNodeLink.cpp
@@ -1085,7 +1085,7 @@ void TwoNodeLink::Print(OPS_Stream &s, int flag)
                 else if (j == 2 && i < 2)
                     s << trans(i, j) << "], [";
                 else if (j == 2 && i == 2)
-                    s << trans(i, j) << "]]";
+                    s << trans(i, j) << "]],";
             }
         }
         s << "\"addRayleigh\": " << addRayleigh << ", ";

--- a/SRC/material/uniaxial/ConcretewBeta.cpp
+++ b/SRC/material/uniaxial/ConcretewBeta.cpp
@@ -462,7 +462,33 @@ int ConcretewBeta::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker
 
 void ConcretewBeta::Print(OPS_Stream &s, int flag)
 {
-	s << "ConcretewBeta, tag: " << this->getTag() << endln;
+	if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		s << "\t\t\t{";
+		s << "\"name\": \"" << this->getTag() << "\", ";
+		s << "\"type\": \"ConcretewBeta\", ";
+		s << "\"fpc\": " << fpc << ", ";
+		s << "\"ec0\": " << ec0 << ", ";
+		s << "\"fcint\": " << fcint << ", ";
+		s << "\"ecint\": " << ecint << ", ";
+		s << "\"fcres\": " << fcres << ", ";
+		s << "\"ecres\": " << ecres << ", ";
+		s << "\"ft\": " << fct << ", ";
+		s << "\"ftint\": " << ftint << ", ";
+		s << "\"etint\": " << etint << ", ";
+		s << "\"ftres\": " << ftres << ", ";
+		s << "\"etres\": " << etres << ", ";
+		s << "\"lambda\": " << lambda << ", ";
+		s << "\"alpha\": " << alpha << ", ";
+		s << "\"bint\": " << bint << ", ";
+		s << "\"ebint\": " << etbint << ", ";
+		s << "\"bres\": " << bres << ", ";
+		s << "\"ebres\": " << etbres << ", ";
+		s << "\"E\": " << E0 << ", ";
+		s << "\"fcc\": " << fcc << ", ";
+		s << "\"ecc\": " << ecc << "}";
+	} else {
+		s << "ConcretewBeta, tag: " << this->getTag() << endln;
+	}
 }
 
 

--- a/SRC/material/uniaxial/ElasticPPMaterial.cpp
+++ b/SRC/material/uniaxial/ElasticPPMaterial.cpp
@@ -325,7 +325,9 @@ ElasticPPMaterial::Print(OPS_Stream &s, int flag)
 		s << "\"name\": \"" << this->getTag() << "\", ";
 		s << "\"type\": \"ElasticPPMaterial\", ";
 		s << "\"E\": " << E << ", ";
-		s << "\"epsp\": " << ep << "}";
+		s << "\"epsyp\": " << fyp/E << ", ";
+		s << "\"epsyn\": " << fyn/E << ", ";
+		s << "\"eps0\": " << ezero << "}";
 	}
 }
 

--- a/SRC/material/uniaxial/InitStrainMaterial.cpp
+++ b/SRC/material/uniaxial/InitStrainMaterial.cpp
@@ -250,9 +250,17 @@ InitStrainMaterial::recvSelf(int cTag, Channel &theChannel,
 void 
 InitStrainMaterial::Print(OPS_Stream &s, int flag)
 {
-  s << "InitStrainMaterial tag: " << this->getTag() << endln;
-  s << "\tMaterial: " << theMaterial->getTag() << endln;
-  s << "\tinitital strain: " << epsInit << endln;
+	if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		s << "\t\t\t{";
+		s << "\"name\": \"" << this->getTag() << "\", ";
+		s << "\"type\": \"InitStrainMaterial\", ";
+		s << "\"Material\": " << theMaterial->getTag() << ", ";
+		s << "\"initialStrain\": " << epsInit <<  "}";
+	} else {
+		s << "InitStrainMaterial tag: " << this->getTag() << endln;
+		s << "\tMaterial: " << theMaterial->getTag() << endln;
+		s << "\tinitital strain: " << epsInit << endln;
+	}
 }
 
 int 


### PR DESCRIPTION
Adding JSON print option for N4BiaxialTruss, ConcretewBeta and InitStrainMaterial.
Modifications / fixes : 
- Truss2                -> add all four nodes to JSON output
- ElastiPPMaterial -> replace "current plastic strain (ep) " with plastic strain values set when creating material (epsyN, epsyP, eps0)
- TwoNodeLink     -> add missing comma required for JSON format compatibility