### PR TITLE
updates on python inputs and outputs

### DIFF
--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -87,8 +87,13 @@ PythonModule::getInt(int *data, int numArgs) {
     for (int i = 0; i < numArgs; i++) {
         PyObject *o = PyTuple_GetItem(wrapper.getCurrentArgv(), wrapper.getCurrentArg());
         wrapper.incrCurrentArg();
-        data[i] = PyLong_AsLong(o);
-        if (PyErr_Occurred()) {
+        if (PyLong_Check(o) || PyFloat_Check(o) || PyBool_Check(o)) {
+            PyErr_Clear();
+            data[i] = PyLong_AsLong(o);
+            if (PyErr_Occurred()) {
+                return -1;
+            }
+        } else {
             return -1;
         }
     }
@@ -105,8 +110,13 @@ PythonModule::getDouble(double *data, int numArgs) {
     for (int i = 0; i < numArgs; i++) {
         PyObject *o = PyTuple_GetItem(wrapper.getCurrentArgv(), wrapper.getCurrentArg());
         wrapper.incrCurrentArg();
-        data[i] = PyFloat_AsDouble(o);
-        if (PyErr_Occurred()) {
+        if (PyLong_Check(o) || PyFloat_Check(o) || PyBool_Check(o)) {
+            PyErr_Clear();
+            data[i] = PyFloat_AsDouble(o);
+            if (PyErr_Occurred()) {
+                return -1;
+            }
+        } else {
             return -1;
         }
     }

--- a/SRC/interpreter/PythonStream.h
+++ b/SRC/interpreter/PythonStream.h
@@ -124,12 +124,10 @@ public:
             if (echoApplication) err_out(p);
             return StandardStream::operator<<(p);
         }
-        if (msg.empty()) {
-            if (echoApplication) {
-                msg = "See stderr output";
-            } else {
-                msg = "See log file";
-            }
+        if (echoApplication) {
+            msg = "See stderr output";
+        } else {
+            msg = "See log file";
         }
         msg.erase(msg.find_last_not_of("\n\r ") + 1);  // Strip extra newlines from the message
         PyErr_SetString(error, msg.c_str());


### PR DESCRIPTION
PythonModule: clear error flag before get inputs, check real numbers for getint and getdouble

current version will generate TypeError when some commands have mixed real and string parameters and test the next parameter is real or string.

PythonStream: set last message when error occurs