### PR TITLE
Newmark updates

### DIFF
--- a/SRC/analysis/integrator/Newmark.cpp
+++ b/SRC/analysis/integrator/Newmark.cpp
@@ -235,18 +235,14 @@ int Newmark::newStep(double deltaT)
     if (init == 1) {
         // determine new velocities and accelerations at t+deltaT
         *Udot = *Utdot;
-        double a1 = (1.0 - gamma / beta);
-        double a2 = (deltaT) * (1.0 - 0.5 * gamma / beta);
-        Udot->addVector(a1, *Utdotdot, a2);
-        Udot->addVector(1.0, *U, c2);
-        Udot->addVector(1.0, *Ut, -c2);
+        Udot->addVector(1.0-gamma/beta, *Utdotdot, deltaT*(1.0-0.5*gamma/beta));
+        Udot->addVector(1.0, *U, gamma / (deltaT * beta));
+        Udot->addVector(1.0, *Ut, -gamma / (deltaT * beta));
 
         *Udotdot = *Utdotdot;
-        double a3 = -1.0 / (beta * deltaT);
-        double a4 = 1.0 - 0.5 / beta;
-        Udotdot->addVector(a4, *Utdot, a3);
-        Udotdot->addVector(1.0, *U, c3);
-        Udotdot->addVector(1.0, *Ut, -c3);
+        Udotdot->addVector(1.0-0.5/beta, *Utdot, -1.0 / (beta * deltaT));
+        Udotdot->addVector(1.0, *U, 1.0/(deltaT * deltaT * beta));
+        Udotdot->addVector(1.0, *Ut, -1.0/(deltaT * deltaT * beta));
 
         // set the trial response quantities
         theModel->setVel(*Udot);
@@ -255,16 +251,13 @@ int Newmark::newStep(double deltaT)
     } else if (init == 2) {
         // determine new displacements and accelerations at t+deltaT
         *U = *Ut;
-        double a1 = deltaT*(1-beta/gamma);
-        U->addVector(1.0, *Utdot, a1);
-        double a2 = deltaT*deltaT*(0.5-beta/gamma);
-        U->addVector(1.0, *Utdotdot, a2);
-        U->addVector(1.0, *Udot, c1);
+        U->addVector(1.0, *Utdot, deltaT*(1-beta/gamma));
+        U->addVector(1.0, *Udot, deltaT*beta/gamma);
+        U->addVector(1.0, *Utdotdot, deltaT*deltaT*(0.5-beta/gamma));
 
         *Udotdot = *Utdotdot;
-        double a3 = (1-1.0/gamma);
-        Udotdot->addVector(a3, *Udot, c3);
-        Udotdot->addVector(1.0, *Utdot, -c3);
+        Udotdot->addVector((1-1.0/gamma), *Udot, 1.0/(gamma*deltaT));
+        Udotdot->addVector(1.0, *Utdot, -1.0/(gamma*deltaT));
 
         // set the trial response quantities
         theModel->setDisp(*U);
@@ -273,16 +266,13 @@ int Newmark::newStep(double deltaT)
     } else  {
         // determine new displacements and velocities at t+deltaT
         *U = *Ut;
-        double a1 = (deltaT*deltaT/2.0);
         U->addVector(1.0, *Utdot, deltaT);
-        U->addVector(1.0, *Utdotdot, a1);
-        U->addVector(1.0, *Udotdot, c1);
-        U->addVector(1.0, *Utdotdot, -c1);
+        U->addVector(1.0, *Utdotdot, deltaT*deltaT*(0.5-beta));
+        U->addVector(1.0, *Udotdot, deltaT*deltaT*beta);
 
         *Udot = *Utdot;
-        Udot->addVector(1.0, *Utdotdot, deltaT);
-        Udot->addVector(1.0, *Udotdot, c2);
-        Udot->addVector(1.0, *Utdotdot, -c2);
+        Udot->addVector(1.0, *Utdotdot, deltaT*(1-gamma));
+        Udot->addVector(1.0, *Udotdot, deltaT*gamma);
 
         // set the trial response quantities
         theModel->setDisp(*U);

--- a/SRC/analysis/integrator/Newmark.h
+++ b/SRC/analysis/integrator/Newmark.h
@@ -48,7 +48,7 @@ class Newmark : public TransientIntegrator
 public:
     // constructors
     Newmark();
-    Newmark(double gamma, double beta, int disp = 1, bool aflag=false);
+    Newmark(double gamma, double beta, int disp = 1, bool aflag=false, int init = 1);
 
     // destructor
     ~Newmark();
@@ -85,6 +85,7 @@ public:
     
 protected:
     int displ;      // a flag indicating whether displ(1), vel(2) or accel(3) increments
+    int init;  // 1-disp, 2-vel, 3-accel
     double gamma;
     double beta;
     
@@ -104,6 +105,8 @@ protected:
     //////////////////////
     
 private:
+    int populateU();
+    int populateUn();
 };
 
 #endif


### PR DESCRIPTION
Currently, user can choose which '-form' for Newmark. The form can be 'A', 'V', or 'D'. If a form is chosen, the corresponding a0, v0, or d0 will be used for the initial guess of the Newton method. 

Sometimes, the form and the initial guess may be different. For example, the user could assume the displacement as the primary variable but use the v0 as the initial guess to populate a0 and d0.

In this pull request, an option '-init' is added to let user choose the initial guess. The default behavior of newmark is not changed, i.e. displacement is the primary variable and Un is the initial guess. 

With the updates, the user could now to predict U of the next time step by setting the trial displacement, and use the U_{n+1}^0 as the initial guess instead of Un.