### PR TITLE
OpenSeesPy development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,22 @@ tk:
 	@$(CD) $(FE)/tcl;  $(MAKE) tk;
 	@$(CD) $(FE)/modelbuilder/tcl;  $(MAKE) tk;
 
+OpenSeesPy: python
+
+python: 
+ifdef MKDIR
+	$(MKDIR) $(HOME)/bin
+	$(MKDIR) $(HOME)/lib
+endif
+	@( \
+	for f in $(DIRS); \
+	do \
+		$(CD) $$f; \
+		$(MAKE); \
+		$(CD) ..; \
+	done );
+	@$(ECHO) LIBRARIES BUILT ... NOW LINKING OpenSeesPy Module;
+	@$(CD) $(FE)/interpreter; $(MAKE) pythonmodule;
 
 libs:
 	@( \

--- a/SRC/handler/StandardStream.cpp
+++ b/SRC/handler/StandardStream.cpp
@@ -30,9 +30,9 @@ using std::cerr;
 using std::ios;
 using std::setiosflags;
 
-StandardStream::StandardStream(int indent)
+StandardStream::StandardStream(int indent, bool echo)
   :OPS_Stream(OPS_STREAM_TAGS_FileStream), 
-   fileOpen(0), echoApplication(true),  indentSize(indent), numIndent(-1)
+   fileOpen(0), echoApplication(echo),  indentSize(indent), numIndent(-1)
 {
   if (indentSize < 1) indentSize = 1;
   indentString = new char[indentSize+1];

--- a/SRC/handler/StandardStream.h
+++ b/SRC/handler/StandardStream.h
@@ -33,7 +33,7 @@ using std::ofstream;
 class StandardStream : public OPS_Stream
 {
  public:
-  StandardStream(int indentSize=2);
+  StandardStream(int indentSize=2, bool echo=true);
   ~StandardStream();
 
   int setFile(const char *fileName, openMode mode = OVERWRITE, bool echoApplication = true);

--- a/SRC/interpreter/Makefile
+++ b/SRC/interpreter/Makefile
@@ -38,6 +38,8 @@ python:  $(PythonOBJS)
 
 OBJSm = OpenSeesCommandsPython.o OpenSeesUniaxialMaterialCommands.o PythonModelBuilder.o PythonAnalysisBuilder.o
 
+LINKFLAGS = -Wl,-rpath,\$$ORIGIN/lib
+
 pythonmodule: $(PythonModuleOBJS)
 	$(RM) $(RMFLAGS) opensees.so;
 	@( \

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -43,7 +43,6 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include "OpenSeesCommands.h"
 #include <OPS_Globals.h>
 #include <elementAPI.h>
-#include <StandardStream.h>
 #include <UniaxialMaterial.h>
 #include <NDMaterial.h>
 #include <SectionForceDeformation.h>
@@ -104,10 +103,6 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 // active object
 static OpenSeesCommands* cmds = 0;
-
-// define opserr
-static StandardStream sserr;
-OPS_Stream *opserrPtr = &sserr;
 
 OpenSeesCommands::OpenSeesCommands(DL_Interpreter* interp)
     :interpreter(interp), theDomain(0), ndf(0), ndm(0),

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -259,6 +259,7 @@ int OPS_basicForce();
 int OPS_basicStiffness();
 int OPS_version();
 int OPS_maxOpenFiles();
+int OPS_logFile();
 // Sensitivity:BEGIN /////////////////////////////////////////////
 int OPS_sensNodeDisp();
 int OPS_sensNodeVel();

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -2503,6 +2503,43 @@ int OPS_version()
     return 0;
 }
 
+int OPS_logFile()
+{
+    if (OPS_GetNumRemainingInputArgs() < 1) { 
+	opserr << "WARNING logFile fileName? - no filename supplied\n";
+	return -1;
+    }
+    openMode mode = OVERWRITE;
+    bool echo = true;
+
+    const char* filename = OPS_GetString();
+    if (strcmp(filename, "Invalid String Input!") == 0) {
+	opserr << "WARNING: invalid string input\n";
+	return -1;
+    }
+
+    while (OPS_GetNumRemainingInputArgs() > 0) {
+
+	const char* opt = OPS_GetString();
+	
+	if (strcmp(opt,"-append") == 0) {
+	    mode = APPEND;
+	} else if (strcmp(opt,"-noEcho") == 0) {
+	    echo = false;
+	}
+    }
+
+    if (opserr.setFile(filename, mode, echo) < 0) {
+	opserr << "WARNING logFile " << filename << " failed to set the file\n";
+	return -1;
+    }
+
+    // const char *pwd = getInterpPWD(interp);  
+    // simulationInfo.addOutputFile(argv[1], pwd);
+
+    return 0;
+}
+
 // Sensitivity:BEGIN /////////////////////////////////////////////
 int OPS_sensNodeDisp()
 {

--- a/SRC/interpreter/OpenSeesReliabilityCommands.cpp
+++ b/SRC/interpreter/OpenSeesReliabilityCommands.cpp
@@ -448,3 +448,9 @@ int OPS_randomVariable()
     return 0;
 
 }
+
+
+int OPS_probabilityTransformation()
+{
+    return 0;
+}

--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -42,6 +42,11 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 //
 
 #include "PythonModule.h"
+#include "PythonStream.h"
+
+// define opserr
+static PythonStream sserr;
+OPS_Stream *opserrPtr = &sserr;
 
 
 PythonModule::PythonModule()
@@ -280,11 +285,14 @@ initopensees(void)
         INITERROR;
     struct module_state *st = GETSTATE(module);
 
-    st->error = PyErr_NewException("opensees.Error", NULL, NULL);
+    st->error = PyErr_NewException("opensees.error", NULL, NULL);
+    PyObject* ops_msg = PyErr_NewException("opensees.msg", NULL, NULL);
     if (st->error == NULL) {
         Py_DECREF(module);
         INITERROR;
     }
+
+    sserr.setError(st->error,ops_msg);
 
     Py_AtExit(cleanupFunc);
 

--- a/SRC/interpreter/PythonStream.h
+++ b/SRC/interpreter/PythonStream.h
@@ -1,0 +1,156 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+                                                                        
+// $Revision$
+// $Date$
+
+#ifndef _PythonStream
+#define _PythonStream
+
+#include <StandardStream.h>
+#include <Python.h>
+#include <sstream>
+
+class PythonStream : public StandardStream
+{
+public:
+    PythonStream(int indentSize=2, bool echo=false)
+	:StandardStream(indentSize,echo), error(0), message(0), msg() {}
+    ~PythonStream() {}
+    
+    void setError(PyObject* err, PyObject* msg) {
+	error = err;
+	message = msg;
+    }
+
+    OPS_Stream& operator<<(char c) {
+	err_out(c);
+	return this->StandardStream::operator<<(c);
+    }
+    
+    OPS_Stream& operator<<(unsigned char c){
+	err_out(c);
+	return this->StandardStream::operator<<(c);
+    }
+    
+    OPS_Stream& operator<<(signed char c){
+	err_out(c);
+	return this->StandardStream::operator<<(c);
+    }
+    
+    OPS_Stream& operator<<(const char *s){
+	err_out(s);
+	return this->StandardStream::operator<<(s);
+    }
+    
+    OPS_Stream& operator<<(const unsigned char *s){
+	err_out(s);
+	return this->StandardStream::operator<<(s);
+    }
+    
+    OPS_Stream& operator<<(const signed char *s){
+	err_out(s);
+	return this->StandardStream::operator<<(s);
+    }
+    
+    OPS_Stream& operator<<(int n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(unsigned int n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(long n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(unsigned long n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(short n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(unsigned short n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(bool b){
+	err_out(b);
+	return this->StandardStream::operator<<(b);
+    }
+    
+    OPS_Stream& operator<<(double n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+    
+    OPS_Stream& operator<<(float n){
+	err_out(n);
+	return this->StandardStream::operator<<(n);
+    }
+
+    OPS_Stream& operator<<(const void *p) {
+	if (p!=0) {
+	    return this->StandardStream::operator<<(p);
+	}
+	if (msg.empty()) {
+	    msg = "See opensees.msg\n";
+	}
+	PyErr_SetString(error, msg.c_str());
+	return *this;
+    }
+
+private:
+
+    template<class T>
+    void err_out(T err) {
+
+	std::stringstream ss;
+	ss << err;
+	msg += ss.str();
+
+	std::size_t pos = msg.find('\n');
+	while (pos != std::string::npos) {
+	    std::string sub = msg.substr(0, pos+1);
+	    if (sub.empty()==false && sub!="\n") {
+		PyErr_SetString(message, sub.c_str());
+		PyErr_Print();
+	    }
+
+	    msg = msg.substr(pos+1);
+	    pos = msg.find('\n');
+	}
+    }
+
+    PyObject* error;
+    PyObject* message;
+    std::string msg;
+};
+
+#endif

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1532,6 +1532,15 @@ static PyObject *Py_ops_setNumThreads(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_logFile(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_logFile() < 0) return NULL;
+
+    return wrapper->getResults();
+}
+
 /////////////////////////////////////////////////
 ////////////// Add Python commands //////////////
 /////////////////////////////////////////////////
@@ -1693,6 +1702,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("probabilityTransformation", &Py_ops_probabilityTransformation);
     addCommand("getNumThreads", &Py_ops_getNumThreads);
     addCommand("setNumThreads", &Py_ops_setNumThreads);
+    addCommand("logFile", &Py_ops_logFile);
 
     PyMethodDef method = {NULL,NULL,0,NULL};
     methodsOpenSees.push_back(method);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -149,7 +149,10 @@ static PyObject *Py_ops_UniaxialMaterial(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_UniaxialMaterial() < 0) return NULL;
+    if (OPS_UniaxialMaterial() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -158,7 +161,10 @@ static PyObject *Py_ops_testUniaxialMaterial(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_testUniaxialMaterial() < 0) return NULL;
+    if (OPS_testUniaxialMaterial() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -167,7 +173,10 @@ static PyObject *Py_ops_setStrain(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setStrain() < 0) return NULL;
+    if (OPS_setStrain() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -176,7 +185,10 @@ static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getStrain() < 0) return NULL;
+    if (OPS_getStrain() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -185,7 +197,10 @@ static PyObject *Py_ops_getStress(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getStress() < 0) return NULL;
+    if (OPS_getStress() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -194,7 +209,10 @@ static PyObject *Py_ops_getTangent(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getTangent() < 0) return NULL;
+    if (OPS_getTangent() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -203,7 +221,10 @@ static PyObject *Py_ops_getDampTangent(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getDampTangent() < 0) return NULL;
+    if (OPS_getDampTangent() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -212,7 +233,10 @@ static PyObject *Py_ops_wipe(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_wipe() < 0) return NULL;
+    if (OPS_wipe() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -221,7 +245,10 @@ static PyObject *Py_ops_model(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_model() < 0) return NULL;
+    if (OPS_model() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -230,7 +257,10 @@ static PyObject *Py_ops_node(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Node() < 0) return NULL;
+    if (OPS_Node() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -239,7 +269,10 @@ static PyObject *Py_ops_fix(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_HomogeneousBC() < 0) return NULL;
+    if (OPS_HomogeneousBC() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -248,7 +281,10 @@ static PyObject *Py_ops_element(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Element() < 0) return NULL;
+    if (OPS_Element() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -257,7 +293,10 @@ static PyObject *Py_ops_timeSeries(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_TimeSeries() < 0) return NULL;
+    if (OPS_TimeSeries() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -266,7 +305,10 @@ static PyObject *Py_ops_pattern(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Pattern() < 0) return NULL;
+    if (OPS_Pattern() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -275,7 +317,10 @@ static PyObject *Py_ops_nodalLoad(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_NodalLoad() < 0) return NULL;
+    if (OPS_NodalLoad() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -284,7 +329,10 @@ static PyObject *Py_ops_system(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_System() < 0) return NULL;
+    if (OPS_System() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -293,7 +341,10 @@ static PyObject *Py_ops_numberer(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Numberer() < 0) return NULL;
+    if (OPS_Numberer() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -302,7 +353,10 @@ static PyObject *Py_ops_constraints(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_ConstraintHandler() < 0) return NULL;
+    if (OPS_ConstraintHandler() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -311,7 +365,10 @@ static PyObject *Py_ops_integrator(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Integrator() < 0) return NULL;
+    if (OPS_Integrator() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -320,7 +377,10 @@ static PyObject *Py_ops_algorithm(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Algorithm() < 0) return NULL;
+    if (OPS_Algorithm() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -329,7 +389,10 @@ static PyObject *Py_ops_analysis(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Analysis() < 0) return NULL;
+    if (OPS_Analysis() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -338,7 +401,10 @@ static PyObject *Py_ops_analyze(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_analyze() < 0) return NULL;
+    if (OPS_analyze() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -347,7 +413,10 @@ static PyObject *Py_ops_test(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_CTest() < 0) return NULL;
+    if (OPS_CTest() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -356,7 +425,10 @@ static PyObject *Py_ops_section(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Section() < 0) return NULL;
+    if (OPS_Section() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -365,7 +437,10 @@ static PyObject *Py_ops_fiber(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Fiber() < 0) return NULL;
+    if (OPS_Fiber() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -374,7 +449,10 @@ static PyObject *Py_ops_patch(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Patch() < 0) return NULL;
+    if (OPS_Patch() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -383,7 +461,10 @@ static PyObject *Py_ops_layer(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Layer() < 0) return NULL;
+    if (OPS_Layer() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -392,7 +473,10 @@ static PyObject *Py_ops_geomTransf(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_CrdTransf() < 0) return NULL;
+    if (OPS_CrdTransf() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -401,7 +485,10 @@ static PyObject *Py_ops_beamIntegration(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_BeamIntegration() < 0) return NULL;
+    if (OPS_BeamIntegration() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -410,7 +497,10 @@ static PyObject *Py_ops_loadConst(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_loadConst() < 0) return NULL;
+    if (OPS_loadConst() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -419,7 +509,10 @@ static PyObject *Py_ops_eleLoad(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_ElementalLoad() < 0) return NULL;
+    if (OPS_ElementalLoad() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -428,7 +521,10 @@ static PyObject *Py_ops_reactions(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_calculateNodalReactions() < 0) return NULL;
+    if (OPS_calculateNodalReactions() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -437,7 +533,10 @@ static PyObject *Py_ops_nodeReaction(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeReaction() < 0) return NULL;
+    if (OPS_nodeReaction() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -446,7 +545,10 @@ static PyObject *Py_ops_eigen(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_eigenAnalysis() < 0) return NULL;
+    if (OPS_eigenAnalysis() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -455,7 +557,10 @@ static PyObject *Py_ops_nDMaterial(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_NDMaterial() < 0) return NULL;
+    if (OPS_NDMaterial() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -464,7 +569,10 @@ static PyObject *Py_ops_block2d(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_doBlock2D() < 0) return NULL;
+    if (OPS_doBlock2D() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -473,7 +581,10 @@ static PyObject *Py_ops_block3d(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_doBlock3D() < 0) return NULL;
+    if (OPS_doBlock3D() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -482,7 +593,10 @@ static PyObject *Py_ops_rayleigh(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_rayleighDamping() < 0) return NULL;
+    if (OPS_rayleighDamping() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -491,7 +605,10 @@ static PyObject *Py_ops_wipeAnalysis(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_wipeAnalysis() < 0) return NULL;
+    if (OPS_wipeAnalysis() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -500,7 +617,10 @@ static PyObject *Py_ops_setTime(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setTime() < 0) return NULL;
+    if (OPS_setTime() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -509,7 +629,10 @@ static PyObject *Py_ops_remove(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_removeObject() < 0) return NULL;
+    if (OPS_removeObject() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -518,7 +641,10 @@ static PyObject *Py_ops_mass(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_addNodalMass() < 0) return NULL;
+    if (OPS_addNodalMass() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -527,7 +653,10 @@ static PyObject *Py_ops_equalDOF(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_EqualDOF() < 0) return NULL;
+    if (OPS_EqualDOF() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -536,7 +665,10 @@ static PyObject *Py_ops_nodeEigenvector(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeEigenvector() < 0) return NULL;
+    if (OPS_nodeEigenvector() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -545,7 +677,10 @@ static PyObject *Py_ops_getTime(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getTime() < 0) return NULL;
+    if (OPS_getTime() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -554,7 +689,10 @@ static PyObject *Py_ops_eleResponse(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_eleResponse() < 0) return NULL;
+    if (OPS_eleResponse() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -563,7 +701,10 @@ static PyObject *Py_ops_SP(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_SP() < 0) return NULL;
+    if (OPS_SP() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -572,7 +713,10 @@ static PyObject *Py_ops_fixX(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_HomogeneousBC_X() < 0) return NULL;
+    if (OPS_HomogeneousBC_X() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -581,7 +725,10 @@ static PyObject *Py_ops_fixY(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_HomogeneousBC_Y() < 0) return NULL;
+    if (OPS_HomogeneousBC_Y() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -590,7 +737,10 @@ static PyObject *Py_ops_fixZ(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_HomogeneousBC_Z() < 0) return NULL;
+    if (OPS_HomogeneousBC_Z() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -599,7 +749,10 @@ static PyObject *Py_ops_reset(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_resetModel() < 0) return NULL;
+    if (OPS_resetModel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -608,7 +761,10 @@ static PyObject *Py_ops_initialize(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_initializeAnalysis() < 0) return NULL;
+    if (OPS_initializeAnalysis() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -617,7 +773,10 @@ static PyObject *Py_ops_getLoadFactor(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getLoadFactor() < 0) return NULL;
+    if (OPS_getLoadFactor() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -626,7 +785,10 @@ static PyObject *Py_ops_build(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_buildModel() < 0) return NULL;
+    if (OPS_buildModel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -635,7 +797,10 @@ static PyObject *Py_ops_print(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_printModel() < 0) return NULL;
+    if (OPS_printModel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -644,7 +809,10 @@ static PyObject *Py_ops_printA(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_printA() < 0) return NULL;
+    if (OPS_printA() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -653,7 +821,10 @@ static PyObject *Py_ops_printB(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_printB() < 0) return NULL;
+    if (OPS_printB() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -662,7 +833,10 @@ static PyObject *Py_ops_printGID(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_printModelGID() < 0) return NULL;
+    if (OPS_printModelGID() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -671,7 +845,10 @@ static PyObject *Py_ops_getCTestNorms(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getCTestNorms() < 0) return NULL;
+    if (OPS_getCTestNorms() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -680,7 +857,10 @@ static PyObject *Py_ops_getCTestIter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getCTestIter() < 0) return NULL;
+    if (OPS_getCTestIter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -689,7 +869,10 @@ static PyObject *Py_ops_recorder(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Recorder() < 0) return NULL;
+    if (OPS_Recorder() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -698,7 +881,10 @@ static PyObject *Py_ops_database(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Database() < 0) return NULL;
+    if (OPS_Database() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -707,7 +893,10 @@ static PyObject *Py_ops_save(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_save() < 0) return NULL;
+    if (OPS_save() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -716,7 +905,10 @@ static PyObject *Py_ops_restore(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_restore() < 0) return NULL;
+    if (OPS_restore() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -725,7 +917,10 @@ static PyObject *Py_ops_eleForce(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_eleForce() < 0) return NULL;
+    if (OPS_eleForce() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -734,7 +929,10 @@ static PyObject *Py_ops_eleDynamicalForce(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_eleDynamicalForce() < 0) return NULL;
+    if (OPS_eleDynamicalForce() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -743,7 +941,10 @@ static PyObject *Py_ops_nodeUnbalance(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeUnbalance() < 0) return NULL;
+    if (OPS_nodeUnbalance() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -752,7 +953,10 @@ static PyObject *Py_ops_nodeDisp(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeDisp() < 0) return NULL;
+    if (OPS_nodeDisp() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -761,7 +965,10 @@ static PyObject *Py_ops_nodeVel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeVel() < 0) return NULL;
+    if (OPS_nodeVel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -770,7 +977,10 @@ static PyObject *Py_ops_setNodeVel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setNodeVel() < 0) return NULL;
+    if (OPS_setNodeVel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -779,7 +989,10 @@ static PyObject *Py_ops_setNodeDisp(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setNodeDisp() < 0) return NULL;
+    if (OPS_setNodeDisp() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -788,7 +1001,10 @@ static PyObject *Py_ops_nodeAccel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeAccel() < 0) return NULL;
+    if (OPS_nodeAccel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -797,7 +1013,10 @@ static PyObject *Py_ops_setNodeAccel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setNodeAccel() < 0) return NULL;
+    if (OPS_setNodeAccel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -806,7 +1025,10 @@ static PyObject *Py_ops_nodeResponse(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeResponse() < 0) return NULL;
+    if (OPS_nodeResponse() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -815,7 +1037,10 @@ static PyObject *Py_ops_nodeCoord(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeCoord() < 0) return NULL;
+    if (OPS_nodeCoord() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -824,7 +1049,10 @@ static PyObject *Py_ops_setNodeCoord(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setNodeCoord() < 0) return NULL;
+    if (OPS_setNodeCoord() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -833,7 +1061,10 @@ static PyObject *Py_ops_updateElementDomain(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_updateElementDomain() < 0) return NULL;
+    if (OPS_updateElementDomain() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -842,7 +1073,10 @@ static PyObject *Py_ops_eleNodes(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_eleNodes() < 0) return NULL;
+    if (OPS_eleNodes() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -851,7 +1085,10 @@ static PyObject *Py_ops_nodeDOFs(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeDOFs() < 0) return NULL;
+    if (OPS_nodeDOFs() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -860,7 +1097,10 @@ static PyObject *Py_ops_nodeMass(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeMass() < 0) return NULL;
+    if (OPS_nodeMass() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -869,7 +1109,10 @@ static PyObject *Py_ops_nodePressure(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodePressure() < 0) return NULL;
+    if (OPS_nodePressure() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -878,7 +1121,10 @@ static PyObject *Py_ops_nodeBounds(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_nodeBounds() < 0) return NULL;
+    if (OPS_nodeBounds() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -887,7 +1133,10 @@ static PyObject *Py_ops_startTimer(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_startTimer() < 0) return NULL;
+    if (OPS_startTimer() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -896,7 +1145,10 @@ static PyObject *Py_ops_stopTimer(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_stopTimer() < 0) return NULL;
+    if (OPS_stopTimer() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -905,7 +1157,10 @@ static PyObject *Py_ops_modalDamping(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_modalDamping() < 0) return NULL;
+    if (OPS_modalDamping() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -914,7 +1169,10 @@ static PyObject *Py_ops_modalDampingQ(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_modalDampingQ() < 0) return NULL;
+    if (OPS_modalDampingQ() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -923,7 +1181,10 @@ static PyObject *Py_ops_setElementRayleighDampingFactors(PyObject *self, PyObjec
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setElementRayleighDampingFactors() < 0) return NULL;
+    if (OPS_setElementRayleighDampingFactors() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -932,7 +1193,10 @@ static PyObject *Py_ops_region(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_MeshRegion() < 0) return NULL;
+    if (OPS_MeshRegion() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -941,7 +1205,10 @@ static PyObject *Py_ops_setPrecision(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setPrecision() < 0) return NULL;
+    if (OPS_setPrecision() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -950,7 +1217,10 @@ static PyObject *Py_ops_searchPeerNGA(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_peerNGA() < 0) return NULL;
+    if (OPS_peerNGA() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -959,7 +1229,10 @@ static PyObject *Py_ops_domainChange(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_domainChange() < 0) return NULL;
+    if (OPS_domainChange() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -968,7 +1241,10 @@ static PyObject *Py_ops_record(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_record() < 0) return NULL;
+    if (OPS_record() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -977,7 +1253,10 @@ static PyObject *Py_ops_metaData(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_neesMetaData() < 0) return NULL;
+    if (OPS_neesMetaData() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -986,7 +1265,10 @@ static PyObject *Py_ops_defaultUnits(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_defaultUnits() < 0) return NULL;
+    if (OPS_defaultUnits() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -995,7 +1277,10 @@ static PyObject *Py_ops_neesUpload(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_neesUpload() < 0) return NULL;
+    if (OPS_neesUpload() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1004,7 +1289,10 @@ static PyObject *Py_ops_stripXML(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_stripOpenSeesXML() < 0) return NULL;
+    if (OPS_stripOpenSeesXML() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1013,7 +1301,10 @@ static PyObject *Py_ops_convertTextToBinary(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_convertTextToBinary() < 0) return NULL;
+    if (OPS_convertTextToBinary() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1022,7 +1313,10 @@ static PyObject *Py_ops_convertBinaryToText(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_convertBinaryToText() < 0) return NULL;
+    if (OPS_convertBinaryToText() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1031,7 +1325,10 @@ static PyObject *Py_ops_getEleTags(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getEleTags() < 0) return NULL;
+    if (OPS_getEleTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1040,7 +1337,10 @@ static PyObject *Py_ops_getNodeTags(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getNodeTags() < 0) return NULL;
+    if (OPS_getNodeTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1049,7 +1349,10 @@ static PyObject *Py_ops_getParamTags(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getParamTags() < 0) return NULL;
+    if (OPS_getParamTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1058,7 +1361,10 @@ static PyObject *Py_ops_getParamValue(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getParamValue() < 0) return NULL;
+    if (OPS_getParamValue() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1067,7 +1373,10 @@ static PyObject *Py_ops_sectionForce(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionForce() < 0) return NULL;
+    if (OPS_sectionForce() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1076,7 +1385,10 @@ static PyObject *Py_ops_sectionDeformation(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionDeformation() < 0) return NULL;
+    if (OPS_sectionDeformation() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1085,7 +1397,10 @@ static PyObject *Py_ops_sectionStiffness(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionStiffness() < 0) return NULL;
+    if (OPS_sectionStiffness() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1094,7 +1409,10 @@ static PyObject *Py_ops_sectionFlexibility(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionFlexibility() < 0) return NULL;
+    if (OPS_sectionFlexibility() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1103,7 +1421,10 @@ static PyObject *Py_ops_sectionLocation(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionLocation() < 0) return NULL;
+    if (OPS_sectionLocation() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1112,7 +1433,10 @@ static PyObject *Py_ops_sectionWeight(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sectionWeight() < 0) return NULL;
+    if (OPS_sectionWeight() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1121,7 +1445,10 @@ static PyObject *Py_ops_basicDeformation(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_basicDeformation() < 0) return NULL;
+    if (OPS_basicDeformation() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1130,7 +1457,10 @@ static PyObject *Py_ops_basicForce(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_basicForce() < 0) return NULL;
+    if (OPS_basicForce() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1139,7 +1469,10 @@ static PyObject *Py_ops_basicStiffness(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_basicStiffness() < 0) return NULL;
+    if (OPS_basicStiffness() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1148,7 +1481,10 @@ static PyObject *Py_ops_InitialStateAnalysis(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_InitialStateAnalysis() < 0) return NULL;
+    if (OPS_InitialStateAnalysis() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1157,7 +1493,10 @@ static PyObject *Py_ops_totalCPU(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_totalCPU() < 0) return NULL;
+    if (OPS_totalCPU() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1167,7 +1506,10 @@ static PyObject *Py_ops_solveCPU(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_solveCPU() < 0) return NULL;
+    if (OPS_solveCPU() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1176,7 +1518,10 @@ static PyObject *Py_ops_accelCPU(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_accelCPU() < 0) return NULL;
+    if (OPS_accelCPU() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1185,7 +1530,10 @@ static PyObject *Py_ops_numFact(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_numFact() < 0) return NULL;
+    if (OPS_numFact() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1194,7 +1542,10 @@ static PyObject *Py_ops_numIter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_numIter() < 0) return NULL;
+    if (OPS_numIter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1203,7 +1554,10 @@ static PyObject *Py_ops_systemSize(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_systemSize() < 0) return NULL;
+    if (OPS_systemSize() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1212,7 +1566,10 @@ static PyObject *Py_ops_version(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_version() < 0) return NULL;
+    if (OPS_version() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1221,7 +1578,10 @@ static PyObject *Py_ops_setMaxOpenFiles(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_maxOpenFiles() < 0) return NULL;
+    if (OPS_maxOpenFiles() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1230,7 +1590,10 @@ static PyObject *Py_ops_limitCurve(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_LimitCurve() < 0) return NULL;
+    if (OPS_LimitCurve() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1239,7 +1602,10 @@ static PyObject *Py_ops_imposedMotion(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_ImposedMotionSP() < 0) return NULL;
+    if (OPS_ImposedMotionSP() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1248,7 +1614,10 @@ static PyObject *Py_ops_groundMotion(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_groundMotion() < 0) return NULL;
+    if (OPS_groundMotion() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1257,7 +1626,10 @@ static PyObject *Py_ops_equalDOF_Mixed(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_EqualDOF_Mixed() < 0) return NULL;
+    if (OPS_EqualDOF_Mixed() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1266,7 +1638,10 @@ static PyObject *Py_ops_rigidLink(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_RigidLink() < 0) return NULL;
+    if (OPS_RigidLink() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1275,7 +1650,10 @@ static PyObject *Py_ops_rigidDiaphragm(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_RigidDiaphragm() < 0) return NULL;
+    if (OPS_RigidDiaphragm() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1284,7 +1662,10 @@ static PyObject *Py_ops_ShallowFoundationGen(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_ShallowFoundationGen() < 0) return NULL;
+    if (OPS_ShallowFoundationGen() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1293,7 +1674,10 @@ static PyObject *Py_ops_setElementRayleighFactors(PyObject *self, PyObject *args
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_addElementRayleigh() < 0) return NULL;
+    if (OPS_addElementRayleigh() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1302,7 +1686,10 @@ static PyObject *Py_ops_mesh(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_mesh() < 0) return NULL;
+    if (OPS_mesh() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1311,7 +1698,10 @@ static PyObject *Py_ops_remesh(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_remesh() < 0) return NULL;
+    if (OPS_remesh() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1320,7 +1710,10 @@ static PyObject *Py_ops_parameter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_Parameter() < 0) return NULL;
+    if (OPS_Parameter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1329,7 +1722,10 @@ static PyObject *Py_ops_addToParameter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_addToParameter() < 0) return NULL;
+    if (OPS_addToParameter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1338,7 +1734,10 @@ static PyObject *Py_ops_updateParameter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_updateParameter() < 0) return NULL;
+    if (OPS_updateParameter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1347,7 +1746,10 @@ static PyObject *Py_ops_setParameter(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setParameter() < 0) return NULL;
+    if (OPS_setParameter() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1356,7 +1758,10 @@ static PyObject *Py_ops_getPID(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    //if (OPS_getPID() < 0) return NULL;
+    //if (OPS_getPID() < 0) {
+    // opserr<<(void*)0;
+    // return NULL;
+    //}
 
     return wrapper->getResults();
 }
@@ -1365,7 +1770,10 @@ static PyObject *Py_ops_getNP(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    //if (OPS_getNP() < 0) return NULL;
+    //if (OPS_getNP() < 0) {
+    // opserr<<(void*)0;
+    // return NULL;
+    //   }
 
     return wrapper->getResults();
 }
@@ -1374,7 +1782,10 @@ static PyObject *Py_ops_barrier(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    //if (OPS_barrier() < 0) return NULL;
+    //if (OPS_barrier() < 0) {
+    // opserr<<(void*)0;
+    // return NULL;
+    //}
 
     return wrapper->getResults();
 }
@@ -1383,7 +1794,10 @@ static PyObject *Py_ops_send(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    //if (OPS_send() < 0) return NULL;
+    //if (OPS_send() < 0) {
+//     opserr<<(void*)0;
+//     return NULL;
+// }
 
     return wrapper->getResults();
 }
@@ -1392,7 +1806,10 @@ static PyObject *Py_ops_recv(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    //if (OPS_recv() < 0) return NULL;
+    //if (OPS_recv() < 0) {
+//     opserr<<(void*)0;
+//     return NULL;
+// }
 
     return wrapper->getResults();
 }
@@ -1401,7 +1818,10 @@ static PyObject *Py_ops_frictionModel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_FrictionModel() < 0) return NULL;
+    if (OPS_FrictionModel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1410,7 +1830,10 @@ static PyObject *Py_ops_computeGradients(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_computeGradients() < 0) return NULL;
+    if (OPS_computeGradients() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1419,7 +1842,10 @@ static PyObject *Py_ops_sensitivityAlgorithm(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensitivityAlgorithm() < 0) return NULL;
+    if (OPS_sensitivityAlgorithm() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1428,7 +1854,10 @@ static PyObject *Py_ops_sensNodeDisp(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensNodeDisp() < 0) return NULL;
+    if (OPS_sensNodeDisp() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1437,7 +1866,10 @@ static PyObject *Py_ops_sensNodeVel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensNodeVel() < 0) return NULL;
+    if (OPS_sensNodeVel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1446,7 +1878,10 @@ static PyObject *Py_ops_sensNodeAccel(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensNodeAccel() < 0) return NULL;
+    if (OPS_sensNodeAccel() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1455,7 +1890,10 @@ static PyObject *Py_ops_sensLambda(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensLambda() < 0) return NULL;
+    if (OPS_sensLambda() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1464,7 +1902,10 @@ static PyObject *Py_ops_sensSectionForce(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensSectionForce() < 0) return NULL;
+    if (OPS_sensSectionForce() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1473,7 +1914,10 @@ static PyObject *Py_ops_sensNodePressure(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sensNodePressure() < 0) return NULL;
+    if (OPS_sensNodePressure() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1482,7 +1926,10 @@ static PyObject *Py_ops_randomVariable(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_randomVariable() < 0) return NULL;
+    if (OPS_randomVariable() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1491,7 +1938,10 @@ static PyObject *Py_ops_probabilityTransformation(PyObject *self, PyObject *args
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_probabilityTransformation() < 0) return NULL;
+    if (OPS_probabilityTransformation() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1500,7 +1950,10 @@ static PyObject *Py_ops_updateMaterialStage(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_updateMaterialStage() < 0) return NULL;
+    if (OPS_updateMaterialStage() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1509,7 +1962,10 @@ static PyObject *Py_ops_sdfResponse(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_sdfResponse() < 0) return NULL;
+    if (OPS_sdfResponse() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1518,7 +1974,10 @@ static PyObject *Py_ops_getNumThreads(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_getNumThreads() < 0) return NULL;
+    if (OPS_getNumThreads() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1527,7 +1986,10 @@ static PyObject *Py_ops_setNumThreads(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_setNumThreads() < 0) return NULL;
+    if (OPS_setNumThreads() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }
@@ -1536,7 +1998,10 @@ static PyObject *Py_ops_logFile(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
-    if (OPS_logFile() < 0) return NULL;
+    if (OPS_logFile() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
 
     return wrapper->getResults();
 }


### PR DESCRIPTION
1. add logFile command to OpenSeesPy
2. error handling in OpenSeesPy
    a. opserr will send all messages to opensees.msg, which can be seen in terminal, Jupyter Notebook or other windows based Python applications
    b. if a command fails, an exception is raised at that command, and print error message
    c. A new PythonStream is created for opserr, which subclass StandardStream, but directs messages to Python instead of stdcerr.
3. add python target in the global makefile 
4. add rpath for the openseespy module to ship some dependencies with the module file.