### PR TITLE
Make MUMPS defaults to unsymmetric matrix type + make matrix type user defined

### DIFF
--- a/SRC/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.h
+++ b/SRC/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.h
@@ -47,7 +47,7 @@ class MumpsParallelSolver;
 class MumpsParallelSOE : public MumpsSOE
 {
   public:
-    MumpsParallelSOE(MumpsParallelSolver &theSolver, int matType=2);
+    MumpsParallelSOE(MumpsParallelSolver &theSolver, int matType=0);
     MumpsParallelSOE();
     
     ~MumpsParallelSOE();

--- a/SRC/system_of_eqn/linearSOE/mumps/MumpsSOE.h
+++ b/SRC/system_of_eqn/linearSOE/mumps/MumpsSOE.h
@@ -49,10 +49,10 @@ class LinearSOESolver;
 class MumpsSOE : public LinearSOE
 {
   public:
-    MumpsSOE(MumpsSolver &theSolver, int matType=2);        
+    MumpsSOE(MumpsSolver &theSolver, int matType=0);        
     MumpsSOE();       
     MumpsSOE(int classTag);        
-    MumpsSOE(LinearSOESolver &theSolver, int classTag, int matType = 2);        
+    MumpsSOE(LinearSOESolver &theSolver, int classTag, int matType = 0);        
 
     virtual ~MumpsSOE();
 


### PR DESCRIPTION
Dear @fmckenna @mhscott, I recently found out that the same analysis had **different convergence rates** in sequential and parallel versions of OpenSees (sequential using SuperLU and parallel using MUMPS).

Then I realized that the **Mumps(Parallel)SOE defaults to "general symmetric" matrix** type. While I was using a plastic damage model whose tangent matrix is unsymmetric due to the spectral decomposition of the stress tensor.

I think the **MUMPS should use Unsymmetric matrix type by default**, since it is the most generic choise (we may have unsym matrices in many cases, unilateral plastic-damage models, non-associated plasticity, beams with corotational kinematics... ).

In this **PR** I made the Mumps(Parallel)SOE set up their **matType fields to 0 (unsym)** in their constructors as default values. Then I **added the -matrixType** option in the TCL/Py commands.

I also **fixed a  bug** in the Py interpreter, in case MUMPS is used in sequential version, since there the builder command was returning NULL and not the constructed SOE.