### PR TITLE
Python updates

### DIFF
--- a/SRC/api/elementAPI.h
+++ b/SRC/api/elementAPI.h
@@ -177,9 +177,9 @@ extern "C" int        OPS_Error(char *, int length);
 extern "C" int        OPS_GetNumRemainingInputArgs();
 extern "C" int        OPS_ResetCurrentInputArg(int cArg);
 extern "C" int        OPS_GetIntInput(int *numData, int*data);
-extern "C" int        OPS_SetIntOutput(int *numData, int*data);
+extern "C" int        OPS_SetIntOutput(int *numData, int*data, bool scalar);
 extern "C" int        OPS_GetDoubleInput(int *numData, double *data);
-extern "C" int        OPS_SetDoubleOutput(int *numData, double *data);
+extern "C" int        OPS_SetDoubleOutput(int *numData, double *data, bool scalar);
 extern "C" const char *OPS_GetString(void); // does a strcpy
 extern "C" int        OPS_SetString(const char*); 
 //extern "C" int        OPS_GetString(char *cArray, int sizeArray); // does a strcpy

--- a/SRC/api/elementAPI_TCL.cpp
+++ b/SRC/api/elementAPI_TCL.cpp
@@ -194,7 +194,7 @@ int OPS_GetIntInput(int *numData, int*data)
 }
 
 extern "C" 
-int OPS_SetIntOutput(int *numData, int *data)
+int OPS_SetIntOutput(int *numData, int *data, bool scalar)
 {
     int numArgs = *numData;
     char buffer[40];
@@ -205,7 +205,7 @@ int OPS_SetIntOutput(int *numData, int *data)
   return 0;  
 }
 
-extern "C" 
+extern "C"
 int OPS_GetDoubleInput(int *numData, double *data)
 {
   int size = *numData;
@@ -221,7 +221,7 @@ int OPS_GetDoubleInput(int *numData, double *data)
 }
 
 extern "C" 
-int OPS_SetDoubleOutput(int *numData, double *data)
+int OPS_SetDoubleOutput(int *numData, double *data, bool scalar)
 {
     int numArgs = *numData;
     char buffer[40];

--- a/SRC/interpreter/DL_Interpreter.cpp
+++ b/SRC/interpreter/DL_Interpreter.cpp
@@ -97,13 +97,13 @@ DL_Interpreter::resetInput(int cArg)
 }
 
 int
-DL_Interpreter::setInt(int *, int numArgs)
+DL_Interpreter::setInt(int *, int numArgs, bool scalar)
 {
     return -1;
 }
 
 int
-DL_Interpreter::setDouble(double *, int numArgs)
+DL_Interpreter::setDouble(double *, int numArgs, bool scalar)
 {
     return -1;
 }

--- a/SRC/interpreter/DL_Interpreter.h
+++ b/SRC/interpreter/DL_Interpreter.h
@@ -68,8 +68,8 @@ class DL_Interpreter
     virtual void resetInput(int cArg);
 
     // methods for interpreters to output results
-    virtual int setInt(int *, int numArgs);
-    virtual int setDouble(double *, int numArgs);
+    virtual int setInt(int *, int numArgs, bool scalar);
+    virtual int setDouble(double *, int numArgs, bool scalar);
     virtual int setString(const char*);
 
     // methods to run a command in the interpreter

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -305,7 +305,7 @@ OpenSeesCommands::eigen(int typeSolver, double shift,
 	for (int i=0; i<numEigen; i++) {
 	    data[i] = eigenvalues(i);
 	}
-	OPS_SetDoubleOutput(&numEigen, data);
+	OPS_SetDoubleOutput(&numEigen, data, false);
 	delete [] data;
     }
 
@@ -318,7 +318,7 @@ int* OPS_GetNumEigen()
     if (cmds == 0) return 0;                                                    
     numEigen = cmds->getNumEigen();                                             
     int numdata = 1;                                                            
-    if (OPS_SetIntOutput(&numdata, &numEigen) < 0) {                            
+    if (OPS_SetIntOutput(&numdata, &numEigen, true) < 0) {
         opserr << "WARNING failed to set output\n";                             
         return 0;                                                               
     }                                                                           
@@ -904,12 +904,11 @@ int OPS_GetIntInput(int *numData, int*data)
     return interp->getInt(data, *numData);
 }
 
-int OPS_SetIntOutput(int *numData, int*data)
+int OPS_SetIntOutput(int *numData, int*data, bool scalar)
 {
     if (cmds == 0) return 0;
     DL_Interpreter* interp = cmds->getInterpreter();
-    if (numData == 0 || data == 0) return -1;
-    return interp->setInt(data, *numData);
+    return interp->setInt(data, *numData, scalar);
 }
 
 int OPS_GetDoubleInput(int *numData, double *data)
@@ -920,12 +919,11 @@ int OPS_GetDoubleInput(int *numData, double *data)
     return interp->getDouble(data, *numData);
 }
 
-int OPS_SetDoubleOutput(int *numData, double *data)
+int OPS_SetDoubleOutput(int *numData, double *data, bool scalar)
 {
     if (cmds == 0) return 0;
     DL_Interpreter* interp = cmds->getInterpreter();
-    if (numData == 0 || data == 0) return -1;
-    return interp->setDouble(data, *numData);
+    return interp->setDouble(data, *numData, scalar);
 }
 
 const char * OPS_GetString(void)
@@ -1675,7 +1673,7 @@ int OPS_analyze()
     }
 
     int numdata = 1;
-    if (OPS_SetIntOutput(&numdata, &result) < 0) {
+    if (OPS_SetIntOutput(&numdata, &result, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -1843,7 +1841,7 @@ int OPS_printA()
 		int size = A->noRows() * A->noCols();
 		if (size >0) {
 		    double& ptr = (*A)(0,0);
-		    if (OPS_SetDoubleOutput(&size, &ptr) < 0) {
+		    if (OPS_SetDoubleOutput(&size, &ptr, false) < 0) {
 			opserr << "WARNING: printA - failed to set output\n";
 			return -1;
 		    }
@@ -1851,7 +1849,21 @@ int OPS_printA()
 	    } else {
 		*output << *A;
 	    }
+	} else {
+        int size = 0;
+        double *ptr = 0;
+        if (OPS_SetDoubleOutput(&size, ptr, false) < 0) {
+            opserr << "WARNING: printA - failed to set output\n";
+            return -1;
+        }
 	}
+    } else {
+        int size = 0;
+        double *ptr = 0;
+        if (OPS_SetDoubleOutput(&size, ptr, false) < 0) {
+            opserr << "WARNING: printA - failed to set output\n";
+            return -1;
+        }
     }
 
     // close the output file
@@ -1898,14 +1910,28 @@ int OPS_printB()
 	    int size = b.Size();
 	    if (size > 0) {
 		double &ptr = b(0);
-		if (OPS_SetDoubleOutput(&size, &ptr) < 0) {
+		if (OPS_SetDoubleOutput(&size, &ptr, false) < 0) {
 		    opserr << "WARNING: printb - failed to set output\n";
 		    return -1;
 		}
+	    } else {
+            size = 0;
+            double *ptr2 = 0;
+            if (OPS_SetDoubleOutput(&size, ptr2, false) < 0) {
+                opserr << "WARNING: printA - failed to set output\n";
+                return -1;
+            }
 	    }
 	} else {
 	    *output << b;
 	}
+    } else {
+        int size = 0;
+        double *ptr = 0;
+        if (OPS_SetDoubleOutput(&size, ptr, false) < 0) {
+            opserr << "WARNING: printA - failed to set output\n";
+            return -1;
+        }
     }
 
     // close the output file
@@ -2378,7 +2404,7 @@ int OPS_getCTestNorms()
 	    data[i] = norms(i);
 	}
 
-	if (OPS_SetDoubleOutput(&numdata, data) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, data, false) < 0) {
 	    opserr << "WARNING failed to set test norms\n";
 	    delete [] data;
 	    return -1;
@@ -2399,7 +2425,7 @@ int OPS_getCTestIter()
     if (theTest != 0) {
 	int res = theTest->getNumTests();
 	int numdata = 1;
-	if (OPS_SetIntOutput(&numdata, &res) < 0) {
+	if (OPS_SetIntOutput(&numdata, &res, true) < 0) {
 	    opserr << "WARNING failed to set test iter\n";
 	    return -1;
 	}
@@ -2892,7 +2918,7 @@ int OPS_totalCPU()
 
     double value = theAlgorithm->getTotalTimeCPU();
     int numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -2911,7 +2937,7 @@ int OPS_solveCPU()
 
     double value = theAlgorithm->getSolveTimeCPU();
     int numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -2930,7 +2956,7 @@ int OPS_accelCPU()
 
     double value = theAlgorithm->getAccelTimeCPU();
     int numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -2949,7 +2975,7 @@ int OPS_numFact()
 
     double value = theAlgorithm->getNumFactorizations();
     int numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -2968,7 +2994,7 @@ int OPS_numIter()
 
     int value = theAlgorithm->getNumIterations();
     int numdata = 1;
-    if (OPS_SetIntOutput(&numdata, &value) < 0) {
+    if (OPS_SetIntOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -2987,7 +3013,7 @@ int OPS_systemSize()
 
     int value = theSOE->getNumEqn();
     int numdata = 1;
-    if (OPS_SetIntOutput(&numdata, &value) < 0) {
+    if (OPS_SetIntOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -1415,7 +1415,7 @@ int OPS_getPID()
 #endif
 
     int size = 1;
-    if (OPS_SetIntOutput(&size, &pid) < 0) {
+    if (OPS_SetIntOutput(&size, &pid, true) < 0) {
 	opserr << "WARNING: failed to set pid\n";
 	return -1;
     }
@@ -1432,7 +1432,7 @@ int OPS_getNP()
 #endif
 
     int size = 1;
-    if (OPS_SetIntOutput(&size, &nump) < 0) {
+    if (OPS_SetIntOutput(&size, &nump, true) < 0) {
 	opserr << "WARNING: failed to set np\n";
 	return -1;
     }
@@ -1658,11 +1658,11 @@ int OPS_recv()
 	    int res = 0;
 	    if (datatype == MPI_INT) {
 
-            res = OPS_SetIntOutput(&msgLength[0], &idata[0]);
+            res = OPS_SetIntOutput(&msgLength[0], &idata[0], false);
 
 	    } else if (datatype == MPI_DOUBLE) {
 
-            res = OPS_SetDoubleOutput(&msgLength[0], &ddata[0]);
+            res = OPS_SetDoubleOutput(&msgLength[0], &ddata[0], false);
 
 	    } else {
 
@@ -1792,11 +1792,11 @@ int OPS_Bcast() {
             int res = 0;
             if (datatype == MPI_INT) {
 
-                res = OPS_SetIntOutput(&msgLength[0], &idata[0]);
+                res = OPS_SetIntOutput(&msgLength[0], &idata[0], false);
 
             } else if (datatype == MPI_DOUBLE) {
 
-                res = OPS_SetDoubleOutput(&msgLength[0], &ddata[0]);
+                res = OPS_SetDoubleOutput(&msgLength[0], &ddata[0], false);
 
             } else {
 
@@ -1955,7 +1955,7 @@ int OPS_sdfResponse()
 
     double output[] = {umax, u, up, amax, tamax};
     numdata = 5;
-    if (OPS_SetDoubleOutput(&numdata,output) < 0) {
+    if (OPS_SetDoubleOutput(&numdata,output, false) < 0) {
 	opserr << "WARNING: failed to set output -- sdfResponse\n";
 	return -1;
     }
@@ -1969,7 +1969,7 @@ int OPS_getNumThreads()
     int num = omp_get_max_threads();
     int numdata = 1;
 
-    if (OPS_SetIntOutput(&numdata,&num) < 0) {
+    if (OPS_SetIntOutput(&numdata,&num,true) < 0) {
 	opserr << "WARNING: failed to set output -- getNumThreads\n";
 	return -1;
     }

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -185,7 +185,7 @@ int OPS_nodeDisp()
 	double value = (*nodalResponse)(data[1]);
 	numdata = 1;
 
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr<<"WARNING nodeDisp - failed to read double inputs\n";
 	    return -1;
 	}
@@ -197,7 +197,7 @@ int OPS_nodeDisp()
 	for (int i=0; i<size; i++) {
 	    values[i] = (*nodalResponse)(i);
 	}
-	if (OPS_SetDoubleOutput(&size, &values[0]) < 0) {
+	if (OPS_SetDoubleOutput(&size, &values[0], false) < 0) {
 	    opserr<<"WARNING nodeDisp - failed to read double inputs\n";
 	    return -1;
 	}
@@ -247,7 +247,7 @@ int OPS_nodeReaction()
       numdata = 1;
 
       // now we copy the value to the tcl string that is returned
-      if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+      if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	  opserr<<"WARNING nodeReaction - failed to set double output\n";
 	  return -1;
       }
@@ -258,7 +258,7 @@ int OPS_nodeReaction()
 	for (int i=0; i<size; i++) {
 	    values[i] = (*nodalResponse)(i);
 	}
-	if (OPS_SetDoubleOutput(&size, &values[0]) < 0) {
+	if (OPS_SetDoubleOutput(&size, &values[0], false) < 0) {
 	    opserr<<"WARNING nodeReaction - failed to set double output\n";
 	    return -1;
 	}
@@ -314,7 +314,7 @@ int OPS_nodeEigenvector()
 	size = 1;
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&size, &value) < 0) {
+	if (OPS_SetDoubleOutput(&size, &value, true) < 0) {
 	    opserr<<"WARNING nodeEigenvector - failed to set double output\n";
 	    return -1;
 	}
@@ -327,7 +327,7 @@ int OPS_nodeEigenvector()
 	}
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&size, &values(0)) < 0) {
+	if (OPS_SetDoubleOutput(&size, &values(0), false) < 0) {
 	    opserr<<"WARNING nodeEigenvector - failed to set double output\n";
 	    return -1;
 	}
@@ -342,7 +342,7 @@ int OPS_getTime()
     if (theDomain == 0) return -1;
     double time = theDomain->getCurrentTime();
     int numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &time) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &time, true) < 0) {
 	opserr << "WARNING failed to get current time\n";
 	return -1;
     }
@@ -383,14 +383,28 @@ int OPS_eleResponse()
 	    for (int i=0; i<size; i++) {
 		newdata[i] = (*data)(i);
 	    }
-	    if (OPS_SetDoubleOutput(&size, newdata) < 0) {
+	    if (OPS_SetDoubleOutput(&size, newdata, false) < 0) {
 		opserr << "WARNING failed to et response\n";
 		delete [] newdata;
 		return -1;
 	    }
 	    delete [] newdata;
 
+	} else {
+        int size = 0;
+        double* newdata = 0;
+        if (OPS_SetDoubleOutput(&size, newdata, false) < 0) {
+            opserr << "WARNING failed to et response\n";
+            return -1;
+        }
 	}
+    } else {
+        int size = 0;
+        double* newdata = 0;
+        if (OPS_SetDoubleOutput(&size, newdata, false) < 0) {
+            opserr << "WARNING failed to et response\n";
+            return -1;
+        }
     }
     return 0;
 
@@ -419,7 +433,7 @@ int OPS_getLoadFactor()
     }
 
     double factor = thePattern->getLoadFactor();
-    if (OPS_SetDoubleOutput(&numdata, &factor) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &factor, true) < 0) {
 	opserr << "WARNING failed to set load factor\n";
 	return -1;
     }
@@ -1046,7 +1060,7 @@ int OPS_eleForce()
 	    double value = (*force)(dof);
 
 	    // now we copy the value to the tcl string that is returned
-	    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 		opserr << "WARNING eleForce failed to set output\n";
 		return -1;
 	    }
@@ -1057,7 +1071,7 @@ int OPS_eleForce()
 	    for (int i=0; i<size; i++) {
 		data[i] = (*force)(i);
 	    }
-	    if (OPS_SetDoubleOutput(&size, data) < 0) {
+	    if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 		opserr << "WARNING eleForce failed to set outputs\n";
 		delete [] data;
 		return -1;
@@ -1119,7 +1133,7 @@ int OPS_eleDynamicalForce()
 	double value = force(dof);
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, false) < 0) {
 	    opserr << "WARNING eleDyanmicalForce failed to set output\n";
 	    return -1;
 	}
@@ -1130,7 +1144,7 @@ int OPS_eleDynamicalForce()
 	for (int i=0; i<size; i++) {
 	    data[i] = force(i);
 	}
-	if (OPS_SetDoubleOutput(&size, data) < 0) {
+	if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	    opserr << "WARNING eleDyanmicalForce failed to set outputs\n";
 	    delete [] data;
 	    return -1;
@@ -1190,7 +1204,7 @@ int OPS_nodeUnbalance()
 	double value = (*nodalResponse)(dof);
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr << "WARNING nodeUnbalance failed to set output\n";
 	    return -1;
 	}
@@ -1201,7 +1215,7 @@ int OPS_nodeUnbalance()
 	for (int i=0; i<size; i++) {
 	    data[i] = (*nodalResponse)(i);
 	}
-	if (OPS_SetDoubleOutput(&size, data) < 0) {
+	if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	    opserr << "WARNING eleDyanmicalForce failed to set outputs\n";
 	    delete [] data;
 	    return -1;
@@ -1261,7 +1275,7 @@ int OPS_nodeVel()
 	double value = (*nodalResponse)(dof);
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr << "WARNING nodeVel failed to set output\n";
 	    return -1;
 	}
@@ -1272,7 +1286,7 @@ int OPS_nodeVel()
 	for (int i=0; i<size; i++) {
 	    data[i] = (*nodalResponse)(i);
 	}
-	if (OPS_SetDoubleOutput(&size, data) < 0) {
+	if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	    opserr << "WARNING nodeVel failed to set outputs\n";
 	    delete [] data;
 	    return -1;
@@ -1332,7 +1346,7 @@ int OPS_nodeAccel()
 	double value = (*nodalResponse)(dof);
 
 	// now we copy the value to the tcl string that is returned
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr << "WARNING nodeAccel failed to set output\n";
 	    return -1;
 	}
@@ -1343,7 +1357,7 @@ int OPS_nodeAccel()
 	for (int i=0; i<size; i++) {
 	    data[i] = (*nodalResponse)(i);
 	}
-	if (OPS_SetDoubleOutput(&size, data) < 0) {
+	if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	    opserr << "WARNING nodeAccel failed to set outputs\n";
 	    delete [] data;
 	    return -1;
@@ -1388,7 +1402,7 @@ int OPS_nodeResponse()
     numdata = 1;
 
     // now we copy the value to the tcl string that is returned
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }
@@ -1450,7 +1464,7 @@ int OPS_nodeCoord()
 	for (int i=0; i<size; i++) {
 	    data[i] = coords(i);
 	}
-	if (OPS_SetDoubleOutput(&size, data) < 0) {
+	if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	    opserr << "WARNING failed to set output\n";
 	    delete [] data;
 	    return -1;
@@ -1459,7 +1473,7 @@ int OPS_nodeCoord()
 
     } else if (dim < size) {
 	double value = coords(dim); // -1 for OpenSees vs C indexing
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr << "WARNING failed to set output\n";
 	    return -1;
 	}
@@ -1563,13 +1577,20 @@ int OPS_eleNodes()
 	    data[i] = (int)(*tags)(i);
 	}
 
-	if (OPS_SetIntOutput(&numTags, data) < 0) {
+	if (OPS_SetIntOutput(&numTags, data, false) < 0) {
 	    opserr << "WARNING failed to set outputs\n";
 	    delete [] data;
 	    return -1;
 	}
 
 	delete [] data;
+    } else {
+        int numTags = 0;
+        int* data = 0;
+        if (OPS_SetIntOutput(&numTags, data, false) < 0) {
+            opserr << "WARNING failed to set outputs\n";
+            return -1;
+        }
     }
 
     return 0;
@@ -1610,7 +1631,7 @@ int OPS_nodeDOFs()
     for (int i = 0; i < numDOF; i++) {
       data[i] = eqnNumbers(i);
     }
-    if (OPS_SetIntOutput(&numDOF, data) < 0) {
+    if (OPS_SetIntOutput(&numDOF, data, false) < 0) {
       opserr << "WARNING nodeDOFs failed to set outputs\n";
       delete [] data;
       return -1;
@@ -1655,7 +1676,7 @@ int OPS_nodeMass()
     else {
 	const Matrix &mass = theNode->getMass();
 	double value = mass(dof-1,dof-1);
-	if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	    opserr << "WARNING nodeMass failed to set mass\n";
 	}
     }
@@ -1686,7 +1707,7 @@ int OPS_nodePressure()
     if(thePC != 0) {
         pressure = thePC->getPressure();
     }
-    if (OPS_SetDoubleOutput(&numdata, &pressure) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &pressure, true) < 0) {
 	opserr << "WARNING failed to get presure\n";
 	return -1;
     }
@@ -1705,7 +1726,7 @@ int OPS_nodeBounds()
     for (int i = 0; i < size; i++)
       data[i] = bounds(i);
 
-    if (OPS_SetDoubleOutput(&size, data) < 0) {
+    if (OPS_SetDoubleOutput(&size, data, false) < 0) {
 	opserr << "WARNING failed to get node bounds\n";
 	delete [] data;
 	return -1;
@@ -1771,12 +1792,14 @@ int OPS_getEleTags()
 	}
     }
 
-    if (eletags.empty()) return 0;
+    int size = 0;
+    int *data = 0;
+    if (!eletags.empty()) {
+        size = (int) eletags.size();
+        data = &eletags[0];
+    }
 
-    int size = (int)eletags.size();
-    int* data = &eletags[0];
-
-    if (OPS_SetIntOutput(&size, data) < 0) {
+    if (OPS_SetIntOutput(&size, data, false) < 0) {
 	opserr << "WARNING failed to set outputs\n";
 	return -1;
     }
@@ -1826,12 +1849,14 @@ int OPS_getNodeTags()
 	}
     }
 
-    if (nodetags.empty()) return 0;
+    int size = 0;
+    int* data = 0;
+    if (!nodetags.empty()) {
+        size = (int)nodetags.size();
+        data = &nodetags[0];
+    }
 
-    int size = (int)nodetags.size();
-    int* data = &nodetags[0];
-
-    if (OPS_SetIntOutput(&size, data) < 0) {
+    if (OPS_SetIntOutput(&size, data, false) < 0) {
 	opserr << "WARNING failed to set outputs\n";
 	return -1;
     }
@@ -1903,7 +1928,7 @@ int OPS_sectionForce()
     double value = theVec(dof-1);
     numdata = 1;
 
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -1978,7 +2003,7 @@ int OPS_sectionDeformation()
     double value = theVec(dof-1);
     numdata = 1;
 
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2046,6 +2071,11 @@ int OPS_sectionStiffness()
     int nsdof = theMat.noCols();
     int size = nsdof*nsdof;
     if (size == 0) {
+        if (OPS_SetDoubleOutput(&size, 0, false) < 0) {
+            opserr << "WARNING failed to set output\n";
+            delete theResponse;
+            return -1;
+        }
 	delete theResponse;
 	return 0;
     }
@@ -2059,7 +2089,7 @@ int OPS_sectionStiffness()
 	}
     }
 
-    if (OPS_SetDoubleOutput(&size, &values[0]) < 0) {
+    if (OPS_SetDoubleOutput(&size, &values[0], false) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2127,6 +2157,11 @@ int OPS_sectionFlexibility()
     int nsdof = theMat.noCols();
     int size = nsdof*nsdof;
     if (size == 0) {
+        if (OPS_SetDoubleOutput(&size, 0, false) < 0) {
+            opserr << "WARNING failed to set output\n";
+            delete theResponse;
+            return -1;
+        }
 	delete theResponse;
 	return 0;
     }
@@ -2140,7 +2175,7 @@ int OPS_sectionFlexibility()
 	}
     }
 
-    if (OPS_SetDoubleOutput(&size, &values[0]) < 0) {
+    if (OPS_SetDoubleOutput(&size, &values[0], false) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2209,7 +2244,7 @@ int OPS_sectionLocation()
     double value = theVec(secNum-1);
     numdata = 1;
 
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2278,7 +2313,7 @@ int OPS_sectionWeight()
     double value = theVec(secNum-1);
     numdata = 1;
 
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2342,7 +2377,7 @@ int OPS_basicDeformation()
 	data[i] = theVec(i);
     }
 
-    if (OPS_SetDoubleOutput(&nbf, &data[0]) < 0) {
+    if (OPS_SetDoubleOutput(&nbf, &data[0], false) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2393,7 +2428,7 @@ int OPS_basicForce()
     Response *theResponse = theElement->setResponse(argvv, argcc, dummy);
     if (theResponse == 0) {
 	double res = 0.0;
-	if (OPS_SetDoubleOutput(&numdata, &res) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &res, false) < 0) {
 	    opserr << "WARNING: failed to set output\n";
 	    return -1;
 	}
@@ -2411,7 +2446,7 @@ int OPS_basicForce()
 	data[i] = theVec(i);
     }
 
-    if (OPS_SetDoubleOutput(&nbf, &data[0]) < 0) {
+    if (OPS_SetDoubleOutput(&nbf, &data[0], false) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2472,7 +2507,14 @@ int OPS_basicStiffness()
 
     std::vector<double> values;
     int size = nbf*nbf;
-    if (size == 0) return 0;
+    if (size == 0) {
+        if (OPS_SetDoubleOutput(&size, 0, false) < 0) {
+            opserr << "WARNING failed to set output\n";
+            delete theResponse;
+            return -1;
+        }
+        return 0;
+    }
     values.reserve(size);
 
 
@@ -2482,7 +2524,7 @@ int OPS_basicStiffness()
 	}
     }
 
-    if (OPS_SetDoubleOutput(&size, &values[0]) < 0) {
+    if (OPS_SetDoubleOutput(&size, &values[0], false) < 0) {
 	opserr << "WARNING failed to set output\n";
 	delete theResponse;
 	return -1;
@@ -2577,7 +2619,7 @@ int OPS_sensNodeDisp()
     double value = theNode->getDispSensitivity(data[1],gradIndex);
 
     numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -2621,7 +2663,7 @@ int OPS_sensNodeVel()
     double value = theNode->getVelSensitivity(data[1],gradIndex);
 
     numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -2665,7 +2707,7 @@ int OPS_sensNodeAccel()
     double value = theNode->getAccSensitivity(data[1],gradIndex);
 
     numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -2706,7 +2748,7 @@ int OPS_sensLambda()
     double factor = thePattern->getLoadFactorSensitivity(gradIndex);
 
     numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &factor) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &factor, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -2785,7 +2827,7 @@ int OPS_sensSectionForce()
     if (theResponse == 0) {
 	numdata = 1;
 	double res = 0.0;
-	if (OPS_SetDoubleOutput(&numdata, &res) < 0) {
+	if (OPS_SetDoubleOutput(&numdata, &res, true) < 0) {
 	    opserr<<"WARNING failed to set output\n";
 	    return -1;
 	}
@@ -2798,7 +2840,7 @@ int OPS_sensSectionForce()
     Vector theVec = *(info.theVector);
 
     numdata = theVec.Size();
-    if (OPS_SetDoubleOutput(&numdata, &theVec(dof-1)) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &theVec(dof-1), false) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
@@ -2848,7 +2890,7 @@ int OPS_sensNodePressure()
     }
 
     numdata = 1;
-    if (OPS_SetDoubleOutput(&numdata, &dp) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &dp, true) < 0) {
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }

--- a/SRC/interpreter/OpenSeesParameterCommands.cpp
+++ b/SRC/interpreter/OpenSeesParameterCommands.cpp
@@ -86,7 +86,7 @@ OPS_Parameter()
 	    return -1;
 	}
 
-	if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+	if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 	    opserr << "WARING: parameter - failed to set parameter tag\n";
 	    return -1;
 	}
@@ -111,7 +111,7 @@ OPS_Parameter()
 	    return -1;
 	}
 
-	if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+	if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 	    opserr << "WARING: parameter - failed to set parameter tag\n";
 	    return -1;
 	}
@@ -151,7 +151,7 @@ OPS_Parameter()
 		    return -1;
 		}
 
-		if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+		if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 		    opserr << "WARING: parameter - failed to set parameter tag\n";
 		    return -1;
 		}
@@ -197,7 +197,7 @@ OPS_Parameter()
 		    return -1;
 		}
 
-		if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+		if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 		    opserr << "WARING: parameter - failed to set parameter tag\n";
 		    return -1;
 		}
@@ -352,7 +352,7 @@ OPS_Parameter()
 	theDomain->addParameter(newParameter);
     }
 
-    if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+    if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 	opserr << "WARING: parameter - failed to set parameter tag\n";
 	return -1;
     }
@@ -492,7 +492,7 @@ OPS_addToParameter()
 
     }
 
-    if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+    if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 	opserr << "WARING: parameter - failed to set parameter tag\n";
 	return -1;
     }
@@ -542,7 +542,7 @@ OPS_updateParameter()
 
     theDomain->updateParameter(paramTag, newValue);
 
-    if (OPS_SetIntOutput(&num, &paramTag) < 0) {
+    if (OPS_SetIntOutput(&num, &paramTag, true) < 0) {
 	opserr << "WARING: parameter - failed to set parameter tag\n";
 	return -1;
     }
@@ -564,12 +564,14 @@ int OPS_getParamTags()
 	tags.push_back(theParam->getTag());
     }
 
-    if (tags.empty()) return 0;
+    int size = 0;
+    int* data = 0;
+    if (!tags.empty()) {
+        size = (int) tags.size();
+        data = &tags[0];
+    }
 
-    int size = (int)tags.size();
-    int* data = &tags[0];
-
-    if (OPS_SetIntOutput(&size, data) < 0) {
+    if (OPS_SetIntOutput(&size, data, false) < 0) {
 	opserr << "WARNING failed to set outputs\n";
 	return -1;
     }
@@ -604,7 +606,7 @@ int OPS_getParamValue()
 
     double value = theParam->getValue();
 
-    if (OPS_SetDoubleOutput(&numdata, &value) < 0) {
+    if (OPS_SetDoubleOutput(&numdata, &value, true) < 0) {
 	opserr << "WARNING failed to set output\n";
 	return -1;
     }

--- a/SRC/interpreter/OpenSeesReliabilityCommands.cpp
+++ b/SRC/interpreter/OpenSeesReliabilityCommands.cpp
@@ -497,10 +497,14 @@ int OPS_getRVTags()
   while ((theRV = rvIter()) != 0)
     rvTags.push_back(theRV->getTag());
 
-  int size = (int)rvTags.size();
-  int *data = &rvTags[0];
+  int size = 0;
+  int *data = 0;
+  if (!rvTags.empty()) {
+      size = (int)rvTags.size();
+      data = &rvTags[0];
+  }
 
-  if (OPS_SetIntOutput(&size,data) < 0) {
+  if (OPS_SetIntOutput(&size,data,false) < 0) {
     opserr << "ERROR: failed to set outputs in getRVTags" << endln;
     return -1;
   }
@@ -532,7 +536,7 @@ int OPS_getRVMean()
   }
 
   double mean = rv->getMean();
-  if (OPS_SetDoubleOutput(&numData, &mean) < 0) {
+  if (OPS_SetDoubleOutput(&numData, &mean, true) < 0) {
     opserr << "ERROR: getMean - failed to set double output\n";
     return -1;
   }
@@ -564,7 +568,7 @@ int OPS_getRVStdv()
   }
 
   double stdv = rv->getStdv();
-  if (OPS_SetDoubleOutput(&numData, &stdv) < 0) {
+  if (OPS_SetDoubleOutput(&numData, &stdv, true) < 0) {
     opserr << "ERROR: getStdv - failed to set double output\n";
     return -1;
   }
@@ -602,7 +606,7 @@ int OPS_getRVPDF()
   }
 
   double pdf = rv->getPDFvalue(x);
-  if (OPS_SetDoubleOutput(&numData, &pdf) < 0) {
+  if (OPS_SetDoubleOutput(&numData, &pdf, true) < 0) {
     opserr << "ERROR: getPDF - failed to set double output\n";
     return -1;
   }
@@ -640,7 +644,7 @@ int OPS_getRVCDF()
   }
 
   double cdf = rv->getCDFvalue(x);
-  if (OPS_SetDoubleOutput(&numData, &cdf) < 0) {
+  if (OPS_SetDoubleOutput(&numData, &cdf, true) < 0) {
     opserr << "ERROR: getCDF - failed to set double output\n";
     return -1;
   }
@@ -678,7 +682,7 @@ int OPS_getRVInverseCDF()
   }
 
   double invcdf = rv->getInverseCDFvalue(p);
-  if (OPS_SetDoubleOutput(&numData, &invcdf) < 0) {
+  if (OPS_SetDoubleOutput(&numData, &invcdf, true) < 0) {
     opserr << "ERROR: getInverseCDF - failed to set double output\n";
     return -1;
   }
@@ -808,7 +812,7 @@ int OPS_transformUtoX()
   Vector x(nrv);
   theTransf->transform_u_to_x(u, x);
 
-  if (OPS_SetDoubleOutput(&nrv, &x[0]) < 0) {
+  if (OPS_SetDoubleOutput(&nrv, &x[0], false) < 0) {
     opserr << "ERROR: failed to set output in transformUtoX" << endln;
     return -1;
   }

--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -495,7 +495,7 @@ int OPS_getStrain()
 
     int numData = 1;
 
-    if (OPS_SetDoubleOutput(&numData, &strain) < 0) {
+    if (OPS_SetDoubleOutput(&numData, &strain, true) < 0) {
 	opserr<<"failed to set strain\n";
 	return -1;
     }
@@ -515,7 +515,7 @@ int OPS_getStress()
 
     int numData = 1;
 
-    if (OPS_SetDoubleOutput(&numData, &stress) < 0) {
+    if (OPS_SetDoubleOutput(&numData, &stress, true) < 0) {
 	opserr<<"failed to set stress\n";
 	return -1;
     }
@@ -535,7 +535,7 @@ int OPS_getTangent()
 
     int numData = 1;
 
-    if (OPS_SetDoubleOutput(&numData, &tangent) < 0) {
+    if (OPS_SetDoubleOutput(&numData, &tangent, true) < 0) {
 	opserr<<"failed to set tangent\n";
 	return -1;
     }
@@ -555,7 +555,7 @@ int OPS_getDampTangent()
 
     int numData = 1;
 
-    if (OPS_SetDoubleOutput(&numData, &tangent) < 0) {
+    if (OPS_SetDoubleOutput(&numData, &tangent, true) < 0) {
 	opserr<<"failed to set damp tangent\n";
 	return -1;
     }

--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -137,7 +137,16 @@ PythonModule::getString() {
         return 0;
     }
 
-    return PyUnicode_AsUTF8(o);
+    PyObject* space = PyUnicode_FromString(" ");
+    PyObject* empty = PyUnicode_FromString("");
+    PyObject* newo = PyUnicode_Replace(o, space, empty, -1);
+    const char* res = PyUnicode_AsUTF8(newo);
+
+    Py_DECREF(newo);
+    Py_DECREF(space);
+    Py_DECREF(empty);
+
+    return res;
 #else
     if (!PyString_Check(o)) {
         return 0;

--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -167,15 +167,15 @@ PythonModule::resetInput(int cArg) {
 }
 
 int
-PythonModule::setInt(int *data, int numArgs) {
-    wrapper.setOutputs(data, numArgs);
+PythonModule::setInt(int *data, int numArgs, bool scalar) {
+    wrapper.setOutputs(data, numArgs, scalar);
 
     return 0;
 }
 
 int
-PythonModule::setDouble(double *data, int numArgs) {
-    wrapper.setOutputs(data, numArgs);
+PythonModule::setDouble(double *data, int numArgs, bool scalar) {
+    wrapper.setOutputs(data, numArgs, scalar);
 
     return 0;
 }

--- a/SRC/interpreter/PythonModule.h
+++ b/SRC/interpreter/PythonModule.h
@@ -78,8 +78,8 @@ class PythonModule: public DL_Interpreter
     virtual void resetInput(int cArg);
 
     // methods for interpreters to output results
-    virtual int setInt(int *, int numArgs);
-    virtual int setDouble(double *, int numArgs);
+    virtual int setInt(int *, int numArgs, bool scalar);
+    virtual int setDouble(double *, int numArgs, bool scalar);
     virtual int setString(const char*);
 
     // methods to run a command in the interpreter

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -95,30 +95,36 @@ PythonWrapper::getMethods()
 }
 
 void
-PythonWrapper::setOutputs(int* data, int numArgs)
+PythonWrapper::setOutputs(int* data, int numArgs, bool scalar)
 {
-    if (numArgs == 0) return;
-    if (numArgs == 1) {
-	currentResult = Py_BuildValue("i", data[0]);
-	return ;
-    }
-    currentResult = PyList_New(numArgs);
-    for (int i=0; i<numArgs; i++) {
-	PyList_SET_ITEM(currentResult, i, Py_BuildValue("i", data[i]));
+    if (numArgs < 0) numArgs = 0;
+
+    if (scalar) {
+        if (numArgs > 0) {
+            currentResult = Py_BuildValue("i", data[0]);
+        }
+    } else {
+        currentResult = PyList_New(numArgs);
+        for (int i = 0; i < numArgs; i++) {
+            PyList_SET_ITEM(currentResult, i, Py_BuildValue("i", data[i]));
+        }
     }
 }
 
 void
-PythonWrapper::setOutputs(double* data, int numArgs)
+PythonWrapper::setOutputs(double* data, int numArgs, bool scalar)
 {
-    if (numArgs == 0) return;
-    if (numArgs == 1) {
-	currentResult = Py_BuildValue("d", data[0]);
-	return ;
-    }
-    currentResult = PyList_New(numArgs);
-    for (int i=0; i<numArgs; i++) {
-	PyList_SET_ITEM(currentResult, i, Py_BuildValue("d", data[i]));
+    if (numArgs < 0) numArgs = 0;
+
+    if (scalar) {
+        if (numArgs > 0) {
+            currentResult = Py_BuildValue("d", data[0]);
+        }
+    } else {
+        currentResult = PyList_New(numArgs);
+        for (int i = 0; i < numArgs; i++) {
+            PyList_SET_ITEM(currentResult, i, Py_BuildValue("d", data[i]));
+        }
     }
 }
 

--- a/SRC/interpreter/PythonWrapper.h
+++ b/SRC/interpreter/PythonWrapper.h
@@ -74,8 +74,8 @@ public:
     void incrCurrentArg() {currentArg++;}
 
     // set outputs
-    void setOutputs(int* data, int numArgs);
-    void setOutputs(double* data, int numArgs);
+    void setOutputs(int* data, int numArgs, bool scalar);
+    void setOutputs(double* data, int numArgs, bool scalar);
     void setOutputs(const char* str);
     PyObject* getResults();
 

--- a/SRC/interpreter/TclInterpreter.cpp
+++ b/SRC/interpreter/TclInterpreter.cpp
@@ -560,14 +560,14 @@ TclInterpreter::resetInput(int cArg)
 }
 
 int
-TclInterpreter::setInt(int* data, int numArgs)
+TclInterpreter::setInt(int* data, int numArgs, bool scalar)
 {
     wrapper.setOutputs(interp, data, numArgs);
     return 0;
 }
 
 int
-TclInterpreter::setDouble(double* data, int numArgs)
+TclInterpreter::setDouble(double* data, int numArgs, bool scalar)
 {
     wrapper.setOutputs(interp, data, numArgs);
     return 0;

--- a/SRC/interpreter/TclInterpreter.h
+++ b/SRC/interpreter/TclInterpreter.h
@@ -66,8 +66,8 @@ class TclInterpreter: public DL_Interpreter
     virtual void resetInput(int cArg);
 
     // methods for interpreters to output results
-    virtual int setInt(int *, int numArgs);
-    virtual int setDouble(double *, int numArgs);
+    virtual int setInt(int *, int numArgs, bool scalar);
+    virtual int setDouble(double *, int numArgs, bool scalar);
     virtual int setString(const char*);
     
   private:


### PR DESCRIPTION
1. In a string input, remove spaces before passing to APIs
2. Python now can return empty and one-element lists in case lists output are expected. Before, python returns None and scalar. In some cases, if a scalar is expected, the scalar is still returned.