### PR TITLE
Take more number classes as Python input

### DIFF
--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -95,10 +95,10 @@ PythonModule::getInt(int *data, int numArgs)
         PyObject *o = PyTuple_GetItem(wrapper.getCurrentArgv(), wrapper.getCurrentArg());
         wrapper.incrCurrentArg();
 #if PY_MAJOR_VERSION >= 3
-        if (!PyLong_Check(o)) {
+        data[i] = PyLong_AsLong(o);
+        if (PyErr_Occurred()) {
             return -1;
         }
-        data[i] = PyLong_AS_LONG(o);
 #else
         if (!PyInt_Check(o)) {
             return -1;
@@ -120,10 +120,10 @@ PythonModule::getDouble(double *data, int numArgs)
     for (int i = 0; i < numArgs; i++) {
         PyObject *o = PyTuple_GetItem(wrapper.getCurrentArgv(), wrapper.getCurrentArg());
         wrapper.incrCurrentArg();
-        if (!PyFloat_Check(o)) {
+        data[i] = PyFloat_AsDouble(o);
+        if (PyErr_Occurred()) {
             return -1;
         }
-        data[i] = PyFloat_AS_DOUBLE(o);
     }
 
     return 0;


### PR DESCRIPTION
Currently, the Python module needs int and float inputs to be the precise class (or subclass of) the input requested. We can skip the up-front check for this, and have the Python internals call the appropriate conversion method if it can. If it can't convert the number, it sets the error state and we can just pass this up the chain as usual.

### Example
``` python
>>> import opensees as ops
>>> ops.model('basic', '-ndm', 2)
>>> ops.node(0, 0, 0)
>>> ops.node(1, 10, 10)
>>> ops.node(2, 20.0, 10)
>>> ops.node(3, 10, 30.0)
>>> ops.printModel()
opensees.msg: Current Domain Information
opensees.msg:   Current Time: 0
opensees.msg: tCommitted Time: 0
opensees.msg: NODE DATA: NumNodes: 4
opensees.msg: 
opensees.msg:  Node: 0
opensees.msg:   Coordinates  : 0 0 
opensees.msg: 
opensees.msg: 
opensees.msg:  Node: 1
opensees.msg:   Coordinates  : 10 10 
opensees.msg: 
opensees.msg: 
opensees.msg:  Node: 2
opensees.msg:   Coordinates  : 20 10 
opensees.msg: 
opensees.msg: 
opensees.msg:  Node: 3
opensees.msg:   Coordinates  : 10 30 
opensees.msg: 
opensees.msg: ELEMENT DATA: NumEle: 0
opensees.msg: 
opensees.msg: SP_Constraints: numConstraints: 0
opensees.msg: 
opensees.msg: Pressure_Constraints: numConstraints: 0
opensees.msg: 
opensees.msg: MP_Constraints: numConstraints: 0
opensees.msg: 
opensees.msg: LOAD PATTERNS: numPatterns: 0
opensees.msg: 
opensees.msg: 
opensees.msg: PARAMETERS: numParameters: 0
opensees.msg: 
```