### PR TITLE
Fix beam partial uniform load and add command for dispBeamColumn3dID

### DIFF
--- a/SRC/interpreter/OpenSeesElementCommands.cpp
+++ b/SRC/interpreter/OpenSeesElementCommands.cpp
@@ -451,6 +451,17 @@ namespace {
     }
   }
 
+  static void* OPS_DispBeamColumn3dID()
+  {
+    int ndm = OPS_GetNDM();
+    if (ndm == 2) {
+      // return OPS_DispBeamColumn2dID();
+    }
+    else {
+      return OPS_DispBeamColumn3dID();
+    }
+  }
+
     static int setUpFunctions(void)
     {
 	functionMap.insert(std::make_pair("KikuchiBearing", &OPS_KikuchiBearing));

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -292,7 +292,7 @@ int OPS_ElementalLoad()
 		return -1;
 	    }
 	    for (int i=0; i<theEleTags.Size(); i++) {
-		if (numdata > 1 && numdata < 5) {
+		if (numdata == 3 || numdata == 4) {
 		  data[4] = data[0];
 		  data[5] = data[1];
 		}

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -279,21 +279,22 @@ int OPS_ElementalLoad()
 	strcmp(type,"beamUniform") == 0) {
 
 	if (ndm == 2) {
-	    // wt, wa, aL, bL
-	    double data[4] = {0.0, 0.0, 0.0, 1.0};
+	    // wta, waa, aL, bL, wtb, wab
+        double data[6] = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0};
 	    int numdata = OPS_GetNumRemainingInputArgs();
 	    if (numdata < 1) {
-		opserr<<"WARNING eleLoad - beamUniform want Wy <Wx>\n";
+		opserr<<"WARNING eleLoad - beamUniform want Wya <Wxa> <aL> <bL> <Wyb> <Wxb>\n";
 		return -1;
 	    }
-	    if (numdata > 4) numdata = 4;
+	    // if (numdata > 4) numdata = 4;
+	    if (numdata > 6) numdata = 6;
 	    if (OPS_GetDoubleInput(&numdata, data) < 0) {
 		opserr<<"WARNING eleLoad - invalid value for beamUniform\n";
 		return -1;
 	    }
 	    for (int i=0; i<theEleTags.Size(); i++) {
-		if (data[2] > 0.0 || data[3] < 1.0)
-		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[1], data[2], data[3], theEleTags(i));
+		if (data[2] > 0.0 || data[3] < 1.0 || data[0] != data[4] || data[1] != data[5])
+		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[1], data[2], data[3], data[4], data[5], theEleTags(i));
 		else
 		    theLoad = new Beam2dUniformLoad(eleLoadTag, data[0], data[1], theEleTags(i));
 

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -286,14 +286,17 @@ int OPS_ElementalLoad()
 		opserr<<"WARNING eleLoad - beamUniform want Wya <Wxa> <aL> <bL> <Wyb> <Wxb>\n";
 		return -1;
 	    }
-	    // if (numdata > 4) numdata = 4;
 	    if (numdata > 6) numdata = 6;
 	    if (OPS_GetDoubleInput(&numdata, data) < 0) {
 		opserr<<"WARNING eleLoad - invalid value for beamUniform\n";
 		return -1;
 	    }
 	    for (int i=0; i<theEleTags.Size(); i++) {
-		if (data[2] > 0.0 || data[3] < 1.0 || data[0] != data[4] || data[1] != data[5])
+		if (numdata > 1 && numdata < 5) {
+		  data[4] = data[0];
+		  data[5] = data[1];
+		}
+		if (data[2] > 0.0 || data[3] < 1.0 || numdata > 4)
 		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[4], data[1], data[5], data[2], data[3], theEleTags(i));
 		else
 		    theLoad = new Beam2dUniformLoad(eleLoadTag, data[0], data[1], theEleTags(i));

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -294,7 +294,7 @@ int OPS_ElementalLoad()
 	    }
 	    for (int i=0; i<theEleTags.Size(); i++) {
 		if (data[2] > 0.0 || data[3] < 1.0 || data[0] != data[4] || data[1] != data[5])
-		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[1], data[2], data[3], data[4], data[5], theEleTags(i));
+		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[4], data[1], data[5], data[2], data[3], theEleTags(i));
 		else
 		    theLoad = new Beam2dUniformLoad(eleLoadTag, data[0], data[1], theEleTags(i));
 


### PR DESCRIPTION
This PR fixes the partial uniform load for Python (Tcl version works!) and adds command for dispBeamColumn3dID
to fix  the following error when running OpenSeesPY:
`undefined symbol: _Z22OPS_DispBeamColumn3dIDv`

