### PR TITLE
add INTEGRATOR_TAGS_GimmeMCK to classTags.h

### DIFF
--- a/DEVELOPER/core/classTags.h
+++ b/DEVELOPER/core/classTags.h
@@ -902,6 +902,8 @@
 #define INTEGRATOR_TAGS_KRAlphaExplicit                 53
 #define INTEGRATOR_TAGS_KRAlphaExplicit_TP              54
 #define INTEGRATOR_TAGS_ExplicitDifference              55
+#define INTEGRATOR_TAGS_EQPath                          56
+#define INTEGRATOR_TAGS_GimmeMCK                        57
 
 #define LinSOE_TAGS_FullGenLinSOE		1
 #define LinSOE_TAGS_BandGenLinSOE		2

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -942,7 +942,8 @@
 #define INTEGRATOR_TAGS_KRAlphaExplicit                 53
 #define INTEGRATOR_TAGS_KRAlphaExplicit_TP              54
 #define INTEGRATOR_TAGS_ExplicitDifference              55
-#define INTEGRATOR_TAGS_EQPath        					        56
+#define INTEGRATOR_TAGS_EQPath                          56
+#define INTEGRATOR_TAGS_GimmeMCK       			        57
 
 #define LinSOE_TAGS_FullGenLinSOE		1
 #define LinSOE_TAGS_BandGenLinSOE		2


### PR DESCRIPTION
Thank you, Michael, for adding the new functionality of GimmeMCK.

This PR adds INTEGRATOR_TAGS_GimmeMCK to classTags.h. Without this change, there is a compilation error.

However after successful OpenSees compilation, there is an error when running an example:
```
ops.wipeAnalysis()
ops.system('FullGeneral')
ops.analysis('Transient')

# Mass
ops.integrator('GimmeMCK', 1.0, 0.0, 0.0)
ops.analyze(1, 0.0)
```
from
https://portwooddigital.com/2020/05/17/gimme-all-your-damping-all-your-mass-and-stiffness-too/

The error is as follows:
```
WARNING analysis Transient - no Algorithm yet specified, 
 NewtonRaphson default will be used
WARNING analysis Transient - no ConstraintHandler yet specified, 
 PlainHandler default will be used
WARNING analysis Transient - no Numberer specified, 
 RCM default will be used
WARNING analysis Transient - no Integrator specified, 
 TransientIntegrator default will be used
GimmeMCK::newStep() - domainChange() failed or hasn't been called
DirectIntegrationAnalysis::analyze() - the Integrator failed at time 0
OpenSees > analyze failed, returned: -2 error flag
```
Any idea?