### PR TITLE
new element recorder option: InternalForce

### DIFF
--- a/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
@@ -51,10 +51,6 @@
 #include <elementAPI.h>
 #include <string>
 #include <ElementIter.h>
-//added by SAJalali-done for InternalForce Recorder
-#define SECTION_RESPONSE_MZ		1
-#define SECTION_RESPONSE_P		2
-#define SECTION_RESPONSE_VY		3
 
 Matrix ElasticBeam2d::K(6,6);
 Vector ElasticBeam2d::P(6);

--- a/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
@@ -1216,21 +1216,21 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
    double oneOverL = 1 / L;
    int order = 3;
    static ID code(3);
-   code(0) = SECTION_RESPONSE_P;	// P is the first quantity
-   code(1) = SECTION_RESPONSE_VY;	// Mz is the second
-   code(2) = SECTION_RESPONSE_MZ;	// My is the third 
+   code(0) = 2;	// P is the first quantity
+   code(1) = 3;	// Mz is the second
+   code(2) = 1;	// My is the third 
    double xL1 = xi - 1;
    double xL = xi;
    sp.Zero();
    for (int ii = 0; ii < order; ii++) {
       switch (code(ii)) {
-      case SECTION_RESPONSE_P:
+      case 2:
          sp(ii) = q(0);
          break;
-      case SECTION_RESPONSE_MZ:
+      case 1:
          sp(ii) = xL1 * q(1) + xL * q(2);
          break;
-      case SECTION_RESPONSE_VY:
+      case 3:
          sp(ii) = oneOverL * (q(1) + q(2));
          break;
       default:
@@ -1256,13 +1256,13 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
          for (int ii = 0; ii < order; ii++) {
 
             switch (code(ii)) {
-            case SECTION_RESPONSE_P:
+            case 2:
                sp(ii) += wa * (L - x);
                break;
-            case SECTION_RESPONSE_MZ:
+            case 1:
                sp(ii) += wy * 0.5*x*(x - L);
                break;
-            case SECTION_RESPONSE_VY:
+            case 3:
                sp(ii) += wy * (x - 0.5*L);
                break;
             default:
@@ -1286,13 +1286,13 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
 
             if (x <= a) {
                switch (code(ii)) {
-               case SECTION_RESPONSE_P:
+               case 2:
                   sp(ii) += Fa;
                   break;
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) -= VI * x;
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) -= VI;
                   break;
                default:
@@ -1301,10 +1301,10 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
             }
             else if (x >= b) {
                switch (code(ii)) {
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) += VJ * (x - L);
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) += VJ;
                   break;
                default:
@@ -1313,13 +1313,13 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
             }
             else {
                switch (code(ii)) {
-               case SECTION_RESPONSE_P:
+               case 2:
                   sp(ii) += Fa - wa * (x - a);
                   break;
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) += -VI * x + 0.5*wy*x*x + wy * a*(0.5*a - x);
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) += -VI + wy * (x - a);
                   break;
                default:
@@ -1345,13 +1345,13 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
 
             if (x <= a) {
                switch (code(ii)) {
-               case SECTION_RESPONSE_P:
+               case 2:
                   sp(ii) += N;
                   break;
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) -= x * V1;
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) -= V1;
                   break;
                default:
@@ -1360,10 +1360,10 @@ ElasticBeam2d::computeSectionForces(Vector &sp, double xi)
             }
             else {
                switch (code(ii)) {
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) -= (L - x)*V2;
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) += V2;
                   break;
                default:

--- a/SRC/element/elasticBeamColumn/ElasticBeam2d.h
+++ b/SRC/element/elasticBeamColumn/ElasticBeam2d.h
@@ -97,6 +97,13 @@ class ElasticBeam2d : public Element
     int updateParameter (int parameterID, Information &info);
 
   private:
+	 //added by SAJalali-done:Start
+	 void  computeSectionForces(Vector& sp, double xi);
+	 int numEleLoads;
+	 ElementalLoad **eleLoads;
+	 double *eleLoadFactors;
+	 //added by SAJalali-done:End
+
     double A,E,I;     // area, elastic modulus, moment of inertia
     double alpha, d;  // coeff. of thermal expansion, depth
     double rho;       // mass per unit length

--- a/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
@@ -1286,33 +1286,33 @@ ElasticBeam3d::computeSectionForces(Vector &sp, double xi)
    double oneOverL = 1 / L;
    int order = 6;
    static ID code(6);
-   code(0) = SECTION_RESPONSE_P;	// P is the first quantity
-   code(1) = SECTION_RESPONSE_VY;	// Mz is the second
-   code(2) = SECTION_RESPONSE_VZ;	// My is the third 
-   code(3) = SECTION_RESPONSE_T;	// T is the fourth
-   code(4) = SECTION_RESPONSE_MY;	// My is the third 
-   code(5) = SECTION_RESPONSE_MZ;	// Mz is the second
+   code(0) = 2;	// P is the first quantity
+   code(1) = 3;	// Mz is the second
+   code(2) = 5;	// My is the third 
+   code(3) = 6;	// T is the fourth
+   code(4) = 4;	// My is the third 
+   code(5) = 1;	// Mz is the second
    sp.Zero();
    double xL1 = xi - 1;
    double xL = xi;
    for (int ii = 0; ii < order; ii++) {
       switch (code(ii)) {
-      case SECTION_RESPONSE_P:
+      case 2:
          sp(ii) = q(0);
          break;
-      case SECTION_RESPONSE_MZ:
+      case 1:
          sp(ii) = xL1 * q(1) + xL * q(2);
          break;
-      case SECTION_RESPONSE_VY:
+      case 3:
          sp(ii) = oneOverL * (q(1) + q(2));
          break;
-      case SECTION_RESPONSE_MY:
+      case 4:
          sp(ii) = xL1 * q(3) + xL * q(4);
          break;
-      case SECTION_RESPONSE_VZ:
+      case 5:
          sp(ii) = oneOverL * (q(3) + q(4));
          break;
-      case SECTION_RESPONSE_T:
+      case 6:
          sp(ii) = q(5);
          break;
       default:
@@ -1339,19 +1339,19 @@ ElasticBeam3d::computeSectionForces(Vector &sp, double xi)
          for (int ii = 0; ii < order; ii++) {
 
             switch (code(ii)) {
-            case SECTION_RESPONSE_P:
+            case 2:
                sp(ii) += wa * (L - x);
                break;
-            case SECTION_RESPONSE_MZ:
+            case 1:
                sp(ii) += wy * 0.5*x*(x - L);
                break;
-            case SECTION_RESPONSE_VY:
+            case 3:
                sp(ii) += wy * (x - 0.5*L);
                break;
-            case SECTION_RESPONSE_MY:
+            case 4:
                sp(ii) += wz * 0.5*x*(L - x);
                break;
-            case SECTION_RESPONSE_VZ:
+            case 5:
                sp(ii) += wz * (x - 0.5*L);
                break;
             default:
@@ -1380,19 +1380,19 @@ ElasticBeam3d::computeSectionForces(Vector &sp, double xi)
 
             if (x <= a) {
                switch (code(ii)) {
-               case SECTION_RESPONSE_P:
+               case 2:
                   sp(ii) += N;
                   break;
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) -= x * Vy1;
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) -= Vy1;
                   break;
-               case SECTION_RESPONSE_MY:
+               case 4:
                   sp(ii) += x * Vz1;
                   break;
-               case SECTION_RESPONSE_VZ:
+               case 5:
                   sp(ii) -= Vz1;
                   break;
                default:
@@ -1401,16 +1401,16 @@ ElasticBeam3d::computeSectionForces(Vector &sp, double xi)
             }
             else {
                switch (code(ii)) {
-               case SECTION_RESPONSE_MZ:
+               case 1:
                   sp(ii) -= (L - x)*Vy2;
                   break;
-               case SECTION_RESPONSE_VY:
+               case 3:
                   sp(ii) += Vy2;
                   break;
-               case SECTION_RESPONSE_MY:
+               case 4:
                   sp(ii) += (L - x)*Vz2;
                   break;
-               case SECTION_RESPONSE_VZ:
+               case 5:
                   sp(ii) += Vz2;
                   break;
                default:

--- a/SRC/element/elasticBeamColumn/ElasticBeam3d.h
+++ b/SRC/element/elasticBeamColumn/ElasticBeam3d.h
@@ -97,7 +97,13 @@ class ElasticBeam3d : public Element
     int updateParameter (int parameterID, Information &info);
 
   private:
-    double A,E,G,Jx,Iy,Iz;
+     //added by SAJalali:Start
+     void  computeSectionForces(Vector& sp, double xi);
+     int numEleLoads;
+     ElementalLoad **eleLoads;
+     double *eleLoadFactors;
+     //added by SAJalali:End
+     double A,E,G,Jx,Iy,Iz;
 
     double rho;
     int cMass;

--- a/Win64/proj/element/element.vcxproj
+++ b/Win64/proj/element/element.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{8062B50D-A609-33D0-8223-81D898DE05D5}</ProjectGuid>
     <SccProjectName />
     <SccLocalPath />
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -116,6 +116,7 @@
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\AxEqDispBeamColumn2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\Element.cpp" />
@@ -378,6 +379,7 @@
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.h" />
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dWithSensitivity.h" />
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h" />
     <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.h" />
     <ClInclude Include="..\..\..\SRC\element\Element.h" />

--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -120,6 +120,9 @@
     <Filter Include="absorbentBoundaries">
       <UniqueIdentifier>{1b806f65-5bd2-4429-9294-d36935d459e3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="TimoshenkoBeamColumn">
+      <UniqueIdentifier>{93df4a99-969d-4de9-bdbd-0b4ab20ae601}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\SRC\element\Element.cpp">
@@ -890,6 +893,9 @@
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp">
       <Filter>elasticBeamColumn</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp">
+      <Filter>TimoshenkoBeamColumn</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\SRC\element\Element.h">
@@ -1551,6 +1557,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h">
       <Filter>elasticBeamColumn</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h">
+      <Filter>TimoshenkoBeamColumn</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -120,9 +120,6 @@
     <Filter Include="absorbentBoundaries">
       <UniqueIdentifier>{1b806f65-5bd2-4429-9294-d36935d459e3}</UniqueIdentifier>
     </Filter>
-    <Filter Include="TimoshenkoBeamColumn">
-      <UniqueIdentifier>{93df4a99-969d-4de9-bdbd-0b4ab20ae601}</UniqueIdentifier>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\SRC\element\Element.cpp">
@@ -894,7 +891,7 @@
       <Filter>elasticBeamColumn</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp">
-      <Filter>TimoshenkoBeamColumn</Filter>
+      <Filter>dispBeamColumn</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1559,7 +1556,7 @@
       <Filter>elasticBeamColumn</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h">
-      <Filter>TimoshenkoBeamColumn</Filter>
+      <Filter>dispBeamColumn</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
the "InternalForce" recorder is required to automate computation of internal forces at given locations inside the beam. This computation is done following the mechanism employed by forceBeamColumn2d element. That is, elementalLoad objects are stored at the class in addition of being used for updating the reaction and fixed-end forces. The stored loading data are then used in newly added "computeSectionForces" function to compute internal force at the intended location. This function is itself invoked by "getResponse" method of the element.

Thanks and Regards
SAJalali