### PR TITLE
print sprase matrix from printA

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -1866,6 +1866,13 @@ int OPS_printA()
 	    theTransientIntegrator->formTangent(0);
 	}
 
+    PFEMLinSOE* pfemsoe = dynamic_cast<PFEMLinSOE*>(theSOE);
+    if (pfemsoe != 0) {
+        pfemsoe->saveK(*output);
+        outputFile.close();
+        return 0;
+    }
+
 	Matrix *A = const_cast<Matrix*>(theSOE->getA());
 	if (A != 0) {
 	    if (ret) {

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.cpp
@@ -47,6 +47,7 @@
 #include <Channel.h>
 #include <FEM_ObjectBroker.h>
 #include <iostream>
+#include <map>
 using std::nothrow;
 #include <Pressure_Constraint.h>
 #include <Pressure_ConstraintIter.h>
@@ -56,6 +57,7 @@ using std::nothrow;
 #include <DOF_Group.h>
 #include <AnalysisModel.h>
 #include <BackgroundMesh.h>
+#include <elementAPI.h>
 #ifdef _PARALLEL_INTERPRETERS
 #include <mpi.h>
 #endif
@@ -754,4 +756,44 @@ PFEMLinSOE::skipFluid() const
 {
     BackgroundMesh& bgmesh = OPS_getBgMesh();
     return assemblyFlag==1 && bgmesh.isDispOn()==false && bgmesh.isFastAssembly();
+}
+
+void PFEMLinSOE::saveK(OPS_Stream& output) {
+    if (M == 0) return;
+    output << "sparse matrix <" << M->m << ", " << M->n << "> with "
+           << M->nzmax << " entries\n";
+
+    // reorder and combine duplicates
+    std::map<std::pair<int, int>, double> mat;
+    for (int j = 0; j < M->n; ++j) {
+        for (int k = M->p[j]; k < M->p[j + 1]; ++k) {
+            mat[std::make_pair(M->i[k], j)] += M->x[k];
+        }
+    }
+
+    // renumber
+    Domain* domain = OPS_GetDomain();
+    NodeIter& nodes = domain->getNodes();
+    Node* node = 0;
+    std::vector<int> dofs;
+    while ((node = nodes()) != 0) {
+        auto dof = node->getDOF_GroupPtr();
+        auto id = dof->getID();
+        for (int i=0; i<id.Size(); ++i) {
+            dofs.push_back(id(i));
+        }
+    }
+
+    // save matrix
+    for (int i = 0; i < dofs.size(); ++i) {
+        int dof1 = dofs[i];
+        for (int j = 0; j < dofs.size(); ++j) {
+            int dof2 = dofs[j];
+            auto it = mat.find(std::make_pair(dof1, dof2));
+            if (it != mat.end()) {
+                output << "    " << i << "    " << j << "    ("
+                       << it->second << ")\n";
+            }
+        }
+    }
 }

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.cpp
@@ -47,7 +47,6 @@
 #include <Channel.h>
 #include <FEM_ObjectBroker.h>
 #include <iostream>
-#include <map>
 using std::nothrow;
 #include <Pressure_Constraint.h>
 #include <Pressure_ConstraintIter.h>
@@ -763,37 +762,11 @@ void PFEMLinSOE::saveK(OPS_Stream& output) {
     output << "sparse matrix <" << M->m << ", " << M->n << "> with "
            << M->nzmax << " entries\n";
 
-    // reorder and combine duplicates
-    std::map<std::pair<int, int>, double> mat;
+    // save the matrix
     for (int j = 0; j < M->n; ++j) {
         for (int k = M->p[j]; k < M->p[j + 1]; ++k) {
-            mat[std::make_pair(M->i[k], j)] += M->x[k];
-        }
-    }
-
-    // renumber
-    Domain* domain = OPS_GetDomain();
-    NodeIter& nodes = domain->getNodes();
-    Node* node = 0;
-    std::vector<int> dofs;
-    while ((node = nodes()) != 0) {
-        auto dof = node->getDOF_GroupPtr();
-        auto id = dof->getID();
-        for (int i=0; i<id.Size(); ++i) {
-            dofs.push_back(id(i));
-        }
-    }
-
-    // save matrix
-    for (int i = 0; i < dofs.size(); ++i) {
-        int dof1 = dofs[i];
-        for (int j = 0; j < dofs.size(); ++j) {
-            int dof2 = dofs[j];
-            auto it = mat.find(std::make_pair(dof1, dof2));
-            if (it != mat.end()) {
-                output << "    " << i << "    " << j << "    ("
-                       << it->second << ")\n";
-            }
+            output << "    " << M->i[k] << "    " << j << "    ("
+                   << M->x[k] << ")\n";
         }
     }
 }

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.h
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/PFEMLinSOE.h
@@ -37,6 +37,7 @@
 
 
 #include <LinearSOE.h>
+#include <OPS_Stream.h>
 #include <Vector.h>
 #include <ID.h>
 extern "C" {
@@ -89,6 +90,7 @@ class PFEMLinSOE : public LinearSOE
     virtual bool skipFluid() const;
     virtual int getStage() const {return stage;}
     virtual void setStage(int s) {stage = s;}
+    void saveK(OPS_Stream& output);
 
 private:
 


### PR DESCRIPTION
To print a sparse matrix from printA command.

The printA command has no change to the user, but one has to define PFEM SOE, an example:

```python
...
ops.system('PFEM')
ops.analyze(1)
ops.printA('-file', filename)
...
```