### PR TITLE
fix a bug in CircPatch.cpp

### DIFF
--- a/SRC/material/section/repres/patch/CircPatch.cpp
+++ b/SRC/material/section/repres/patch/CircPatch.cpp
@@ -51,9 +51,11 @@ void* OPS_CircPatch()
     double data[6];
     numData = 6;
     static Vector centerPos(2);
+    /*centerPos(0) = data[0];
+    centerPos(1) = data[1];*/
+    if(OPS_GetDoubleInput(&numData,&data[0]) < 0) return 0;
     centerPos(0) = data[0];
     centerPos(1) = data[1];
-    if(OPS_GetDoubleInput(&numData,&data[0]) < 0) return 0;
 
     return new CircPatch(idata[0],idata[1],idata[2],centerPos,
 			 data[2],data[3],data[4],data[5]);


### PR DESCRIPTION
When I build the cross-section of fibers, I output the model file in-json format and draw the cross-section of fibers by python. I  find that the center coordinate of the semi-circular cross-section is always at the origin and has nothing to do with the center coordinate given by me. 
I solved the problem. Please check it.
Your reply is expected.