### PR TITLE
fix Makefiles after moving Bilin from snap up to uniaxial

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -766,8 +766,8 @@ MATERIAL_LIBS   =  $(FE)/material/Material.o \
 	$(FE)/material/uniaxial/pyUCLA.o \
 	$(FE)/material/uniaxial/FatigueMaterial.o \
 	$(FE)/material/uniaxial/SAWSMaterial.o \
-	$(FE)/material/uniaxial/snap/Bilin.o \
-	$(FE)/material/uniaxial/snap/Bilin02.o \
+	$(FE)/material/uniaxial/Bilin.o \
+	$(FE)/material/uniaxial/Bilin02.o \
 	$(FE)/material/uniaxial/ConfinedConcrete01.o \
 	$(FE)/material/uniaxial/CableMaterial.o \
 	$(FE)/material/uniaxial/ENTMaterial.o \

--- a/SRC/material/uniaxial/Makefile
+++ b/SRC/material/uniaxial/Makefile
@@ -5,6 +5,8 @@ OBJS       = UniaxialMaterial.o \
 	Elastic2Material.o \
 	ElasticPowerFunc.o \
 	UVCuniaxial.o \
+	Bilin.o \
+	Bilin02.o \
 	IMKBilin.o \
 	IMKPeakOriented.o \
 	IMKPinching.o \

--- a/SRC/material/uniaxial/snap/Makefile
+++ b/SRC/material/uniaxial/snap/Makefile
@@ -2,13 +2,10 @@ include ../../../../Makefile.def
 
 OBJS       = Pinching.o \
 	Bilinear.o \
-	Bilin.o \
-	Bilin02.o \
 	Clough.o \
 	CloughHenry.o \
 	CloughDamage.o \
 	PinchingDamage.o \
-	Bilin.o \
 	TclSnapMaterialCommand.o
 
 all:         $(OBJS)


### PR DESCRIPTION
This PR fixes Makefile files after moving Bilin from snap up to uniaxial.