### PR TITLE
Allow body forces as element load (-selfWeight option) in Tri31element 

### DIFF
--- a/SRC/element/triangle/Tri31.h
+++ b/SRC/element/triangle/Tri31.h
@@ -115,6 +115,10 @@ class Tri31 : public Element
     static Vector P;		// Element resisting force vector
     Vector Q;		        // Applied nodal loads
     double b[2];		// Body forces
+
+	double appliedB[2]; // Body forces applied with load pattern
+	int applyLoad;      // flag for body force in load
+
     Vector pressureLoad;	// Pressure load at nodes
 
     double thickness;	        // Element thickness


### PR DESCRIPTION
This PR makes the triangular element Tri31 consistent with the quad and SSPquad elements, e.i. it allows us to use -selfWeight option of eleLoad pattern.