### PR TITLE
Performance Up

### DIFF
--- a/SRC/graph/graph/Vertex.h
+++ b/SRC/graph/graph/Vertex.h
@@ -61,6 +61,7 @@ class Vertex: public TaggedObject
     virtual int addEdge(int otherTag);
     virtual int getDegree(void) const;
     virtual const ID &getAdjacency(void) const;
+    virtual void setAdjacency(const ID& adj) {myAdjacency = adj;}
 
     virtual  void Print(OPS_Stream &s, int flag =0);
     int sendSelf(int commitTag, Channel &theChannel);

--- a/SRC/tagged/storage/MapOfTaggedObjects.cpp
+++ b/SRC/tagged/storage/MapOfTaggedObjects.cpp
@@ -78,22 +78,11 @@ MapOfTaggedObjects::addComponent(TaggedObject *newComponent)
     int tag = newComponent->getTag();
 
     // check if the ele already in map, if not we add
-    theEle = theMap.find(tag);
-    if (theEle == theMap.end()) {
-	theMap.insert(MAP_TAGGED_TYPE(tag,newComponent));
-		      
-	// check if sucessfully added 
-	theEle = theMap.find(tag);
-	if (theEle == theMap.end()) {
-	  opserr << "MapOfTaggedObjects::addComponent - map STL failed to add object with tag : " << 
-	    newComponent->getTag() << "\n";
-	  return false;
-	}
-    }
-    
+    std::pair<MAP_TAGGED_ITERATOR,bool> res = theMap.insert(MAP_TAGGED_TYPE(tag,newComponent));
+    if (res.second == false) {
+
     // if ele already there map cannot add even if allowMultiple is true
     // as the map template does not allow multiple entries wih the same tag
-    else {	
       opserr << "MapOfTaggedObjects::addComponent - not adding as one with similar tag exists, tag: " <<
 	newComponent->getTag() << "\n";
       return false;


### PR DESCRIPTION
1. In addComponent of MapOfTaggedObjects, the find, insert, and check can now combined in one insert function, avoiding search the map 3 times.
2.The getDOFGraph function in AnalysisModel is boosted. For a 3 million nodes example, the function takes 2.73 sec instead of 12.2 sec.  