### PR TITLE
Change Python output strategy

### DIFF
--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -285,14 +285,15 @@ initopensees(void)
         INITERROR;
     struct module_state *st = GETSTATE(module);
 
-    st->error = PyErr_NewException("opensees.error", NULL, NULL);
-    PyObject* ops_msg = PyErr_NewException("opensees.msg", NULL, NULL);
+    st->error = PyErr_NewExceptionWithDoc("opensees.OpenSeesError", "Internal OpenSees errors.", NULL, NULL);
     if (st->error == NULL) {
         Py_DECREF(module);
         INITERROR;
     }
+    Py_INCREF(st->error);
+    PyModule_AddObject(module, "OpenSeesError", st->error);
 
-    sserr.setError(st->error,ops_msg);
+    sserr.setError(st->error);
 
     Py_AtExit(cleanupFunc);
 

--- a/SRC/interpreter/PythonStream.h
+++ b/SRC/interpreter/PythonStream.h
@@ -32,12 +32,11 @@ class PythonStream : public StandardStream
 {
 public:
     PythonStream(int indentSize=2, bool echo=false)
-	:StandardStream(indentSize,echo), error(0), message(0), msg() {}
+	:StandardStream(indentSize,echo), error(0), msg() {}
     ~PythonStream() {}
     
-    void setError(PyObject* err, PyObject* msg) {
+    void setError(PyObject* err) {
 	error = err;
-	message = msg;
     }
 
     OPS_Stream& operator<<(char c) {
@@ -120,7 +119,7 @@ public:
 	    return this->StandardStream::operator<<(p);
 	}
 	if (msg.empty()) {
-	    msg = "See opensees.msg\n";
+	    msg = "See stderr output";
 	}
 	PyErr_SetString(error, msg.c_str());
 	return *this;
@@ -130,24 +129,13 @@ private:
 
     template<class T>
     void err_out(T err) {
-
 	std::stringstream ss;
 	ss << err;
-	msg += ss.str();
-
-	std::size_t pos = msg.find('\n');
-	while (pos != std::string::npos) {
-	    std::string sub = msg.substr(0, pos+1);
-	    PyErr_SetString(message, sub.c_str());
-	    PyErr_Print();
-
-	    msg = msg.substr(pos+1);
-	    pos = msg.find('\n');
-	}
+	msg = ss.str();
+	PySys_FormatStderr(msg.c_str());
     }
 
     PyObject* error;
-    PyObject* message;
     std::string msg;
 };
 

--- a/SRC/interpreter/PythonStream.h
+++ b/SRC/interpreter/PythonStream.h
@@ -121,6 +121,7 @@ public:
 	if (msg.empty()) {
 	    msg = "See stderr output";
 	}
+	msg.erase(msg.find_last_not_of("\n\r ") + 1);  // Strip extra newlines from the message
 	PyErr_SetString(error, msg.c_str());
 	return *this;
     }


### PR DESCRIPTION
Instead of creating a stepping stone error (`opensees.msg`), we can pass things directly to Python's stderr using `PySys_FormatStderr`. This output can be caught and redirected by things expecting it (e.g. Python's `contextlib.redirect_stderr`). Additionally, the last message printed is saved, so when a real error occurs, it has that information along with it.

Finally, I've renamed `opensees.error` to `opensees.OpenSeesError` and made it available from the actual module. This allows it to be caught by the calling Python script.

### Example: uncaught error
``` python
>>> import opensees as ops
>>> ops.model('basic', '-ndm', 2)
>>> ops.node(0, 0.0)
insufficient number of arguments
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
opensees.OpenSeesError: insufficient number of arguments
```

### Example: catching the error
``` python
>>> try:
...     ops.node(0, 0.0)
... except ops.OpenSeesError:
...     print('an error occurred!')
... 
insufficient number of arguments
an error occurred!
```

### Example: capturing output with `contextlib`
``` python
>>> import contextlib
>>> import io
>>> f = io.StringIO()
>>> with contextlib.redirect_stderr(f):
...     ops.node(0, 0.0)
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
opensees.OpenSeesError: insufficient number of arguments
>>> f.getvalue()
'insufficient number of arguments\n'
```