### PR TITLE
Fixing bug in DKG family of shell elements - wrong B-bending sign

### DIFF
--- a/SRC/element/shell/ShellDKGQ.cpp
+++ b/SRC/element/shell/ShellDKGQ.cpp
@@ -1611,6 +1611,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+     /*
+     bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+     sent to the section had the wrong sign.
+     */
+     Bbend *= -1.0;
+
 	 return Bbend;
  }
 

--- a/SRC/element/shell/ShellDKGT.cpp
+++ b/SRC/element/shell/ShellDKGT.cpp
@@ -2036,6 +2036,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+     /*
+     bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+     sent to the section had the wrong sign.
+     */
+     Bbend *= -1.0;
+
 	 return Bbend;
  }
 

--- a/SRC/element/shell/ShellNLDKGQ.cpp
+++ b/SRC/element/shell/ShellNLDKGQ.cpp
@@ -1920,6 +1920,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 //*************************************************************************

--- a/SRC/element/shell/ShellNLDKGQThermal.cpp
+++ b/SRC/element/shell/ShellNLDKGQThermal.cpp
@@ -2206,6 +2206,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 //*************************************************************************

--- a/SRC/element/shell/ShellNLDKGT.cpp
+++ b/SRC/element/shell/ShellNLDKGT.cpp
@@ -1842,6 +1842,12 @@ const Matrix&
 	 Bbend(2,1) = shpBend[3][j] + shpBend[4][j];
 	 Bbend(2,2) = shpBend[3][k] + shpBend[4][k];
 
+	 /*
+	 bugfix: Massimo Petracca 02/26/2020. with the original implementation, the curvatures
+	 sent to the section had the wrong sign.
+	 */
+	 Bbend *= -1.0;
+
 	 return Bbend;
  }
 

--- a/SRC/material/section/FiberSection3d.cpp
+++ b/SRC/material/section/FiberSection3d.cpp
@@ -1363,7 +1363,7 @@ FiberSection3d::setParameter(const char **argv, int argc, Parameter &param)
   if (argc < 1)
     return -1;
 
-  int result = 0;
+  int result = -1;
 
   // A material parameter
   if (strstr(argv[0],"material") != 0) {


### PR DESCRIPTION
**DKG  family** of shell elements (ShellDKGQ, ShellDKGT, ShellNLDKGQ, ShellNLDKGT and ShellDKGQThermal) show a **wrong behaviour in bending** only visible when used with LayeredShellSection.

They compute the **curvature** with a **sign** which is **inverted** with respect to what the layered shell expects. However they post-multiply the bending B-matrix so when they compute B^T*S the sign of the internal forces is correct.

However this does not give correct results when used with composite sections, with nonlinear material that behave differently in tension and compression.

The following problem consists in a cantilever beam with a composite cross section. The top-half of the section is elastic, while the bottom-half is a drucker-prager plastic model with compressive strength > tensile strength. Then a comparison is made among ShellMITC4 (correct), ShellDKGQ (and other variants, bug) and the reference solid model (brick 20 nodes):

![bug_dkgq](https://user-images.githubusercontent.com/26160906/75400174-c64b9100-58fe-11ea-8f5f-0462c711eedc.png)

Here you can find the TCL files to reproduce the bug. They use the mpco recorder command to output the HDF5 database for post-processing in STKO. If you don't want to use it, just comment the recorder command in the analysis_step.tcl files. At the end of the analysis, the maximum deflection of each of the 3 models is printed to the terminal. Also there is an element recorder that outputs the stress at the top fiber, where you can see that the DKG elements outputs a positive S11 stress while it should be negative.
[DKGQ.zip](https://github.com/OpenSees/OpenSees/files/4258859/DKGQ.zip)
[DKGT.zip](https://github.com/OpenSees/OpenSees/files/4258862/DKGT.zip)
[NLDKGQ.zip](https://github.com/OpenSees/OpenSees/files/4258863/NLDKGQ.zip)
[NLDKGT.zip](https://github.com/OpenSees/OpenSees/files/4258864/NLDKGT.zip)
[NLDKGQThermal.zip](https://github.com/OpenSees/OpenSees/files/4258867/NLDKGQThermal.zip)
