### PR TITLE
Add xml version tag to a vtu file header (pvd and vtk recorder)

### DIFF
--- a/SRC/recorder/PVDRecorder.cpp
+++ b/SRC/recorder/PVDRecorder.cpp
@@ -383,6 +383,7 @@ PVDRecorder::savePart0(int nodendf)
     theFile << std::scientific;
 
     // header
+    theFile<<"<?xml version="<<quota<<"1.0"<<quota<<"?>\n";
     theFile<<"<VTKFile type="<<quota<<"UnstructuredGrid"<<quota;
     theFile<<" version="<<quota<<"1.0"<<quota;
     theFile<<" byte_order="<<quota<<"LittleEndian"<<quota;
@@ -845,6 +846,7 @@ PVDRecorder::savePartParticle(int pno, int bgtag, int nodendf)
     theFile << std::scientific;
 
     // header
+    theFile<<"<?xml version="<<quota<<"1.0"<<quota<<"?>\n";
     theFile<<"<VTKFile type="<<quota<<"UnstructuredGrid"<<quota;
     theFile<<" version="<<quota<<"1.0"<<quota;
     theFile<<" byte_order="<<quota<<"LittleEndian"<<quota;
@@ -1231,6 +1233,7 @@ PVDRecorder::savePart(int partno, int ctag, int nodendf)
     theFile << std::scientific;
 
     // header
+    theFile<<"<?xml version="<<quota<<"1.0"<<quota<<"?>\n";
     theFile<<"<VTKFile type="<<quota<<"UnstructuredGrid"<<quota;
     theFile<<" version="<<quota<<"1.0"<<quota;
     theFile<<" byte_order="<<quota<<"LittleEndian"<<quota;

--- a/SRC/recorder/VTK_Recorder.cpp
+++ b/SRC/recorder/VTK_Recorder.cpp
@@ -276,7 +276,7 @@ VTK_Recorder::VTK_Recorder(const char *inputName,
   //
   // spit out header to file
   //
-
+  thePVDFile << "<?xml version="<<quota<<"1.0"<<quota<<"?>\n";
   thePVDFile << "<VTKFile type=\"Collection\" version=\"1.0\" \n";
   thePVDFile << "byte_order=\"LittleEndian\" \n";
   thePVDFile << "compressor=\"vtkZLibDataCompressor\">\n";
@@ -408,6 +408,7 @@ VTK_Recorder::vtu()
   theFileVTU << std::scientific;
   
   // header
+  theFileVTU<<"<?xml version="<<quota<<"1.0"<<quota<<"?>\n";
   theFileVTU<<"<VTKFile type="<<quota<<"UnstructuredGrid"<<quota;
   theFileVTU<<" version="<<quota<<"1.0"<<quota;
   theFileVTU<<" byte_order="<<quota<<"LittleEndian"<<quota;


### PR DESCRIPTION
This PR adds `<?xml version="1.0"?>` tag at the beginning of each vtu file header (as it is already done for .pvd files). This xml tag facilitates to recognize the mode in some text editors (e.g. emacs). 