### PR TITLE
Fix UVC class names and add UVCuniaxial to the TclModelBuilder

### DIFF
--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -213,7 +213,7 @@
 #define MAT_TAG_Concrete02IS                    100 //nassermarafi
 #define MAT_TAG_ConfinedConcrete01              101
 #define MAT_TAG_ElasticPowerFunc                102
-#define MAT_TAG_RESSCppLab                      103
+#define MAT_TAG_UVCuniaxial                     103
 #define MAT_TAG_PySimple1                    205
 #define MAT_TAG_TzSimple1                    206
 #define MAT_TAG_QzSimple1                    207
@@ -371,8 +371,8 @@
 #define ND_TAG_CThreeDimensional   55
 #define ND_TAG_StressDensityModel2D 56
 #define ND_TAG_StressDensityModel3D 57
-#define ND_TAG_RESSCppLabMA 58
-#define ND_TAG_RESSCppLabPS 59
+#define ND_TAG_UVCmultiaxial  58
+#define ND_TAG_UVCplanestress 59
 
 #define ND_TAG_FluidSolidPorousMaterial        100
 #define ND_TAG_PressureDependMultiYield		101

--- a/SRC/material/nD/UVCmultiaxial.cpp
+++ b/SRC/material/nD/UVCmultiaxial.cpp
@@ -131,7 +131,7 @@ UVCmultiaxial::UVCmultiaxial(int tag, double E, double poissonRatio,
   double sy0, double qInf, double b,
   double dInf, double a,
   std::vector<double> cK, std::vector<double> gammaK)
-  : NDMaterial(tag, ND_TAG_RESSCppLabMA),
+  : NDMaterial(tag, ND_TAG_UVCmultiaxial),
   elasticModulus(E),
   poissonRatio(poissonRatio),
   initialYield(sy0),
@@ -178,7 +178,7 @@ UVCmultiaxial::UVCmultiaxial(int tag, double E, double poissonRatio,
 /* ----------------------------------------------------------------------------------------------------------------- */
 
 UVCmultiaxial::UVCmultiaxial()
-  : NDMaterial(0, ND_TAG_RESSCppLabMA),
+  : NDMaterial(0, ND_TAG_UVCmultiaxial),
   elasticModulus(0.),
   poissonRatio(0.),
   initialYield(0.),

--- a/SRC/material/nD/UVCplanestress.cpp
+++ b/SRC/material/nD/UVCplanestress.cpp
@@ -130,7 +130,7 @@ UVCplanestress::UVCplanestress(int tag, double E, double poissonRatio,
   double sy0, double qInf, double b,
   double dInf, double a,
   std::vector<double> cK, std::vector<double> gammaK)
-  : NDMaterial(tag, ND_TAG_RESSCppLabPS),
+  : NDMaterial(tag, ND_TAG_UVCplanestress),
   elasticModulus(E),
   poissonRatio(poissonRatio),
   initialYield(sy0),
@@ -184,7 +184,7 @@ UVCplanestress::UVCplanestress(int tag, double E, double poissonRatio,
 /* ----------------------------------------------------------------------------------------------------------------- */
 
 UVCplanestress::UVCplanestress()
-  : NDMaterial(0, ND_TAG_RESSCppLabPS),
+  : NDMaterial(0, ND_TAG_UVCplanestress),
   elasticModulus(0.),
   poissonRatio(0.),
   initialYield(0.),

--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -160,7 +160,8 @@ extern void *OPS_PySimple3(void);
 extern void *OPS_BoucWenOriginal(void);
 extern void *OPS_GNGMaterial(void);
 extern void *OPS_OOHystereticMaterial(void);
-extern void* OPS_ElasticPowerFunc(void);
+extern void *OPS_ElasticPowerFunc(void);
+extern void *OPS_UVCuniaxial(void);
 
 //extern int TclCommand_ConfinedConcrete02(ClientData clientData, Tcl_Interp *interp, int argc, 
 //					 TCL_Char **argv, TclModelBuilder *theTclBuilder);
@@ -441,11 +442,12 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
 	return TCL_ERROR;
     }
     else if (strcmp(argv[1], "ElasticPowerFunc") == 0) {
-    void* theMat = OPS_ElasticPowerFunc();
-    if (theMat != 0)
+      void* theMat = OPS_ElasticPowerFunc();
+      if (theMat != 0)
         theMaterial = (UniaxialMaterial*)theMat;
-    else
+      else
         return TCL_ERROR;
+    }
     /*
 	} else if (strcmp(argv[1],"HoehlerStanton") == 0) {
       void *theMat = OPS_HoehlerStanton();
@@ -454,7 +456,14 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
       else 
 	return TCL_ERROR;
 */
-    } else if ((strcmp(argv[1],"RambergOsgood") == 0) || (strcmp(argv[1],"RambergOsgoodSteel") == 0)) {
+    else if (strcmp(argv[1], "UVCuniaxial") == 0) {
+      void *theMat = OPS_UVCuniaxial();
+      if (theMat != 0)
+        theMaterial = (UniaxialMaterial *)theMat;
+      else
+        return TCL_ERROR;
+    }
+    else if ((strcmp(argv[1],"RambergOsgood") == 0) || (strcmp(argv[1],"RambergOsgoodSteel") == 0)) {
       void *theMat = OPS_RambergOsgoodSteel();
       if (theMat != 0) 
 	theMaterial = (UniaxialMaterial *)theMat;

--- a/SRC/material/uniaxial/UVCuniaxial.cpp
+++ b/SRC/material/uniaxial/UVCuniaxial.cpp
@@ -127,7 +127,7 @@ void* OPS_UVCuniaxial(void) {
 UVCuniaxial::UVCuniaxial(int tag, double E, double sy0, double qInf, double b,
   double dInf, double a,
   std::vector<double> cK, std::vector<double> gammaK)
-  : UniaxialMaterial(tag, MAT_TAG_RESSCppLab),
+  : UniaxialMaterial(tag, MAT_TAG_UVCuniaxial),
   elasticModulus(E),
   yieldStress(sy0),
   qInf(qInf),


### PR DESCRIPTION
c92fb2a - updated old names for the materials in the class tags
801c764 - add UVCuniaxial to the TclModelBuilderUniaxial