### PR TITLE
Partition in OpenSeesPy

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -1036,11 +1036,15 @@ SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSolver.o
 endif
 
-# ifeq ($(PROGRAMMING_MODE), PARALLEL_INTERPRETERS)
-# SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o \
-# 	$(FE)/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.o \
-# 	$(FE)/system_of_eqn/linearSOE/sparseGEN/DistributedSparseGenColLinSOE.o 
-# endif
+ifeq ($(PROGRAMMING_MODE), PARALLEL_INTERPRETERS)
+SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o \
+	$(FE)/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.o \
+	$(FE)/system_of_eqn/linearSOE/sparseGEN/DistributedSparseGenColLinSOE.o \
+	$(FE)/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.o \
+	$(FE)/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.o \
+	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSOE.o \
+	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSolver.o
+endif
 
 CUDA_CLASSES = 
 

--- a/SRC/interpreter/Makefile
+++ b/SRC/interpreter/Makefile
@@ -35,9 +35,9 @@ OBJSm = OpenSeesCommandsPython.o OpenSeesUniaxialMaterialCommands.o PythonModelB
 pythonmodule: $(PythonModuleOBJS)
 	$(RM) $(RMFLAGS) opensees.so;
 	$(LINKER) $(LINKFLAGS) -Wl,-rpath,\$$ORIGIN/lib -shared $(PythonModuleOBJS) \
+	$(INTERPRETER_LIBS_MPI_PARAMETERS) \
 	$(FE_LIBRARY) $(MACHINE_LINKLIBS) $(PYTHON_LIBRARY) \
 	$(MACHINE_NUMERICAL_LIBS) $(MACHINE_SPECIFIC_LIBS) $(PARALLEL_LIB) \
-	$(INTERPRETER_LIBS_MPI_PARAMETERS) \
 	 -o opensees.so
 
 

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -97,14 +97,38 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <NewtonLineSearch.h>
 #include <FileDatastore.h>
 #include <Mesh.h>
+#include <MumpsSolver.h>
+#include <MumpsSOE.h>
 
 #ifdef _PARALLEL_INTERPRETERS
+bool setMPIDSOEFlag = false;
+
 #include <mpi.h>
 #include <MPI_MachineBroker.h>
 #include <ParallelNumberer.h>
 #include <DistributedDisplacementControl.h>
+#include <DistributedBandSPDLinSOE.h>
+#include <DistributedSparseGenColLinSOE.h>
+#include <DistributedSparseGenRowLinSOE.h>
+#include <DistributedBandGenLinSOE.h>
+#include <DistributedDiagonalSOE.h>
+#include <DistributedDiagonalSolver.h>
+#include <MPIDiagonalSOE.h>
+#include <MPIDiagonalSolver.h>
+#define MPIPP_H
+#include <DistributedSuperLU.h>
+#include <DistributedProfileSPDLinSOE.h>
+#ifdef _MUMPS
 #include <MumpsParallelSOE.h>
 #include <MumpsParallelSolver.h>
+#endif
+#elif _PARALLEL_PROCESSING
+#include <mpi.h>
+#include <PartitionedDomain.h>
+#ifdef _MUMPS
+#include <MumpsParallelSOE.h>
+#include <MumpsParallelSolver.h>
+#endif
 #endif
 
 
@@ -548,6 +572,12 @@ OpenSeesCommands::setStaticAnalysis()
     if (theEigenSOE != 0) {
 	theStaticAnalysis->setEigenSOE(*theEigenSOE);
     }
+
+#ifdef _PARALLEL_INTERPRETERS
+    if (setMPIDSOEFlag) {
+        ((MPIDiagonalSOE*)theSOE)->setAnalysisModel(*theAnalysisModel);
+    }
+#endif
 }
 
 int
@@ -628,6 +658,12 @@ OpenSeesCommands::setPFEMAnalysis()
     if (theEigenSOE != 0) {
 	theTransientAnalysis->setEigenSOE(*theEigenSOE);
     }
+
+#ifdef _PARALLEL_INTERPRETERS
+    if (setMPIDSOEFlag) {
+        ((MPIDiagonalSOE*)theSOE)->setAnalysisModel(*theAnalysisModel);
+    }
+#endif
 
     return 0;
 }
@@ -767,7 +803,11 @@ OpenSeesCommands::setTransientAnalysis()
     if (theEigenSOE != 0) {
 	theTransientAnalysis->setEigenSOE(*theEigenSOE);
     }
-
+#ifdef _PARALLEL_INTERPRETERS
+	if (setMPIDSOEFlag) {
+	  ((MPIDiagonalSOE*) theSOE)->setAnalysisModel(*theAnalysisModel);
+	}
+#endif
 }
 
 void
@@ -1099,8 +1139,14 @@ int OPS_System()
 
 
     } else if (strcmp(type,"MPIDiagonal") == 0) {
+#ifdef _PARALLEL_INTERPRETERS
+        MPIDiagonalSolver* theSolver = new MPIDiagonalSolver();
+        theSOE = new MPIDiagonalSOE(*theSolver);
+        setMPIDSOEFlag = true;
+#else
 	// Diagonal SOE & SOLVER
 	theSOE = (LinearSOE*)OPS_DiagonalDirectSolver();
+#endif
 
     } else if (strcmp(type,"SProfileSPD") == 0) {
 	// PROFILE SPD SOE * SOLVER
@@ -1110,6 +1156,20 @@ int OPS_System()
     } else if (strcmp(type, "ProfileSPD") == 0) {
 
 	theSOE = (LinearSOE*)OPS_ProfileSPDLinDirectSolver();
+
+#ifdef _PARALLEL_INTERPRETERS
+    } else if (strcmp(type, "ParallelProfileSPD") == 0) {
+        ProfileSPDLinSolver* theSolver = new ProfileSPDLinDirectSolver();
+        DistributedProfileSPDLinSOE* theParallelSOE = new DistributedProfileSPDLinSOE(*theSolver);
+        theSOE = theParallelSOE;
+        auto theMachineBroker = cmds->getMachineBroker();
+        auto rank = theMachineBroker->getPID();
+        auto numChannels = cmds->getNumChannels();
+        auto theChannels = cmds->getChannels();
+        theParallelSOE->setProcessID(rank);
+        theParallelSOE->setChannels(numChannels, theChannels);
+    
+#endif
 
     } else if (strcmp(type, "PFEM") == 0) {
 	// PFEM SOE & SOLVER
@@ -3123,6 +3183,8 @@ void* OPS_MumpsSolver() {
     soe->setChannels(numChannels, channels);
     return soe;
 #else
+    MumpsSolver *theSolver = new MumpsSolver(icntl7, icntl14);
+    theSOE = new MumpsSOE(*theSolver);
     return 0;
 #endif
 

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -316,6 +316,7 @@ int OPS_sdfResponse();
 int OPS_getNumThreads();
 int OPS_setNumThreads();
 int OPS_setStartNodeTag();
+int OPS_partition();
 
 // OpenSeesReliabilityCommands.cpp
 int OPS_randomVariable();

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -490,8 +490,7 @@ void* OPS_BFGS();
 
 // commands that changed or added:
 //
-//    missing : video, partition,
-//              reliability, wipeReliability,
+//    missing : video,
 //              FiberThermal, FiberInt,
 //              UCFiber, TclModelBuilderYS_SectionCommand, yieldSurface_BC,
 //              ysEvolutionModel, plasticMaterial, cyclicModel, damageModel,

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -26,13 +26,21 @@
 #include <Domain.h>
 #include <LoadPattern.h>
 #include <LoadPatternIter.h>
+#include <ElementalLoad.h>
 #include <ElementalLoadIter.h>
 #include <Element.h>
+#include <ElementIter.h>
 #include <Parameter.h>
 #include <Node.h>
+#include <NodeIter.h>
 #include <Pressure_Constraint.h>
 #include <TimeSeries.h>
 #include <SP_Constraint.h>
+#include <SP_ConstraintIter.h>
+#include <MP_Constraint.h>
+#include <MP_ConstraintIter.h>
+#include <NodalLoad.h>
+#include <NodalLoadIter.h>
 #include <Matrix.h>
 #include <MeshRegion.h>
 #include <StringContainer.h>
@@ -49,6 +57,7 @@
 
 #ifdef _PARALLEL_INTERPRETERS
 #include <mpi.h>
+#include <metis.h>
 #endif
 
 #ifdef _OPENMP
@@ -2035,5 +2044,303 @@ int OPS_setStartNodeTag() {
 
     Mesh::setStartNodeTag(tag);
 
+    return 0;
+}
+
+int OPS_partition() {
+#ifdef _PARALLEL_INTERPRETERS
+    // domain
+    Domain* domain = OPS_GetDomain();
+    if (domain ==0) {
+        return 0;
+    }
+
+    int pid = 0;
+    int np = 1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &pid);
+    MPI_Comm_size(MPI_COMM_WORLD, &np);
+
+    if (np == 1) return 0;
+
+    // parameters
+    int ncuts = 1;
+    int niter = 10;
+    int ufactor = 30;
+    int info = 0;
+    while (OPS_GetNumRemainingInputArgs() > 0) {
+        int num = 1;
+        auto opt = OPS_GetString();
+        if (strcmp(opt, "-ncuts") == 0) {
+            if (OPS_GetNumRemainingInputArgs() > 0 &&
+                OPS_GetIntInput(&num, &ncuts) < 0) {
+                opserr << "WARNING: failed to get ncuts\n";
+                return -1;
+            }
+            if (ncuts < 1) {
+                ncuts = 1;
+            }
+        } else if (strcmp(opt, "-niter") == 0) {
+            if (OPS_GetNumRemainingInputArgs() > 0 &&
+                OPS_GetIntInput(&num, &niter) < 0) {
+                opserr << "WARNING: failed to get niter\n";
+                return -1;
+            }
+            if (niter < 1) {
+                niter = 10;
+            }
+        } else if (strcmp(opt, "-ufactor") == 0) {
+            if (OPS_GetNumRemainingInputArgs() > 0 &&
+                OPS_GetIntInput(&num, &ncuts) < 0) {
+                opserr << "WARNING: failed to get ufactor\n";
+                return -1;
+            }
+            if (ufactor < 1) {
+                ufactor = 30;
+            }
+        } else if (strcmp(opt, "-info") == 0) {
+            info = METIS_DBG_INFO;
+        }
+    }
+
+
+    // map of node tag to index
+    std::map<int, idx_t> nind;
+    Node *nd = 0;
+    auto &nodes = domain->getNodes();
+    int index = 0;
+    while ((nd = nodes()) != 0) {
+        nind[nd->getTag()] = index++;
+    }
+
+    // check size
+    if (nind.empty()) {
+        opserr << "WARNING: no node is found on processorr "<<pid<<"\n";
+        return -1;
+    }
+
+    // number of nodes
+    idx_t nn = (idx_t)nind.size();
+
+    // check if all processors have same number
+    idx_t nn_max = 0;
+    if (MPI_Reduce(&nn, &nn_max, 1, MPI_INT,
+                   MPI_MAX, 0, MPI_COMM_WORLD) != MPI_SUCCESS) {
+        opserr << "WARNING: failed to get max nn\n";
+        return -1;
+    }
+    if (pid == 0) {
+        if (nn_max != nn) {
+            opserr << "WARNING: all processors should "
+                      "have the same mesh before partitioning";
+            return -1;
+        }
+    }
+
+    // pair of arrays storing the mesh
+    std::map<int, idx_t> eindex;
+    std::vector<idx_t> eptr;
+    std::vector<idx_t> eind;
+    std::vector<int> etag;
+
+    Element *ele = 0;
+    auto &eles = domain->getElements();
+    eptr.push_back(0);
+    index = 0;
+    while ((ele = eles()) != 0) {
+        const auto &elenodes = ele->getExternalNodes();
+        for (int i = 0; i < elenodes.Size(); ++i) {
+            eind.push_back(nind[elenodes(i)]);
+        }
+        eptr.push_back((idx_t)eind.size());
+        eindex[ele->getTag()] = index++;
+        etag.push_back(ele->getTag());
+    }
+
+    // check size
+    if (eptr.size() == 1) {
+        opserr << "WARNING: no element is found on processorr 0\n";
+        return -1;
+    }
+
+    // number of elements
+    idx_t ne = (idx_t)eptr.size() - 1;
+
+    // check if all processors have same number
+    idx_t ne_max = 0;
+    if (MPI_Reduce(&ne, &ne_max, 1, MPI_INT,
+                   MPI_MAX, 0, MPI_COMM_WORLD) != MPI_SUCCESS) {
+        opserr << "WARNING: failed to get max ne\n";
+        return -1;
+    }
+    if (pid == 0) {
+        if (ne_max != ne) {
+            opserr << "WARNING: all processors should "
+                      "have the same mesh before partitioning";
+            return -1;
+        }
+    }
+
+    // partition for elements
+    std::vector<idx_t> epart(ne);
+
+
+    // do partition on P0
+    if (pid == 0) {
+
+        // options
+        idx_t options[METIS_NOPTIONS];
+        METIS_SetDefaultOptions(options);
+        options[METIS_OPTION_PTYPE] = METIS_PTYPE_KWAY;
+        options[METIS_OPTION_OBJTYPE] = METIS_OBJTYPE_VOL;
+        options[METIS_OPTION_NCUTS] = ncuts;
+        options[METIS_OPTION_NITER] = niter;
+        options[METIS_OPTION_NUMBERING] = 0;
+        options[METIS_OPTION_UFACTOR] = ufactor;
+        options[METIS_OPTION_DBGLVL] = info;
+
+        // number of parts to partition
+        idx_t nparts = np;
+
+        // total communications volume
+        idx_t objval;
+
+        // partition for nodes
+        std::vector<idx_t> npart(nn);
+
+        // call metis
+        auto res =
+            METIS_PartMeshNodal(&ne, &nn,
+                                &eptr[0], &eind[0], 
+                                NULL, NULL, &nparts, 
+                                NULL, options,
+                                &objval, 
+                                &epart[0], &npart[0]);
+
+        // check errors 
+        if (res == METIS_ERROR_INPUT) {
+            opserr << "WARNING: metis input error\n";
+            return -1;
+        } else if (res == METIS_ERROR_MEMORY) {
+            opserr << "WARNING: metis memory error\n";
+            return -1;
+        } else if (res == METIS_ERROR) {
+            opserr << "WARNING: metis error\n";
+            return -1;
+        }
+    }
+
+    // broadcast partitions
+    if (MPI_Bcast(&epart[0], ne, MPI_INT, 0, MPI_COMM_WORLD) !=
+        MPI_SUCCESS) {
+        opserr << "WARNING: failed to broadcast epart\n";
+        return -1;
+    }
+
+    // get nodes in current processor and remove elements
+    for (int i = 0; i < ne; ++i) {
+
+        // remove element
+        if (epart[i] != pid) {
+            Element* ele = domain->removeElement(etag[i]);
+            if (ele != 0) {
+                delete ele;
+            }
+            continue;
+        }
+
+        // get elenodes
+        Element *ele = domain->getElement(etag[i]);
+        const auto &elenodes = ele->getExternalNodes();
+        for (int j = 0; j < elenodes.Size(); ++j) {
+            nind[elenodes(j)] = -1;
+        }
+    }
+
+    // get nodes in current processor and remove mp
+    auto &mps = domain->getMPs();
+    MP_Constraint *mp = 0;
+    while ((mp = mps()) != 0) {
+        int rtag = mp->getNodeRetained();
+        int ctag = mp->getNodeConstrained();
+        auto &rid = nind[rtag];
+        auto &cid = nind[ctag];
+        if (rid == -1 || cid == -1) {
+            rid = -1;
+            cid = -1;
+        } else {
+            domain->removeMP_Constraint(mp->getTag());
+            delete mp;
+        }
+    }
+
+    // remove nodes
+    for (const auto& item: nind) {
+        int ndtag = item.first;
+        auto id = item.second;
+        if (id >= 0) {
+            auto node = domain->removeNode(ndtag);
+            if (node != 0) {
+                delete node;
+            }
+            auto pc = domain->removePressure_Constraint(ndtag);
+            if (pc != 0) {
+                delete pc;
+            }
+        }
+    }
+
+    // remove sps
+    auto& sps = domain->getSPs();
+    SP_Constraint* sp = 0;
+    while ((sp = sps()) != 0) {
+        int ndtag = sp->getNodeTag();
+        auto id = nind[ndtag];
+        if (id >= 0) {
+            domain->removeSP_Constraint(sp->getTag());
+            delete sp;
+        }
+    }
+
+    // go throug load patterns
+    auto& lps = domain->getLoadPatterns();
+    LoadPattern* lp = 0;
+    while ((lp = lps()) != 0) {
+        // remove nodal loads
+        auto& nloads = lp->getNodalLoads();
+        NodalLoad* nload = 0;
+        while ((nload = nloads()) != 0) {
+            int ndtag = nload->getNodeTag();
+            auto id = nind[ndtag];
+            if (id >= 0) {
+                lp->removeNodalLoad(nload->getTag());
+                delete nload;
+            }
+        }
+
+        // remove elemental loads
+        auto& eloads = lp->getElementalLoads();
+        ElementalLoad* eload = 0;
+        while ((eload = eloads()) != 0) {
+            int e = eload->getElementTag();
+            auto id = epart[eindex[e]];
+            if (id >= 0) {
+                lp->removeElementalLoad(eload->getTag());
+                delete eload;
+            }
+        }
+
+        // remove sps
+        auto& sps2 = lp->getSPs();
+        while ((sp = sps2()) != 0) {
+            int ndtag = sp->getNodeTag();
+            auto id = nind[ndtag];
+            if (id >= 0) {
+                lp->removeSP_Constraint(sp->getTag());
+                delete sp;
+            }
+        }
+    }
+
+#endif
     return 0;
 }

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -2156,6 +2156,19 @@ static PyObject *Py_ops_unloadingRule(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_partition(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_partition() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
+
 /////////////////////////////////////////////////
 ////////////// Add Python commands //////////////
 /////////////////////////////////////////////////
@@ -2332,6 +2345,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("stiffnessDegradation", &Py_ops_stiffnessDegradation);
     addCommand("strengthDegradation", &Py_ops_strengthDegradation);
     addCommand("unloadingRule", &Py_ops_unloadingRule);
+    addCommand("parition", &Py_ops_partition);
 
     PyMethodDef method = {NULL,NULL,0,NULL};
     methodsOpenSees.push_back(method);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -2345,7 +2345,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("stiffnessDegradation", &Py_ops_stiffnessDegradation);
     addCommand("strengthDegradation", &Py_ops_strengthDegradation);
     addCommand("unloadingRule", &Py_ops_unloadingRule);
-    addCommand("parition", &Py_ops_partition);
+    addCommand("partition", &Py_ops_partition);
 
     PyMethodDef method = {NULL,NULL,0,NULL};
     methodsOpenSees.push_back(method);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1480,6 +1480,15 @@ static int Tcl_ops_unloadingRule(ClientData clientData, Tcl_Interp *interp, int 
     return TCL_OK;
 }
 
+static int Tcl_ops_partition(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_partition() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 //////////////////////////////////////////////
 ////////////// Add Tcl commands //////////////
 //////////////////////////////////////////////
@@ -1656,4 +1665,5 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"strengthDegradation", &Tcl_ops_stiffnessDegradation);
     addCommand(interp,"stiffnessDegradation", &Tcl_ops_strengthDegradation);
     addCommand(interp,"unloadingRule", &Tcl_ops_unloadingRule);
+    addCommand(interp,"partition", &Tcl_ops_partition);
 }


### PR DESCRIPTION
Add a partition command in OpenSeesPy, which simulates the OpenSeesSp behavior. But user needs explicitly to call the partition command to partition the domain to subdomain on different processors after the model is built. Then the rest of setup is like OpenSeesMp, such parallel numberer and solver.