### PR TITLE
Fix PlainStrain typo in UCSD UP elements

### DIFF
--- a/SRC/element/UP-ucsd/BBarFourNodeQuadUP.cpp
+++ b/SRC/element/UP-ucsd/BBarFourNodeQuadUP.cpp
@@ -94,7 +94,7 @@ void* OPS_BBarFourNodeQuadUP()
     }
 
     return new BBarFourNodeQuadUP(tags[0],tags[1],tags[2],tags[3],tags[4],
-				  *mat,"PlainStrain",thk,data[0],data[1],data[2],data[3],
+				  *mat,"PlaneStrain",thk,data[0],data[1],data[2],data[3],
 				  opt[0],opt[1],opt[2]);
 }
 

--- a/SRC/element/UP-ucsd/FourNodeQuadUP.cpp
+++ b/SRC/element/UP-ucsd/FourNodeQuadUP.cpp
@@ -91,7 +91,7 @@ void* OPS_FourNodeQuadUP()
     }
 
     return new FourNodeQuadUP(tags[0],tags[1],tags[2],tags[3],tags[4],
-			      *mat,"PlainStrain",thk,data[0],data[1],data[2],data[3],
+			      *mat,"PlaneStrain",thk,data[0],data[1],data[2],data[3],
 			      opt[0],opt[1],opt[2]);
 }
 

--- a/SRC/element/UP-ucsd/Nine_Four_Node_QuadUP.cpp
+++ b/SRC/element/UP-ucsd/Nine_Four_Node_QuadUP.cpp
@@ -92,7 +92,7 @@ void* OPS_NineFourNodeQuadUP()
 
     return new NineFourNodeQuadUP(tags[0],tags[1],tags[2],tags[3],tags[4],
 				  tags[5],tags[6],tags[7],tags[8],tags[9],
-				  *mat,"PlainStrain",thk,data[0],data[1],data[2],data[3],
+				  *mat,"PlaneStrain",thk,data[0],data[1],data[2],data[3],
 				  opt[0],opt[1]);
 }
 


### PR DESCRIPTION
I have made a forum post on the matter: http://opensees.berkeley.edu/community/viewtopic.php?f=4&t=64858 
In method NDMaterial * PressureIndependMultiYield::getCopy (const char *code) at file PressureIndependMultiYield.cpp the value "**PlaneStrain**" is expected for the code argument in 2D case. Yet the constructor of NineFourNodeQuadUP is being called in method void* OPS_NineFourNodeQuadUP() with the value "**PlainStrain**" at file Nine_Four_Node_QuadUP.cpp and "PlainStrain" is passed as argument in the getCopy call. The string "PlainStrain" is used at two more UP elements. 