### PR TITLE
Fixing wrong return code in FiberSection3d::setParameter

### DIFF
--- a/SRC/material/section/FiberSection3d.cpp
+++ b/SRC/material/section/FiberSection3d.cpp
@@ -1363,7 +1363,7 @@ FiberSection3d::setParameter(const char **argv, int argc, Parameter &param)
   if (argc < 1)
     return -1;
 
-  int result = 0;
+  int result = -1;
 
   // A material parameter
   if (strstr(argv[0],"material") != 0) {

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1198,7 +1198,7 @@ FiberSection3dThermal::setParameter(const char **argv, int argc, Parameter &para
     return -1;
 
 
-  int result = 0;
+  int result = -1;
 
   // A material parameter
   if (strstr(argv[0],"material") != 0) {


### PR DESCRIPTION
The return code is wrongly initialized to 0, thus If the parameter is not handled by the section, the method will reuturn 0 (which means "handled") instead of -1.
This creates bugs in the following SSI scenario:
1) you have a beam element with fiber section
2) you have solid elements whose material stage should be updated from elastic to plastic with the updateMaterialStage command.
3) Then if the beam element has a tag < than the smallest tag of the solid elements (i.e. if it has been created before the solid elements), the updateMaterialStage will stop iterating on elements when it finds the first one who handle the paramter, in this case (erroneously) the beam element, thus not reaching the solid elements.

This PR simply changes the return code from 0 to -1 as initial value.