### PR TITLE
Adding NineNodeQuad (quad9n) and EightNodeQuad (quad8n) elements

### DIFF
--- a/DEVELOPER/core/classTags.h
+++ b/DEVELOPER/core/classTags.h
@@ -557,6 +557,8 @@
 #define ELE_TAG_NLBeamColumn3d	        29
 #define ELE_TAG_LargeDispBeamColumn3d	30
 #define ELE_TAG_FourNodeQuad	        31
+#define ELE_TAG_NineNodeQuad	        311
+#define ELE_TAG_EightNodeQuad	        312
 #define ELE_TAG_FourNodeQuad3d	        32
 #define ELE_TAG_Tri31	                33    //Added by Roozbeh Geraili Mikola
 #define ELE_TAG_BeamWithHinges2d        34

--- a/EXAMPLES/ExamplePython/bending_quad9n.py
+++ b/EXAMPLES/ExamplePython/bending_quad9n.py
@@ -1,0 +1,52 @@
+import openseespy.opensees as ops
+# import opensees as ops
+
+ops.wipe()
+
+ops.model('basic', '-ndm', 2, '-ndf', 2)
+
+L = 5.
+H = 1.
+
+thk = 0.01
+
+P = 100.
+E = 200.e6
+nu = 0.3
+
+ops.nDMaterial('ElasticIsotropic', 1, E, nu)
+
+ops.node(1, 0., 0.)
+ops.node(2, 5., 0.)
+ops.node(3, 5., 1.)
+ops.node(4, 0., 1.)
+ops.node(5, 2.5, 0.)
+ops.node(6, 5., .5)
+ops.node(7, 2.5, 1.)
+ops.node(8, 0., .5)
+ops.node(9, 2.5, .5)  # comment for quad8n element
+
+ops.element('quad9n', 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, thk, 'PlaneStress', 1)
+# ops.element('quad8n', 1, 1, 2, 3, 4, 5, 6, 7, 8, thk, 'PlaneStress', 1)
+
+ops.fix(1, 1, 1)
+ops.fix(4, 1, 0)
+ops.fix(8, 1, 0)
+
+ops.timeSeries('Linear', 1)
+ops.pattern('Plain', 1, 1)
+ops.load(2, P, 0.)
+ops.load(3, -P, 0.)
+
+ops.analysis('Static')
+
+ops.analyze(1)
+
+ops.printModel()
+
+# verification:
+# tip vertical displacement (node 2 and 3) = 0.0075
+# bottom Gauss Point stress_xx = 46475.8
+# bottom extrem stress_xx (extrapolated) = 60000.0
+
+exit()

--- a/EXAMPLES/ExampleScripts/bending_quad9n.tcl
+++ b/EXAMPLES/ExampleScripts/bending_quad9n.tcl
@@ -1,0 +1,48 @@
+model Basic -ndm 2 -ndf 2
+
+set thk 0.01
+set L 5.0
+set H 1.0
+
+set P 100.
+set E 200.e6
+set nu 0.3
+
+node 1 0. 0.
+node 2 5. 0.
+node 3 5. 1.
+node 4 0. 1.
+node 5 2.5 0.
+node 6 5. .5
+node 7 2.5 1.
+node 8 0. .5
+# node 9 2.5 .5; # comment for quad8n element
+
+nDMaterial ElasticIsotropic 1 $E $nu
+
+# element quad9n 1 1 2 3 4 5 6 7 8 9 $thk "PlaneStress" 1
+element quad8n 1 1 2 3 4 5 6 7 8 $thk "PlaneStress" 1
+
+fix 1 1 1
+fix 4 1 0
+fix 8 1 0
+
+timeSeries Linear 1
+
+pattern Plain 1 1 {
+	load 2 $P 0.
+	load 3 -$P 0.
+}
+
+analysis Static
+
+analyze 1
+
+print
+
+# verification:
+# tip vertical displacement (node 2 and 3) = 0.0075
+# bottom Gauss Point stress_xx = 46475.8
+# bottom extrem stress_xx (extrapolated) = 60000.0
+
+exit

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -537,6 +537,8 @@ ELE_LIBS   =  $(FE)/element/Element.o \
 	$(FE)/element/fourNodeQuad/EnhancedQuad.o \
 	$(FE)/element/componentElement/ComponentElement2d.o \
 	$(FE)/element/fourNodeQuad/NineNodeMixedQuad.o \
+	$(FE)/element/fourNodeQuad/NineNodeQuad.o \
+	$(FE)/element/fourNodeQuad/EightNodeQuad.o \
 	$(FE)/element/shell/ShellMITC4.o \
 	$(FE)/element/shell/ShellMITC4Thermal.o \
 	$(FE)/element/shell/ShellMITC9.o \

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -222,6 +222,8 @@
 #include "fourNodeQuad/FourNodeQuad.h"
 #include "fourNodeQuad/EnhancedQuad.h"
 #include "fourNodeQuad/NineNodeMixedQuad.h"
+#include "fourNodeQuad/NineNodeQuad.h"
+#include "fourNodeQuad/EightNodeQuad.h"
 #include "fourNodeQuad/ConstantPressureVolumeQuad.h"
 #include "elasticBeamColumn/ElasticBeam2d.h"
 #include "elasticBeamColumn/ElasticBeam3d.h"
@@ -698,6 +700,12 @@ FEM_ObjectBrokerAllClasses::getNewElement(int classTag)
       
     case ELE_TAG_NineNodeMixedQuad:
       return new NineNodeMixedQuad();
+      
+    case ELE_TAG_NineNodeQuad:
+      return new NineNodeQuad();
+      
+    case ELE_TAG_EightNodeQuad:
+      return new EightNodeQuad();
       
     case ELE_TAG_ConstantPressureVolumeQuad:
       return new ConstantPressureVolumeQuad();

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -583,6 +583,8 @@
 #define ELE_TAG_NLBeamColumn3d	        29
 #define ELE_TAG_LargeDispBeamColumn3d	30
 #define ELE_TAG_FourNodeQuad	        31
+#define ELE_TAG_NineNodeQuad	        311
+#define ELE_TAG_EightNodeQuad	        312
 #define ELE_TAG_FourNodeQuad3d	        32
 #define ELE_TAG_Tri31	                33    //Added by Roozbeh Geraili Mikola
 #define ELE_TAG_BeamWithHinges2d        34

--- a/SRC/element/TclElementCommands.cpp
+++ b/SRC/element/TclElementCommands.cpp
@@ -218,6 +218,14 @@ extern int
 TclModelBuilder_addNineNodeMixedQuad(ClientData, Tcl_Interp *, int, TCL_Char **,
 				     Domain*, TclModelBuilder *);
 
+extern int
+TclModelBuilder_addNineNodeQuad(ClientData, Tcl_Interp *, int, TCL_Char **,
+								Domain*, TclModelBuilder *);
+
+extern int
+TclModelBuilder_addEightNodeQuad(ClientData, Tcl_Interp *, int, TCL_Char **,
+								Domain*, TclModelBuilder *);
+
 
 // GLF
 extern int
@@ -1446,6 +1454,14 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
 						      argc, argv,
 						      theTclDomain,
 						      theTclBuilder);
+    return result;
+  } else if (strcmp(argv[1],"quad9n") == 0) {
+    int result = TclModelBuilder_addNineNodeQuad(clientData, interp, argc, argv,
+						 theTclDomain, theTclBuilder);
+    return result;
+  } else if (strcmp(argv[1],"quad8n") == 0) {
+    int result = TclModelBuilder_addEightNodeQuad(clientData, interp, argc, argv,
+						 theTclDomain, theTclBuilder);
     return result;
   } else if (strcmp(argv[1],"quadUP") == 0) {
     int result = TclModelBuilder_addFourNodeQuadUP(clientData, interp, argc, argv,

--- a/SRC/element/fourNodeQuad/EightNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/EightNodeQuad.cpp
@@ -1,0 +1,1582 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+//
+// based on FourNodeQuad by MHS
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: Aug 2020
+//
+// Description: This file contains the class definition for EightNodeQuad.
+
+#include "EightNodeQuad.h"
+#include <Node.h>
+#include <NDMaterial.h>
+#include <Matrix.h>
+#include <Vector.h>
+#include <ID.h>
+#include <Renderer.h>
+#include <Domain.h>
+#include <string.h>
+#include <Information.h>
+#include <Parameter.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <ElementResponse.h>
+#include <ElementalLoad.h>
+#include <elementAPI.h>
+
+void* OPS_EightNodeQuad()
+{
+    int ndm = OPS_GetNDM();
+    int ndf = OPS_GetNDF();
+
+    if (ndm != 2 || ndf != 2) {
+	opserr << "WARNING -- model dimensions and/or nodal DOF not compatible with quad element\n";
+	return 0;
+    }
+
+    if (OPS_GetNumRemainingInputArgs() < 12) {
+	opserr << "WARNING insufficient arguments\n";
+	opserr << "Want: element EightNodeQuad eleTag? Node1? Node2? Node3? Node4? Node5? Node6? Node7? Node8? thk? type? matTag? <pressure? rho? b1? b2?>\n";
+	return 0;
+    }
+
+    // EightNodeQuadId, iNode, jNode, kNode, lNode
+	// nNode, mNode, pNode, qNode
+    int idata[9];
+    int num = 9;
+    if (OPS_GetIntInput(&num,idata) < 0) {
+	opserr<<"WARNING: invalid integer inputs\n";
+	return 0;
+    }
+
+    double thk = 1.0;
+    num = 1;
+    if (OPS_GetDoubleInput(&num,&thk) < 0) {
+	opserr<<"WARNING: invalid double inputs\n";
+	return 0;
+    }
+
+    const char* type = OPS_GetString();
+
+    int matTag;
+    num = 1;
+    if (OPS_GetIntInput(&num,&matTag) < 0) {
+	opserr<<"WARNING: invalid matTag\n";
+	return 0;
+    }
+
+    NDMaterial* mat = OPS_getNDMaterial(matTag);
+    if (mat == 0) {
+	opserr << "WARNING material not found\n";
+	opserr << "Material: " << matTag;
+	opserr << "\nEightNodeQuad element: " << idata[0] << endln;
+	return 0;
+    }
+
+    // p, rho, b1, b2
+    double data[4] = {0,0,0,0};
+    num = OPS_GetNumRemainingInputArgs();
+    if (num > 4) {
+	num = 4;
+    }
+    if (num > 0) {
+	if (OPS_GetDoubleInput(&num,data) < 0) {
+	    opserr<<"WARNING: invalid integer data\n";
+	    return 0;
+	}
+    }
+
+    return new EightNodeQuad(idata[0],idata[1],idata[2],idata[3],idata[4],
+							idata[5],idata[6],idata[7],idata[8],
+			                *mat,type,thk,data[0],data[1],data[2],data[3]);
+}
+
+
+double EightNodeQuad::matrixData[256];
+Matrix EightNodeQuad::K(matrixData, 16, 16);
+Vector EightNodeQuad::P(16);
+double EightNodeQuad::shp[3][8];
+double EightNodeQuad::pts[8][2];
+double EightNodeQuad::wts[8];
+
+EightNodeQuad::EightNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4,
+						   int nd5, int nd6, int nd7, int nd8,
+						   NDMaterial &m, const char *type, double t,
+						   double p, double r, double b1, double b2)
+:Element (tag, ELE_TAG_EightNodeQuad),
+  theMaterial(0), connectedExternalNodes(8),
+ Q(16), applyLoad(0), pressureLoad(16), thickness(t), pressure(p), rho(r), Ki(0)
+{
+	pts[0][0] = -0.7745966692414834;
+	pts[0][1] = -0.7745966692414834;
+	pts[1][0] =  0.7745966692414834;
+	pts[1][1] = -0.7745966692414834;
+	pts[2][0] =  0.7745966692414834;
+	pts[2][1] =  0.7745966692414834;
+	pts[3][0] = -0.7745966692414834;
+	pts[3][1] =  0.7745966692414834;
+	pts[4][0] =  0.0;
+	pts[4][1] = -0.7745966692414834;
+	pts[5][0] =  0.7745966692414834;
+	pts[5][1] =  0.0;
+	pts[6][0] =  0.0;
+	pts[6][1] =  0.7745966692414834;
+	pts[7][0] = -0.7745966692414834;
+	pts[7][1] =  0.0;
+
+	wts[0] = 0.30864197530864196;
+	wts[1] = 0.30864197530864196;
+	wts[2] = 0.30864197530864196;
+	wts[3] = 0.30864197530864196;
+	wts[4] = 0.49382716049382713;
+	wts[5] = 0.49382716049382713;
+	wts[6] = 0.49382716049382713;
+	wts[7] = 0.49382716049382713;
+
+	if (strcmp(type,"PlaneStrain") != 0 && strcmp(type,"PlaneStress") != 0
+	    && strcmp(type,"PlaneStrain2D") != 0 && strcmp(type,"PlaneStress2D") != 0) {
+	  opserr << "EightNodeQuad::EightNodeQuad -- improper material type: " << type << "for EightNodeQuad\n";
+	  exit(-1);
+	}
+
+	// Body forces
+	b[0] = b1;
+	b[1] = b2;
+
+    // Allocate arrays of pointers to NDMaterials
+    theMaterial = new NDMaterial *[8];
+
+    if (theMaterial == 0) {
+      opserr << "EightNodeQuad::EightNodeQuad - failed allocate material model pointer\n";
+      exit(-1);
+    }
+
+	int i;
+    for (i = 0; i < 8; i++) {
+
+      // Get copies of the material model for each integration point
+      theMaterial[i] = m.getCopy(type);
+
+      // Check allocation
+      if (theMaterial[i] == 0) {
+	opserr << "EightNodeQuad::EightNodeQuad -- failed to get a copy of material model\n";
+	exit(-1);
+      }
+    }
+
+    // Set connected external node IDs
+    connectedExternalNodes(0) = nd1;
+    connectedExternalNodes(1) = nd2;
+    connectedExternalNodes(2) = nd3;
+    connectedExternalNodes(3) = nd4;
+    connectedExternalNodes(4) = nd5;
+    connectedExternalNodes(5) = nd6;
+    connectedExternalNodes(6) = nd7;
+    connectedExternalNodes(7) = nd8;
+
+    for (i=0; i<8; i++)
+      theNodes[i] = 0;
+}
+
+EightNodeQuad::EightNodeQuad()
+:Element (0,ELE_TAG_EightNodeQuad),
+  theMaterial(0), connectedExternalNodes(8),
+ Q(16), applyLoad(0), pressureLoad(16), thickness(0.0), pressure(0.0), Ki(0)
+{
+	pts[0][0] = -0.7745966692414834;
+	pts[0][1] = -0.7745966692414834;
+	pts[1][0] =  0.7745966692414834;
+	pts[1][1] = -0.7745966692414834;
+	pts[2][0] =  0.7745966692414834;
+	pts[2][1] =  0.7745966692414834;
+	pts[3][0] = -0.7745966692414834;
+	pts[3][1] =  0.7745966692414834;
+	pts[4][0] =  0.0;
+	pts[4][1] = -0.7745966692414834;
+	pts[5][0] =  0.7745966692414834;
+	pts[5][1] =  0.0;
+	pts[6][0] =  0.0;
+	pts[6][1] =  0.7745966692414834;
+	pts[7][0] = -0.7745966692414834;
+	pts[7][1] =  0.0;
+
+	wts[0] = 0.30864197530864196;
+	wts[1] = 0.30864197530864196;
+	wts[2] = 0.30864197530864196;
+	wts[3] = 0.30864197530864196;
+	wts[4] = 0.49382716049382713;
+	wts[5] = 0.49382716049382713;
+	wts[6] = 0.49382716049382713;
+	wts[7] = 0.49382716049382713;
+
+    for (int i=0; i<8; i++)
+      theNodes[i] = 0;
+}
+
+EightNodeQuad::~EightNodeQuad()
+{
+  for (int i = 0; i < 8; i++) {
+    if (theMaterial[i])
+      delete theMaterial[i];
+  }
+
+  // Delete the array of pointers to NDMaterial pointer arrays
+  if (theMaterial)
+    delete [] theMaterial;
+
+  if (Ki != 0)
+    delete Ki;
+}
+
+int
+EightNodeQuad::getNumExternalNodes() const
+{
+    return 8;
+}
+
+const ID&
+EightNodeQuad::getExternalNodes()
+{
+    return connectedExternalNodes;
+}
+
+
+Node **
+EightNodeQuad::getNodePtrs(void)
+{
+  return theNodes;
+}
+
+int
+EightNodeQuad::getNumDOF()
+{
+    return 16;
+}
+
+void
+EightNodeQuad::setDomain(Domain *theDomain)
+{
+	// Check Domain is not null - invoked when object removed from a domain
+    if (theDomain == 0) {
+	theNodes[0] = 0;
+	theNodes[1] = 0;
+	theNodes[2] = 0;
+	theNodes[3] = 0;
+	theNodes[4] = 0;
+	theNodes[5] = 0;
+	theNodes[6] = 0;
+	theNodes[7] = 0;
+	return;
+    }
+
+    int Nd1 = connectedExternalNodes(0);
+    int Nd2 = connectedExternalNodes(1);
+    int Nd3 = connectedExternalNodes(2);
+    int Nd4 = connectedExternalNodes(3);
+    int Nd5 = connectedExternalNodes(4);
+    int Nd6 = connectedExternalNodes(5);
+    int Nd7 = connectedExternalNodes(6);
+    int Nd8 = connectedExternalNodes(7);
+
+    theNodes[0] = theDomain->getNode(Nd1);
+    theNodes[1] = theDomain->getNode(Nd2);
+    theNodes[2] = theDomain->getNode(Nd3);
+    theNodes[3] = theDomain->getNode(Nd4);
+    theNodes[4] = theDomain->getNode(Nd5);
+    theNodes[5] = theDomain->getNode(Nd6);
+    theNodes[6] = theDomain->getNode(Nd7);
+    theNodes[7] = theDomain->getNode(Nd8);
+
+    if (theNodes[0] == 0 || theNodes[1] == 0 || theNodes[2] == 0 || theNodes[3] == 0 ||
+		theNodes[4] == 0 || theNodes[5] == 0 || theNodes[6] == 0 || theNodes[7] == 0) {
+	//opserr << "FATAL ERROR EightNodeQuad (tag: %d), node not found in domain",
+	//	this->getTag());
+
+	return;
+    }
+
+    int dofNd1 = theNodes[0]->getNumberDOF();
+    int dofNd2 = theNodes[1]->getNumberDOF();
+    int dofNd3 = theNodes[2]->getNumberDOF();
+    int dofNd4 = theNodes[3]->getNumberDOF();
+    int dofNd5 = theNodes[4]->getNumberDOF();
+    int dofNd6 = theNodes[5]->getNumberDOF();
+    int dofNd7 = theNodes[6]->getNumberDOF();
+    int dofNd8 = theNodes[7]->getNumberDOF();
+
+    if (dofNd1 != 2 || dofNd2 != 2 || dofNd3 != 2 || dofNd4 != 2 ||
+		dofNd5 != 2 || dofNd6 != 2 || dofNd7 != 2 || dofNd8 != 2) {
+	//opserr << "FATAL ERROR EightNodeQuad (tag: %d), has differing number of DOFs at its nodes",
+	//	this->getTag());
+
+	return;
+    }
+    this->DomainComponent::setDomain(theDomain);
+
+    // Compute consistent nodal loads due to pressure
+    this->setPressureLoadAtNodes();
+}
+
+int
+EightNodeQuad::commitState()
+{
+    int retVal = 0;
+
+    // call element commitState to do any base class stuff
+    if ((retVal = this->Element::commitState()) != 0) {
+      opserr << "EightNodeQuad::commitState () - failed in base class";
+    }
+
+    // Loop over the integration points and commit the material states
+    for (int i = 0; i < 8; i++)
+      retVal += theMaterial[i]->commitState();
+
+    return retVal;
+}
+
+int
+EightNodeQuad::revertToLastCommit()
+{
+    int retVal = 0;
+
+    // Loop over the integration points and revert to last committed state
+    for (int i = 0; i < 8; i++)
+		retVal += theMaterial[i]->revertToLastCommit();
+
+    return retVal;
+}
+
+int
+EightNodeQuad::revertToStart()
+{
+    int retVal = 0;
+
+    // Loop over the integration points and revert states to start
+    for (int i = 0; i < 8; i++)
+		retVal += theMaterial[i]->revertToStart();
+
+    return retVal;
+}
+
+
+int
+EightNodeQuad::update()
+{
+	const Vector &disp1 = theNodes[0]->getTrialDisp();
+	const Vector &disp2 = theNodes[1]->getTrialDisp();
+	const Vector &disp3 = theNodes[2]->getTrialDisp();
+	const Vector &disp4 = theNodes[3]->getTrialDisp();
+	const Vector &disp5 = theNodes[4]->getTrialDisp();
+	const Vector &disp6 = theNodes[5]->getTrialDisp();
+	const Vector &disp7 = theNodes[6]->getTrialDisp();
+	const Vector &disp8 = theNodes[7]->getTrialDisp();
+
+	static double u[2][8];
+
+	u[0][0] = disp1(0);
+	u[1][0] = disp1(1);
+	u[0][1] = disp2(0);
+	u[1][1] = disp2(1);
+	u[0][2] = disp3(0);
+	u[1][2] = disp3(1);
+	u[0][3] = disp4(0);
+	u[1][3] = disp4(1);
+	u[0][4] = disp5(0);
+	u[1][4] = disp5(1);
+	u[0][5] = disp6(0);
+	u[1][5] = disp6(1);
+	u[0][6] = disp7(0);
+	u[1][6] = disp7(1);
+	u[0][7] = disp8(0);
+	u[1][7] = disp8(1);
+
+	static Vector eps(3);
+
+	int ret = 0;
+
+	// Loop over the integration points
+	for (int i = 0; i < 8; i++) {
+
+		// Determine Jacobian for this integration point
+		this->shapeFunction(pts[i][0], pts[i][1]);
+
+		// Interpolate strains
+		//eps = B*u;
+		//eps.addMatrixVector(0.0, B, u, 1.0);
+		eps.Zero();
+		for (int beta = 0; beta < 8; beta++) {
+			eps(0) += shp[0][beta]*u[0][beta];
+			eps(1) += shp[1][beta]*u[1][beta];
+			eps(2) += shp[0][beta]*u[1][beta] + shp[1][beta]*u[0][beta];
+		}
+
+		// Set the material strain
+		ret += theMaterial[i]->setTrialStrain(eps);
+	}
+
+	return ret;
+}
+
+
+const Matrix&
+EightNodeQuad::getTangentStiff()
+{
+
+	K.Zero();
+
+	double dvol;
+	double DB[3][2];
+
+	// Loop over the integration points
+	for (int i = 0; i < 8; i++) {
+
+	  // Determine Jacobian for this integration point
+	  dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+	  dvol *= (thickness*wts[i]);
+
+	  // Get the material tangent
+	  const Matrix &D = theMaterial[i]->getTangent();
+
+	  // Perform numerical integration
+	  //K = K + (B^ D * B) * intWt(i)*intWt(j) * detJ;
+	  //K.addMatrixTripleProduct(1.0, B, D, intWt(i)*intWt(j)*detJ);
+
+	  double D00 = D(0,0); double D01 = D(0,1); double D02 = D(0,2);
+	  double D10 = D(1,0); double D11 = D(1,1); double D12 = D(1,2);
+	  double D20 = D(2,0); double D21 = D(2,1); double D22 = D(2,2);
+
+	  //	  for (int beta = 0, ib = 0, colIb =0, colIbP1 = 8;
+	  //   beta < 4;
+	  //   beta++, ib += 2, colIb += 16, colIbP1 += 16) {
+
+	  for (int alpha = 0, ia = 0; alpha < 8; alpha++, ia += 2) {
+	    for (int beta = 0, ib = 0; beta < 8; beta++, ib += 2) {
+
+	      DB[0][0] = dvol * (D00 * shp[0][beta] + D02 * shp[1][beta]);
+	      DB[1][0] = dvol * (D10 * shp[0][beta] + D12 * shp[1][beta]);
+	      DB[2][0] = dvol * (D20 * shp[0][beta] + D22 * shp[1][beta]);
+	      DB[0][1] = dvol * (D01 * shp[1][beta] + D02 * shp[0][beta]);
+	      DB[1][1] = dvol * (D11 * shp[1][beta] + D12 * shp[0][beta]);
+	      DB[2][1] = dvol * (D21 * shp[1][beta] + D22 * shp[0][beta]);
+
+
+	      K(ia,ib) += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	      K(ia,ib+1) += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	      K(ia+1,ib) += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	      K(ia+1,ib+1) += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+	      // matrixData[colIb   +   ia] += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	      // matrixData[colIbP1 +   ia] += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	      // matrixData[colIb   + ia+1] += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	      // matrixData[colIbP1 + ia+1] += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+
+	    }
+	  }
+	}
+
+	return K;
+}
+
+
+const Matrix&
+EightNodeQuad::getInitialStiff()
+{
+  if (Ki != 0)
+    return *Ki;
+
+  K.Zero();
+
+  double dvol;
+  double DB[3][2];
+
+  // Loop over the integration points
+  for (int i = 0; i < 8; i++) {
+
+    // Determine Jacobian for this integration point
+    dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+    dvol *= (thickness*wts[i]);
+
+    // Get the material tangent
+    const Matrix &D = theMaterial[i]->getInitialTangent();
+
+    double D00 = D(0,0); double D01 = D(0,1); double D02 = D(0,2);
+    double D10 = D(1,0); double D11 = D(1,1); double D12 = D(1,2);
+    double D20 = D(2,0); double D21 = D(2,1); double D22 = D(2,2);
+
+    // Perform numerical integration
+    //K = K + (B^ D * B) * intWt(i)*intWt(j) * detJ;
+    //K.addMatrixTripleProduct(1.0, B, D, intWt(i)*intWt(j)*detJ);
+    for (int beta = 0, ib = 0, colIb =0, colIbP1 = 8;
+	 beta < 8;
+	 beta++, ib += 2, colIb += 16, colIbP1 += 16) {
+
+      for (int alpha = 0, ia = 0; alpha < 8; alpha++, ia += 2) {
+
+	DB[0][0] = dvol * (D00 * shp[0][beta] + D02 * shp[1][beta]);
+	DB[1][0] = dvol * (D10 * shp[0][beta] + D12 * shp[1][beta]);
+	DB[2][0] = dvol * (D20 * shp[0][beta] + D22 * shp[1][beta]);
+	DB[0][1] = dvol * (D01 * shp[1][beta] + D02 * shp[0][beta]);
+	DB[1][1] = dvol * (D11 * shp[1][beta] + D12 * shp[0][beta]);
+	DB[2][1] = dvol * (D21 * shp[1][beta] + D22 * shp[0][beta]);
+
+	matrixData[colIb   +   ia] += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	matrixData[colIbP1 +   ia] += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	matrixData[colIb   + ia+1] += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	matrixData[colIbP1 + ia+1] += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+      }
+    }
+  }
+
+  Ki = new Matrix(K);
+  return K;
+}
+
+const Matrix&
+EightNodeQuad::getMass()
+{
+	K.Zero();
+
+	int i;
+	static double rhoi[8];
+	double sum = 0.0;
+	for (i = 0; i < 8; i++) {
+	  if (rho == 0)
+	    rhoi[i] = theMaterial[i]->getRho();
+	  else
+	    rhoi[i] = rho;
+	  sum += rhoi[i];
+	}
+
+	if (sum == 0.0)
+	  return K;
+
+	double rhodvol, Nrho;
+
+	// Compute a lumped mass matrix
+	for (i = 0; i < 8; i++) {
+
+		// Determine Jacobian for this integration point
+		rhodvol = this->shapeFunction(pts[i][0], pts[i][1]);
+
+		// Element plus material density ... MAY WANT TO REMOVE ELEMENT DENSITY
+		rhodvol *= (rhoi[i]*thickness*wts[i]);
+
+		for (int alpha = 0, ia = 0; alpha < 8; alpha++, ia++) {
+			Nrho = shp[2][alpha]*rhodvol;
+			K(ia,ia) += Nrho;
+			ia++;
+			K(ia,ia) += Nrho;
+		}
+	}
+
+	return K;
+}
+
+void
+EightNodeQuad::zeroLoad(void)
+{
+	Q.Zero();
+
+	applyLoad = 0;
+
+	appliedB[0] = 0.0;
+	appliedB[1] = 0.0;
+
+  	return;
+}
+
+int
+EightNodeQuad::addLoad(ElementalLoad *theLoad, double loadFactor)
+{
+	// Added option for applying body forces in load pattern: C.McGann, U.Washington
+	int type;
+	const Vector &data = theLoad->getData(type, loadFactor);
+
+	if (type == LOAD_TAG_SelfWeight) {
+		applyLoad = 1;
+		appliedB[0] += loadFactor*data(0)*b[0];
+		appliedB[1] += loadFactor*data(1)*b[1];
+		return 0;
+	} else {
+		opserr << "EightNodeQuad::addLoad - load type unknown for ele with tag: " << this->getTag() << endln;
+		return -1;
+	}
+
+	return -1;
+}
+
+int
+EightNodeQuad::addInertiaLoadToUnbalance(const Vector &accel)
+{
+  int i;
+  static double rhoi[8];
+  double sum = 0.0;
+  for (i = 0; i < 8; i++) {
+    rhoi[i] = theMaterial[i]->getRho();
+    sum += rhoi[i];
+  }
+
+  if (sum == 0.0)
+    return 0;
+
+  // Get R * accel from the nodes
+  const Vector &Raccel1 = theNodes[0]->getRV(accel);
+  const Vector &Raccel2 = theNodes[1]->getRV(accel);
+  const Vector &Raccel3 = theNodes[2]->getRV(accel);
+  const Vector &Raccel4 = theNodes[3]->getRV(accel);
+  const Vector &Raccel5 = theNodes[4]->getRV(accel);
+  const Vector &Raccel6 = theNodes[5]->getRV(accel);
+  const Vector &Raccel7 = theNodes[6]->getRV(accel);
+  const Vector &Raccel8 = theNodes[7]->getRV(accel);
+
+  if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size() ||
+      2 != Raccel4.Size() || 2 != Raccel5.Size() || 2 != Raccel6.Size() ||
+	  2 != Raccel7.Size() || 2 != Raccel8.Size()) {
+    opserr << "EightNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
+    return -1;
+  }
+
+  static double ra[16];
+
+  ra[0] = Raccel1(0);
+  ra[1] = Raccel1(1);
+  ra[2] = Raccel2(0);
+  ra[3] = Raccel2(1);
+  ra[4] = Raccel3(0);
+  ra[5] = Raccel3(1);
+  ra[6] = Raccel4(0);
+  ra[7] = Raccel4(1);
+  ra[8] = Raccel5(0);
+  ra[9] = Raccel5(1);
+  ra[10] = Raccel6(0);
+  ra[11] = Raccel6(1);
+  ra[12] = Raccel7(0);
+  ra[13] = Raccel7(1);
+  ra[14] = Raccel8(0);
+  ra[15] = Raccel8(1);
+
+  // Compute mass matrix
+  this->getMass();
+
+  // Want to add ( - fact * M R * accel ) to unbalance
+  // Take advantage of lumped mass matrix
+  for (i = 0; i < 16; i++)
+    Q(i) += -K(i,i)*ra[i];
+
+  return 0;
+}
+
+const Vector&
+EightNodeQuad::getResistingForce()
+{
+	P.Zero();
+
+	double dvol;
+
+	// Loop over the integration points
+	for (int i = 0; i < 8; i++) {
+
+		// Determine Jacobian for this integration point
+		dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+		dvol *= (thickness*wts[i]);
+
+		// Get material stress response
+		const Vector &sigma = theMaterial[i]->getStress();
+
+		// Perform numerical integration on internal force
+		//P = P + (B^ sigma) * intWt(i)*intWt(j) * detJ;
+		//P.addMatrixTransposeVector(1.0, B, sigma, intWt(i)*intWt(j)*detJ);
+		for (int alpha = 0, ia = 0; alpha < 8; alpha++, ia += 2) {
+
+			P(ia) += dvol*(shp[0][alpha]*sigma(0) + shp[1][alpha]*sigma(2));
+
+			P(ia+1) += dvol*(shp[1][alpha]*sigma(1) + shp[0][alpha]*sigma(2));
+
+			// Subtract equiv. body forces from the nodes
+			//P = P - (N^ b) * intWt(i)*intWt(j) * detJ;
+			//P.addMatrixTransposeVector(1.0, N, b, -intWt(i)*intWt(j)*detJ);
+			if (applyLoad == 0) {
+				P(ia) -= dvol*(shp[2][alpha]*b[0]);
+				P(ia+1) -= dvol*(shp[2][alpha]*b[1]);
+			} else {
+				P(ia) -= dvol*(shp[2][alpha]*appliedB[0]);
+				P(ia+1) -= dvol*(shp[2][alpha]*appliedB[1]);
+			}
+		}
+	}
+
+	// Subtract pressure loading from resisting force
+	if (pressure != 0.0) {
+		//P = P - pressureLoad;
+		P.addVector(1.0, pressureLoad, -1.0);
+	}
+
+	// Subtract other external nodal loads ... P_res = P_int - P_ext
+	//P = P - Q;
+	P.addVector(1.0, Q, -1.0);
+
+	return P;
+}
+
+const Vector&
+EightNodeQuad::getResistingForceIncInertia()
+{
+	int i;
+	static double rhoi[8];
+	double sum = 0.0;
+	for (i = 0; i < 8; i++) {
+	  rhoi[i] = theMaterial[i]->getRho();
+	  sum += rhoi[i];
+	}
+
+	// if no mass terms .. just add damping terms
+	if (sum == 0.0) {
+	  this->getResistingForce();
+
+	  // add the damping forces if rayleigh damping
+	  if (betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	    P += this->getRayleighDampingForces();
+
+	  return P;
+	}
+
+	const Vector &accel1 = theNodes[0]->getTrialAccel();
+	const Vector &accel2 = theNodes[1]->getTrialAccel();
+	const Vector &accel3 = theNodes[2]->getTrialAccel();
+	const Vector &accel4 = theNodes[3]->getTrialAccel();
+	const Vector &accel5 = theNodes[4]->getTrialAccel();
+	const Vector &accel6 = theNodes[5]->getTrialAccel();
+	const Vector &accel7 = theNodes[6]->getTrialAccel();
+	const Vector &accel8 = theNodes[7]->getTrialAccel();
+
+	static double a[16];
+
+	a[0] = accel1(0);
+	a[1] = accel1(1);
+	a[2] = accel2(0);
+	a[3] = accel2(1);
+	a[4] = accel3(0);
+	a[5] = accel3(1);
+	a[6] = accel4(0);
+	a[7] = accel4(1);
+	a[8] = accel5(0);
+	a[9] = accel5(1);
+	a[10] = accel6(0);
+	a[11] = accel6(1);
+	a[12] = accel7(0);
+	a[13] = accel7(1);
+	a[14] = accel8(0);
+	a[15] = accel8(1);
+
+	// Compute the current resisting force
+	this->getResistingForce();
+
+	// Compute the mass matrix
+	this->getMass();
+
+	// Take advantage of lumped mass matrix
+	for (i = 0; i < 16; i++)
+		P(i) += K(i,i)*a[i];
+
+	// add the damping forces if rayleigh damping
+	if (alphaM != 0.0 || betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	  P += this->getRayleighDampingForces();
+
+	return P;
+}
+
+int
+EightNodeQuad::sendSelf(int commitTag, Channel &theChannel)
+{
+  int res = 0;
+
+  // note: we don't check for dataTag == 0 for Element
+  // objects as that is taken care of in a commit by the Domain
+  // object - don't want to have to do the check if sending data
+  int dataTag = this->getDbTag();
+
+  // Quad packs its data into a Vector and sends this to theChannel
+  // along with its dbTag and the commitTag passed in the arguments
+  static Vector data(9);
+  data(0) = this->getTag();
+  data(1) = thickness;
+  data(2) = b[0];
+  data(3) = b[1];
+  data(4) = pressure;
+
+  data(5) = alphaM;
+  data(6) = betaK;
+  data(7) = betaK0;
+  data(8) = betaKc;
+
+  res += theChannel.sendVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr << "WARNING EightNodeQuad::sendSelf() - " << this->getTag() << " failed to send Vector\n";
+    return res;
+  }
+
+
+  // Now quad sends the ids of its materials
+  int matDbTag;
+
+  static ID idData(24);
+
+  int i;
+  for (i = 0; i < 8; i++) {
+    idData(i) = theMaterial[i]->getClassTag();
+    matDbTag = theMaterial[i]->getDbTag();
+    // NOTE: we do have to ensure that the material has a database
+    // tag if we are sending to a database channel.
+    if (matDbTag == 0) {
+      matDbTag = theChannel.getDbTag();
+			if (matDbTag != 0)
+			  theMaterial[i]->setDbTag(matDbTag);
+    }
+    // idData(i+4) = matDbTag;
+    idData(i+8) = matDbTag;
+  }
+
+  for( i = 0; i < 8; i++)
+	idData(16+i) = connectedExternalNodes(i);
+
+  res += theChannel.sendID(dataTag, commitTag, idData);
+  if (res < 0) {
+    opserr << "WARNING EightNodeQuad::sendSelf() - " << this->getTag() << " failed to send ID\n";
+    return res;
+  }
+
+  // Finally, quad asks its material objects to send themselves
+  for (i = 0; i < 8; i++) {
+    res += theMaterial[i]->sendSelf(commitTag, theChannel);
+    if (res < 0) {
+      opserr << "WARNING EightNodeQuad::sendSelf() - " << this->getTag() << " failed to send its Material\n";
+      return res;
+    }
+  }
+
+  return res;
+}
+
+int
+EightNodeQuad::recvSelf(int commitTag, Channel &theChannel,
+                       FEM_ObjectBroker &theBroker)
+{
+  int res = 0;
+
+  int dataTag = this->getDbTag();
+
+  // Quad creates a Vector, receives the Vector and then sets the
+  // internal data with the data in the Vector
+  static Vector data(9);
+  res += theChannel.recvVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr << "WARNING EightNodeQuad::recvSelf() - failed to receive Vector\n";
+    return res;
+  }
+
+  this->setTag((int)data(0));
+  thickness = data(1);
+  b[0] = data(2);
+  b[1] = data(3);
+  pressure = data(4);
+
+  alphaM = data(5);
+  betaK = data(6);
+  betaK0 = data(7);
+  betaKc = data(8);
+
+  static ID idData(24); // 2*8+8
+  // Quad now receives the tags of its nine external nodes
+  res += theChannel.recvID(dataTag, commitTag, idData);
+  if (res < 0) {
+    opserr << "WARNING EightNodeQuad::recvSelf() - " << this->getTag() << " failed to receive ID\n";
+    return res;
+  }
+
+  for( int i = 0; i < 8; i++)
+    connectedExternalNodes(i) = idData(16+i);
+
+  if (theMaterial == 0) {
+    // Allocate new materials
+    theMaterial = new NDMaterial *[8];
+    if (theMaterial == 0) {
+      opserr << "EightNodeQuad::recvSelf() - Could not allocate NDMaterial* array\n";
+      return -1;
+    }
+    for (int i = 0; i < 8; i++) {
+      int matClassTag = idData(i);
+      int matDbTag = idData(i+8);
+      // Allocate new material with the sent class tag
+      theMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+      if (theMaterial[i] == 0) {
+	    opserr << "EightNodeQuad::recvSelf() - Broker could not create NDMaterial of class type " << matClassTag << endln;
+	    return -1;
+      }
+      // Now receive materials into the newly allocated space
+      theMaterial[i]->setDbTag(matDbTag);
+      res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+      if (res < 0) {
+        opserr << "EightNodeQuad::recvSelf() - material " << i << "failed to recv itself\n";
+	    return res;
+      }
+    }
+  }
+
+  // materials exist , ensure materials of correct type and recvSelf on them
+  else {
+    for (int i = 0; i < 8; i++) {
+      int matClassTag = idData(i);
+      int matDbTag = idData(i+8);
+      // Check that material is of the right type; if not,
+      // delete it and create a new one of the right type
+      if (theMaterial[i]->getClassTag() != matClassTag) {
+	    delete theMaterial[i];
+	    theMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+	    if (theMaterial[i] == 0) {
+          opserr << "EightNodeQuad::recvSelf() - material " << i << "failed to create\n";
+	      return -1;
+	    }
+      }
+      // Receive the material
+      theMaterial[i]->setDbTag(matDbTag);
+      res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+      if (res < 0) {
+        opserr << "EightNodeQuad::recvSelf() - material " << i << "failed to recv itself\n";
+	    return res;
+      }
+    }
+  }
+
+  return res;
+}
+
+void
+EightNodeQuad::Print(OPS_Stream &s, int flag)
+{
+  if (flag == 2) {
+
+    s << "#EightNodeQuad\n";
+
+    int i;
+    const int numNodes = 8;
+    const int nstress = 3 ;
+
+    for (i=0; i<numNodes; i++) {
+      const Vector &nodeCrd = theNodes[i]->getCrds();
+      const Vector &nodeDisp = theNodes[i]->getDisp();
+      s << "#NODE " << nodeCrd(0) << " " << nodeCrd(1) << " " << endln;
+     }
+
+    // spit out the section location & invoke print on the scetion
+    // const int numMaterials = 4;
+    const int numMaterials = 8;
+
+    static Vector avgStress(nstress);
+    static Vector avgStrain(nstress);
+    avgStress.Zero();
+    avgStrain.Zero();
+    for (i=0; i<numMaterials; i++) {
+      avgStress += theMaterial[i]->getStress();
+      avgStrain += theMaterial[i]->getStrain();
+    }
+    avgStress /= numMaterials;
+    avgStrain /= numMaterials;
+
+    s << "#AVERAGE_STRESS ";
+    for (i=0; i<nstress; i++)
+      s << avgStress(i) << " " ;
+    s << endln;
+
+    s << "#AVERAGE_STRAIN ";
+    for (i=0; i<nstress; i++)
+      s << avgStrain(i) << " " ;
+    s << endln;
+  }
+
+  if (flag == OPS_PRINT_CURRENTSTATE) {
+    s << "\nEightNodeQuad, element id:  " << this->getTag() << endln;
+	s << "\tConnected external nodes:  " << connectedExternalNodes;
+	s << "\tthickness:  " << thickness << endln;
+	s << "\tsurface pressure:  " << pressure << endln;
+    s << "\tmass density:  " << rho << endln;
+    s << "\tbody forces:  " << b[0] << " " << b[1] << endln;
+	theMaterial[0]->Print(s,flag);
+	s << "\tStress (xx yy xy)" << endln;
+	for (int i = 0; i < 8; i++)
+		s << "\t\tGauss point " << i+1 << ": " << theMaterial[i]->getStress();
+  }
+
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+      s << "\t\t\t{";
+      s << "\"name\": " << this->getTag() << ", ";
+      s << "\"type\": \"EightNodeQuad\", ";
+      s << "\"nodes\": [" << connectedExternalNodes(0) << ", ";
+      s << connectedExternalNodes(1) << ", ";
+      s << connectedExternalNodes(2) << ", ";
+      s << connectedExternalNodes(3) << ", ";
+      s << connectedExternalNodes(4) << ", ";
+      s << connectedExternalNodes(5) << ", ";
+      s << connectedExternalNodes(6) << ", ";
+      s << connectedExternalNodes(7) << "], ";
+      s << "\"thickness\": " << thickness << ", ";
+      s << "\"surfacePressure\": " << pressure << ", ";
+      s << "\"masspervolume\": " << rho << ", ";
+      s << "\"bodyForces\": [" << b[0] << ", " << b[1] << "], ";
+      s << "\"material\": \"" << theMaterial[0]->getTag() << "\"}";
+  }
+}
+
+int
+EightNodeQuad::displaySelf(Renderer &theViewer, int displayMode, float fact, const char **modes, int numMode)
+{
+
+    // first set the quantity to be displayed at the nodes;
+    // if displayMode is 1 through 3 we will plot material stresses otherwise 0.0
+
+    static Vector values(8);
+
+    for (int j=0; j<8; j++)
+	   values(j) = 0.0;
+
+    if (displayMode < 8 && displayMode > 0) {
+	for (int i=0; i<8; i++) {
+	  const Vector &stress = theMaterial[i]->getStress();
+	  values(i) = stress(displayMode-1);
+	}
+    }
+
+    // now  determine the end points of the quad based on
+    // the display factor (a measure of the distorted image)
+    // store this information in 4 3d vectors v1 through v4
+    const Vector &end1Crd = theNodes[0]->getCrds();
+    const Vector &end2Crd = theNodes[1]->getCrds();
+    const Vector &end3Crd = theNodes[2]->getCrds();
+    const Vector &end4Crd = theNodes[3]->getCrds();
+    const Vector &end5Crd = theNodes[4]->getCrds();
+    const Vector &end6Crd = theNodes[5]->getCrds();
+    const Vector &end7Crd = theNodes[6]->getCrds();
+    const Vector &end8Crd = theNodes[7]->getCrds();
+
+    static Matrix coords(8,3);
+
+    if (displayMode >= 0) {
+
+      const Vector &end1Disp = theNodes[0]->getDisp();
+      const Vector &end2Disp = theNodes[1]->getDisp();
+      const Vector &end3Disp = theNodes[2]->getDisp();
+      const Vector &end4Disp = theNodes[3]->getDisp();
+      const Vector &end5Disp = theNodes[4]->getDisp();
+      const Vector &end6Disp = theNodes[5]->getDisp();
+      const Vector &end7Disp = theNodes[6]->getDisp();
+      const Vector &end8Disp = theNodes[7]->getDisp();
+
+      for (int i = 0; i < 2; i++) {
+	coords(0,i) = end1Crd(i) + end1Disp(i)*fact;
+	coords(1,i) = end2Crd(i) + end2Disp(i)*fact;
+	coords(2,i) = end3Crd(i) + end3Disp(i)*fact;
+	coords(3,i) = end4Crd(i) + end4Disp(i)*fact;
+	coords(4,i) = end5Crd(i) + end5Disp(i)*fact;
+	coords(5,i) = end6Crd(i) + end6Disp(i)*fact;
+	coords(6,i) = end7Crd(i) + end7Disp(i)*fact;
+	coords(7,i) = end8Crd(i) + end8Disp(i)*fact;
+      }
+    } else {
+      int mode = displayMode * -1;
+      const Matrix &eigen1 = theNodes[0]->getEigenvectors();
+      const Matrix &eigen2 = theNodes[1]->getEigenvectors();
+      const Matrix &eigen3 = theNodes[2]->getEigenvectors();
+      const Matrix &eigen4 = theNodes[3]->getEigenvectors();
+      const Matrix &eigen5 = theNodes[4]->getEigenvectors();
+      const Matrix &eigen6 = theNodes[5]->getEigenvectors();
+      const Matrix &eigen7 = theNodes[6]->getEigenvectors();
+      const Matrix &eigen8 = theNodes[7]->getEigenvectors();
+      if (eigen1.noCols() >= mode) {
+	for (int i = 0; i < 2; i++) {
+	  coords(0,i) = end1Crd(i) + eigen1(i,mode-1)*fact;
+	  coords(1,i) = end2Crd(i) + eigen2(i,mode-1)*fact;
+	  coords(2,i) = end3Crd(i) + eigen3(i,mode-1)*fact;
+	  coords(3,i) = end4Crd(i) + eigen4(i,mode-1)*fact;
+	  coords(4,i) = end5Crd(i) + eigen5(i,mode-1)*fact;
+	  coords(5,i) = end6Crd(i) + eigen6(i,mode-1)*fact;
+	  coords(6,i) = end7Crd(i) + eigen7(i,mode-1)*fact;
+	  coords(7,i) = end8Crd(i) + eigen8(i,mode-1)*fact;
+	}
+      } else {
+	for (int i = 0; i < 2; i++) {
+	  coords(0,i) = end1Crd(i);
+	  coords(1,i) = end2Crd(i);
+	  coords(2,i) = end3Crd(i);
+	  coords(3,i) = end4Crd(i);
+	  coords(4,i) = end5Crd(i);
+	  coords(5,i) = end6Crd(i);
+	  coords(6,i) = end7Crd(i);
+	  coords(7,i) = end8Crd(i);
+	}
+      }
+    }
+
+    int error = 0;
+
+    // finally we  the element using drawPolygon
+    error += theViewer.drawPolygon (coords, values, this->getTag());
+
+    return error;
+}
+
+Response*
+EightNodeQuad::setResponse(const char **argv, int argc,
+			  OPS_Stream &output)
+{
+  Response *theResponse =0;
+
+  output.tag("ElementOutput");
+  output.attr("eleType","EightNodeQuad");
+  output.attr("eleTag",this->getTag());
+  output.attr("node1",connectedExternalNodes[0]);
+  output.attr("node2",connectedExternalNodes[1]);
+  output.attr("node3",connectedExternalNodes[2]);
+  output.attr("node4",connectedExternalNodes[3]);
+  output.attr("node5",connectedExternalNodes[4]);
+  output.attr("node6",connectedExternalNodes[5]);
+  output.attr("node7",connectedExternalNodes[6]);
+  output.attr("node8",connectedExternalNodes[7]);
+
+  // check out ??? test recorder for 'force'
+  char dataOut[20];
+  // char dataOut[32];
+  if (strcmp(argv[0],"force") == 0 || strcmp(argv[0],"forces") == 0) {
+
+    for (int i=1; i<=8; i++) {
+      sprintf(dataOut,"P1_%d",i);
+      output.tag("ResponseType",dataOut);
+      sprintf(dataOut,"P2_%d",i);
+      output.tag("ResponseType",dataOut);
+    }
+
+    theResponse =  new ElementResponse(this, 1, P);
+  }
+
+  else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"integrPoint") == 0) {
+
+    int pointNum = atoi(argv[1]);
+    if (pointNum > 0 && pointNum <= 8) {
+
+      output.tag("GaussPoint");
+      output.attr("number",pointNum);
+      output.attr("eta",pts[pointNum-1][0]);
+      output.attr("neta",pts[pointNum-1][1]);
+
+      theResponse =  theMaterial[pointNum-1]->setResponse(&argv[2], argc-2, output);
+
+      output.endTag();
+
+    }
+  }
+  else if ((strcmp(argv[0],"stresses") ==0) || (strcmp(argv[0],"stress") ==0)) {
+    for (int i=0; i<8; i++) {
+      output.tag("GaussPoint");
+      output.attr("number",i+1);
+      output.attr("eta",pts[i][0]);
+      output.attr("neta",pts[i][1]);
+
+      output.tag("NdMaterialOutput");
+      output.attr("classType", theMaterial[i]->getClassTag());
+      output.attr("tag", theMaterial[i]->getTag());
+
+      output.tag("ResponseType","sigma11");
+      output.tag("ResponseType","sigma22");
+      output.tag("ResponseType","sigma12");
+
+      output.endTag(); // GaussPoint
+      output.endTag(); // NdMaterialOutput
+      }
+    theResponse =  new ElementResponse(this, 3, Vector(27));
+  }
+
+  else if ((strcmp(argv[0],"strain") ==0) || (strcmp(argv[0],"strains") ==0)) {
+    for (int i=0; i<8; i++) {
+      output.tag("GaussPoint");
+      output.attr("number",i+1);
+      output.attr("eta",pts[i][0]);
+      output.attr("neta",pts[i][1]);
+
+      output.tag("NdMaterialOutput");
+      output.attr("classType", theMaterial[i]->getClassTag());
+      output.attr("tag", theMaterial[i]->getTag());
+
+      output.tag("ResponseType","eta11");
+      output.tag("ResponseType","eta22");
+      output.tag("ResponseType","eta12");
+
+      output.endTag(); // GaussPoint
+      output.endTag(); // NdMaterialOutput
+      }
+    theResponse =  new ElementResponse(this, 4, Vector(27));
+  }
+
+  output.endTag(); // ElementOutput
+
+  return theResponse;
+}
+
+int
+EightNodeQuad::getResponse(int responseID, Information &eleInfo)
+{
+  if (responseID == 1) {
+
+    return eleInfo.setVector(this->getResistingForce());
+
+  } else if (responseID == 3) {
+
+    // Loop over the integration points
+    static Vector stresses(24);
+    int cnt = 0;
+    for (int i = 0; i < 8; i++) {
+
+      // Get material stress response
+      const Vector &sigma = theMaterial[i]->getStress();
+      stresses(cnt) = sigma(0);
+      stresses(cnt+1) = sigma(1);
+      stresses(cnt+2) = sigma(2);
+      cnt += 3;
+    }
+
+    return eleInfo.setVector(stresses);
+
+  } else if (responseID == 4) {
+
+    // Loop over the integration points
+    static Vector stresses(24);
+    int cnt = 0;
+    for (int i = 0; i < 8; i++) {
+
+      // Get material stress response
+      const Vector &sigma = theMaterial[i]->getStrain();
+      stresses(cnt) = sigma(0);
+      stresses(cnt+1) = sigma(1);
+      stresses(cnt+2) = sigma(2);
+      cnt += 3;
+    }
+
+    return eleInfo.setVector(stresses);
+
+  } else
+
+    return -1;
+}
+
+int
+EightNodeQuad::setParameter(const char **argv, int argc, Parameter &param)
+{
+  if (argc < 1)
+    return -1;
+
+  int res = -1;
+
+  // quad pressure loading
+  if (strcmp(argv[0],"pressure") == 0) {
+    return param.addObject(2, this);
+  }
+  // a material parameter
+  else if ((strstr(argv[0],"material") != 0) && (strcmp(argv[0],"materialState") != 0)) {
+
+    if (argc < 3)
+      return -1;
+
+    int pointNum = atoi(argv[1]);
+    if (pointNum > 0 && pointNum <= 8)
+      return theMaterial[pointNum-1]->setParameter(&argv[2], argc-2, param);
+    else
+      return -1;
+  }
+
+  // otherwise it could be just a forall material parameter
+  else {
+
+    int matRes = res;
+    for (int i=0; i<8; i++) {
+
+      matRes =  theMaterial[i]->setParameter(argv, argc, param);
+
+      if (matRes != -1)
+	res = matRes;
+    }
+  }
+
+  return res;
+}
+
+int
+EightNodeQuad::updateParameter(int parameterID, Information &info)
+{
+	int res = -1;
+		int matRes = res;
+  switch (parameterID) {
+    case -1:
+      return -1;
+
+	case 1:
+
+		for (int i = 0; i<8; i++) {
+		matRes = theMaterial[i]->updateParameter(parameterID, info);
+		}
+		if (matRes != -1) {
+			res = matRes;
+		}
+		return res;
+
+	case 2:
+		pressure = info.theDouble;
+		this->setPressureLoadAtNodes();	// update consistent nodal loads
+		return 0;
+
+	default:
+	  /*
+	  if (parameterID >= 100) { // material parameter
+	    int pointNum = parameterID/100;
+	    if (pointNum > 0 && pointNum <= 4)
+	      return theMaterial[pointNum-1]->updateParameter(parameterID-100*pointNum, info);
+	    else
+	      return -1;
+	  } else // unknown
+	  */
+	    return -1;
+  }
+}
+
+double EightNodeQuad::shapeFunction(double s, double t)
+{
+	const Vector &nd1Crds = theNodes[0]->getCrds();
+	const Vector &nd2Crds = theNodes[1]->getCrds();
+	const Vector &nd3Crds = theNodes[2]->getCrds();
+	const Vector &nd4Crds = theNodes[3]->getCrds();
+	const Vector &nd5Crds = theNodes[4]->getCrds();
+	const Vector &nd6Crds = theNodes[5]->getCrds();
+	const Vector &nd7Crds = theNodes[6]->getCrds();
+	const Vector &nd8Crds = theNodes[7]->getCrds();
+
+	// double oneMinusT = 1.0-t;
+	// double onePlusT = 1.0+t;
+	// double oneMinusS = 1.0-s;
+	// double onePlusS = 1.0+s;
+	// double oneMinusSSq = 1.0-(s*s);
+	// double oneMinusTSq = 1.0-(t*t);
+	// double N9 = oneMinusSSq*oneMinusTSq;
+	// double N5 = 0.5*oneMinusSSq*oneMinusT - 0.5*N9;
+	// double N6 = 0.5*onePlusS*oneMinusTSq - 0.5*N9;
+	// double N7 = 0.5*oneMinusSSq*onePlusT - 0.5*N9;
+	// double N8 = 0.5*oneMinusS*oneMinusTSq - 0.5*N9;
+
+	double N1 = -(1-s)*(1-t)*(1+s+t)/4;
+	double N2 = -(1+s)*(1-t)*(1-s+t)/4;
+	double N3 = -(1+s)*(1+t)*(1-s-t)/4;
+	double N4 = -(1-s)*(1+t)*(1+s-t)/4;
+
+	double N5 = (1-s*s)*(1-t)/2;
+	double N6 = (1+s)*(1-t*t)/2;
+	double N7 = (1-s*s)*(1+t)/2;
+	double N8 = (1-s)*(1-t*t)/2;
+
+	shp[2][0] = N1;
+	shp[2][1] = N2;
+	shp[2][2] = N3;
+	shp[2][3] = N4;
+	shp[2][4] = N5;
+	shp[2][5] = N6;
+	shp[2][6] = N7;
+	shp[2][7] = N8;
+
+	// shp[2][0] = 0.25*oneMinusS*oneMinusT - 0.5*N5 - 0.5*N8 - 0.25*N9; // N_1
+	// shp[2][1] = 0.25*onePlusS*oneMinusT - 0.5*N5 - 0.5*N6 - 0.25*N9; // N_2
+	// shp[2][2] = 0.25*onePlusS*onePlusT - 0.5*N6 - 0.5*N7 - 0.25*N9; // N_3
+	// shp[2][3] = 0.25*oneMinusS*onePlusT - 0.5*N7 - 0.5*N8 - 0.25*N9; // N_4
+
+	// derivatives
+	double N11 = -1*(-(1-t)*(1+s+t)+(1-s)*(1-t))/4;
+	double N21 = -1*((1-t)*(1-s+t)-(1+s)*(1-t))/4;
+	double N31 = -1*((1+t)*(1-s-t)-(1+s)*(1+t))/4;
+	double N41 = -1*(-(1+t)*(1+s-t)+(1-s)*(1+t))/4;
+	double N51 = -s*(1-t);
+	double N61 = (1-t*t)/2;
+	double N71 = -s*(1+t);
+	double N81 = -1*(1-t*t)/2;
+	double N12 = -1*(-(1-s)*(1+s+t)+(1-s)*(1-t))/4;
+	double N22 = -1*(-(1+s)*(1-s+t)+(1+s)*(1-t))/4;
+	double N32 = -1*((1+s)*(1-s-t)-(1+s)*(1+t))/4;
+	double N42 = -1*((1-s)*(1+s-t)-(1-s)*(1+t))/4;
+	double N52 = -1*(1-s*s)/2;
+	double N62 = -t*(1+s);
+	double N72 = (1-s*s)/2;
+	double N82 = -t*(1-s);
+
+	// remains the same 2x2 matrix Cook Malkus Plesha 6.6, p. 180
+	double J[2][2];
+
+	J[0][0] = nd1Crds(0)*N11 + nd2Crds(0)*N21 + nd3Crds(0)*N31 + nd4Crds(0)*N41 +
+	  nd5Crds(0)*N51 + nd6Crds(0)*N61 + nd7Crds(0)*N71 + nd8Crds(0)*N81;
+
+	J[0][1] = nd1Crds(0)*N12 + nd2Crds(0)*N22 + nd3Crds(0)*N32 + nd4Crds(0)*N42 +
+	  nd5Crds(0)*N52 + nd6Crds(0)*N62 + nd7Crds(0)*N72 + nd8Crds(0)*N82;
+
+	J[1][0] = nd1Crds(1)*N11 + nd2Crds(1)*N21 + nd3Crds(1)*N31 + nd4Crds(1)*N41 +
+	  nd5Crds(1)*N51 + nd6Crds(1)*N61 + nd7Crds(1)*N71 + nd8Crds(1)*N81;
+
+	J[1][1] = nd1Crds(1)*N12 + nd2Crds(1)*N22 + nd3Crds(1)*N32 + nd4Crds(1)*N42 +
+	  nd5Crds(1)*N52 + nd6Crds(1)*N62 + nd7Crds(1)*N72 + nd8Crds(1)*N82;
+
+	double detJ = J[0][0]*J[1][1] - J[0][1]*J[1][0];
+
+	double L[2][2];
+
+	// L = inv(J)
+	L[0][0] =  J[1][1]/detJ;
+	L[1][0] = -J[0][1]/detJ;
+	L[0][1] = -J[1][0]/detJ;
+	L[1][1] =  J[0][0]/detJ;
+
+    double L00 = L[0][0];
+    double L10 = L[1][0];
+    double L01 = L[0][1];
+    double L11 = L[1][1];
+
+    shp[0][0] = L00*N11 + L01*N12;
+    shp[0][1] = L00*N21 + L01*N22;
+    shp[0][2] = L00*N31 + L01*N32;
+    shp[0][3] = L00*N41 + L01*N42;
+    shp[0][4] = L00*N51 + L01*N52;
+    shp[0][5] = L00*N61 + L01*N62;
+    shp[0][6] = L00*N71 + L01*N72;
+    shp[0][7] = L00*N81 + L01*N82;
+
+    shp[1][0] = L10*N11 + L11*N12;
+    shp[1][1] = L10*N21 + L11*N22;
+    shp[1][2] = L10*N31 + L11*N32;
+    shp[1][3] = L10*N41 + L11*N42;
+    shp[1][4] = L10*N51 + L11*N52;
+    shp[1][5] = L10*N61 + L11*N62;
+    shp[1][6] = L10*N71 + L11*N72;
+    shp[1][7] = L10*N81 + L11*N82;
+
+    return detJ;
+}
+
+void
+EightNodeQuad::setPressureLoadAtNodes(void)
+{
+        pressureLoad.Zero();
+
+	if (pressure == 0.0)
+		return;
+
+	const Vector &node1 = theNodes[0]->getCrds();
+	const Vector &node2 = theNodes[1]->getCrds();
+	const Vector &node3 = theNodes[2]->getCrds();
+	const Vector &node4 = theNodes[3]->getCrds();
+	const Vector &node5 = theNodes[4]->getCrds();
+	const Vector &node6 = theNodes[5]->getCrds();
+	const Vector &node7 = theNodes[6]->getCrds();
+	const Vector &node8 = theNodes[7]->getCrds();
+
+	double x1 = node1(0);
+	double y1 = node1(1);
+	double x2 = node2(0);
+	double y2 = node2(1);
+	double x3 = node3(0);
+	double y3 = node3(1);
+	double x4 = node4(0);
+	double y4 = node4(1);
+	double x5 = node5(0);
+	double y5 = node5(1);
+	double x6 = node6(0);
+	double y6 = node6(1);
+	double x7 = node7(0);
+	double y7 = node7(1);
+	double x8 = node8(0);
+	double y8 = node8(1);
+
+	double dx15 = x5-x1;
+	double dy15 = y5-y1;
+	double dx52 = x2-x5;
+	double dy52 = y2-y5;
+	double dx26 = x6-x2;
+	double dy26 = y6-y2;
+	double dx63 = x3-x6;
+	double dy63 = y3-y6;
+	double dx37 = x7-x3;
+	double dy37 = y7-y3;
+	double dx74 = x4-x7;
+	double dy74 = y4-y7;
+	double dx48 = x8-x4;
+	double dy48 = y8-y4;
+	double dx81 = x1-x8;
+	double dy81 = y1-y8;
+
+	double fac1 = 0.3333333333333333;
+	double fac2 = 0.6666666666666667;
+
+	// Contribution from side 15
+	pressureLoad(0) += pressure*fac1*dy15;
+	pressureLoad(8) += pressure*fac2*dy15;
+	pressureLoad(1) += pressure*fac1*-dx15;
+	pressureLoad(9) += pressure*fac2*-dx15;
+
+	// Contribution from side 52
+	pressureLoad(8) += pressure*fac2*dy52;
+	pressureLoad(2) += pressure*fac1*dy52;
+	pressureLoad(9) += pressure*fac2*-dx52;
+	pressureLoad(3) += pressure*fac1*-dx52;
+
+	// Contribution from side 26
+	pressureLoad(2) += pressure*fac1*dy26;
+	pressureLoad(10) += pressure*fac2*dy26;
+	pressureLoad(3) += pressure*fac1*-dx26;
+	pressureLoad(11) += pressure*fac2*-dx26;
+
+	// Contribution from side 63
+	pressureLoad(10) += pressure*fac2*dy63;
+	pressureLoad(4) += pressure*fac1*dy63;
+	pressureLoad(11) += pressure*fac2*-dx63;
+	pressureLoad(5) += pressure*fac1*-dx63;
+
+	// Contribution from side 37
+	pressureLoad(4) += pressure*fac1*dy37;
+	pressureLoad(12) += pressure*fac2*dy37;
+	pressureLoad(5) += pressure*fac1*-dx37;
+	pressureLoad(13) += pressure*fac2*-dx37;
+
+	// Contribution from side 74
+	pressureLoad(12) += pressure*fac2*dy74;
+	pressureLoad(6) += pressure*fac1*dy74;
+	pressureLoad(13) += pressure*fac2*-dx74;
+	pressureLoad(7) += pressure*fac1*-dx74;
+
+	// Contribution from side 48
+	pressureLoad(6) += pressure*fac1*dy48;
+	pressureLoad(14) += pressure*fac2*dy48;
+	pressureLoad(7) += pressure*fac1*-dx48;
+	pressureLoad(15) += pressure*fac2*-dx48;
+
+	// Contribution from side 81
+	pressureLoad(14) += pressure*fac2*dy81;
+	pressureLoad(0) += pressure*fac1*dy81;
+	pressureLoad(15) += pressure*fac2*-dx81;
+	pressureLoad(1) += pressure*fac1*-dx81;
+
+	//pressureLoad = pressureLoad*thickness;
+}

--- a/SRC/element/fourNodeQuad/EightNodeQuad.h
+++ b/SRC/element/fourNodeQuad/EightNodeQuad.h
@@ -1,0 +1,137 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+//
+// based on FourNodeQuad by MHS
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: Aug 2020
+//
+// Description: This file contains the class definition for EightNodeQuad.
+
+#ifndef EightNodeQuad_h
+#define EightNodeQuad_h
+
+#ifndef _bool_h
+#include "bool.h"
+#endif
+
+#include <Element.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <Vector.h>
+
+class Node;
+class NDMaterial;
+class Response;
+
+class EightNodeQuad : public Element {
+public:
+  EightNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4, int nd5, int nd6,
+               int nd7, int nd8, NDMaterial &m, const char *type, double t,
+               double pressure = 0.0, double rho = 0.0, double b1 = 0.0,
+               double b2 = 0.0);
+  EightNodeQuad();
+  ~EightNodeQuad();
+
+  const char *getClassType(void) const { return "EightNodeQuad"; };
+
+  int getNumExternalNodes(void) const;
+  const ID &getExternalNodes(void);
+  Node **getNodePtrs(void);
+
+  int getNumDOF(void);
+  void setDomain(Domain *theDomain);
+
+  // public methods to set the state of the element
+  int commitState(void);
+  int revertToLastCommit(void);
+  int revertToStart(void);
+  int update(void);
+
+  // public methods to obtain stiffness, mass, damping and residual information
+  const Matrix &getTangentStiff(void);
+  const Matrix &getInitialStiff(void);
+  const Matrix &getMass(void);
+
+  void zeroLoad();
+  int addLoad(ElementalLoad *theLoad, double loadFactor);
+  int addInertiaLoadToUnbalance(const Vector &accel);
+
+  const Vector &getResistingForce(void);
+  const Vector &getResistingForceIncInertia(void);
+
+  // public methods for element output
+  int sendSelf(int commitTag, Channel &theChannel);
+  int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
+
+  int displaySelf(Renderer &, int mode, float fact,
+                  const char **displayModes = 0, int numModes = 0);
+  void Print(OPS_Stream &s, int flag = 0);
+
+  Response *setResponse(const char **argv, int argc, OPS_Stream &s);
+
+  int getResponse(int responseID, Information &eleInformation);
+
+  int setParameter(const char **argv, int argc, Parameter &param);
+  int updateParameter(int parameterID, Information &info);
+
+  // RWB; PyLiq1 & TzLiq1 need to see the excess pore pressure and initial
+  // stresses.
+  friend class PyLiq1;
+  friend class TzLiq1;
+
+protected:
+private:
+  // private attributes - a copy for each object of the class
+
+  NDMaterial **theMaterial; // pointer to the ND material objects
+
+  ID connectedExternalNodes; // Tags of quad nodes
+
+  Node *theNodes[8];
+
+  // static double matrixData[64]; // array data for matrix
+  static double matrixData[256]; // array data for matrix
+  static Matrix K;              // Element stiffness, damping, and mass Matrix
+  static Vector P;              // Element resisting force vector
+  Vector Q;                     // Applied nodal loads
+  double b[2];                  // Body forces
+
+  double appliedB[2]; // Body forces applied with load pattern, C.McGann,
+                      // U.Washington
+  int applyLoad;      // flag for body force in load, C.McGann, U.Washington
+
+  Vector pressureLoad; // Pressure load at nodes
+
+  double thickness; // Element thickness
+  double pressure;  // Normal surface traction (pressure) over entire element
+                   // Note: positive for outward normal
+  double rho;
+  static double shp[3][8]; // Stores shape functions and derivatives (overwritten)
+  static double pts[8][2]; // Stores quadrature points
+  static double wts[8];    // Stores quadrature weights
+
+  // private member functions - only objects of this class can call these
+  double shapeFunction(double xi, double eta);
+  void setPressureLoadAtNodes(void);
+
+  Matrix *Ki;
+};
+
+#endif

--- a/SRC/element/fourNodeQuad/Makefile
+++ b/SRC/element/fourNodeQuad/Makefile
@@ -6,6 +6,8 @@ OBJS       = FourNodeQuad.o \
 	EnhancedQuad.o \
 	FourNodeQuad3d.o \
 	NineNodeMixedQuad.o \
+	NineNodeQuad.o \
+	EightNodeQuad.o \
 	FourNodeQuadWithSensitivity.o
 
 all:         $(OBJS)

--- a/SRC/element/fourNodeQuad/NineNodeQuad.cpp
+++ b/SRC/element/fourNodeQuad/NineNodeQuad.cpp
@@ -1,0 +1,1640 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+//
+// based on FourNodeQuad by MHS
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: Aug 2020
+//
+// Description: This file contains the class definition for NineNodeQuad.
+
+#include "NineNodeQuad.h"
+#include <Node.h>
+#include <NDMaterial.h>
+#include <Matrix.h>
+#include <Vector.h>
+#include <ID.h>
+#include <Renderer.h>
+#include <Domain.h>
+#include <string.h>
+#include <Information.h>
+#include <Parameter.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <ElementResponse.h>
+#include <ElementalLoad.h>
+#include <elementAPI.h>
+
+void* OPS_NineNodeQuad()
+{
+    int ndm = OPS_GetNDM();
+    int ndf = OPS_GetNDF();
+
+    if (ndm != 2 || ndf != 2) {
+	opserr << "WARNING -- model dimensions and/or nodal DOF not compatible with quad element\n";
+	return 0;
+    }
+
+    if (OPS_GetNumRemainingInputArgs() < 13) {
+	opserr << "WARNING insufficient arguments\n";
+	opserr << "Want: element NineNodeQuad eleTag? Node1? Node2? Node3? Node4? Node5? Node6? Node7? Node8? Node9? thk? type? matTag? <pressure? rho? b1? b2?>\n";
+	return 0;
+    }
+
+    // NineNodeQuadId, iNode, jNode, kNode, lNode
+	// nNode, mNode, pNode, qNode, cNode
+    int idata[10];
+    int num = 10;
+    if (OPS_GetIntInput(&num,idata) < 0) {
+	opserr<<"WARNING: invalid integer inputs\n";
+	return 0;
+    }
+
+    double thk = 1.0;
+    num = 1;
+    if (OPS_GetDoubleInput(&num,&thk) < 0) {
+	opserr<<"WARNING: invalid double inputs\n";
+	return 0;
+    }
+
+    const char* type = OPS_GetString();
+
+    int matTag;
+    num = 1;
+    if (OPS_GetIntInput(&num,&matTag) < 0) {
+	opserr<<"WARNING: invalid matTag\n";
+	return 0;
+    }
+
+    NDMaterial* mat = OPS_getNDMaterial(matTag);
+    if (mat == 0) {
+	opserr << "WARNING material not found\n";
+	opserr << "Material: " << matTag;
+	opserr << "\nNineNodeQuad element: " << idata[0] << endln;
+	return 0;
+    }
+
+    // p, rho, b1, b2
+    double data[4] = {0,0,0,0};
+    num = OPS_GetNumRemainingInputArgs();
+    if (num > 4) {
+	num = 4;
+    }
+    if (num > 0) {
+	if (OPS_GetDoubleInput(&num,data) < 0) {
+	    opserr<<"WARNING: invalid integer data\n";
+	    return 0;
+	}
+    }
+
+    return new NineNodeQuad(idata[0],idata[1],idata[2],idata[3],idata[4],
+							idata[5],idata[6],idata[7],idata[8],idata[9],
+			                *mat,type,thk,data[0],data[1],data[2],data[3]);
+}
+
+
+double NineNodeQuad::matrixData[324];
+Matrix NineNodeQuad::K(matrixData, 18, 18);
+Vector NineNodeQuad::P(18);
+double NineNodeQuad::shp[3][9];
+double NineNodeQuad::pts[9][2];
+double NineNodeQuad::wts[9];
+
+NineNodeQuad::NineNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4,
+						   int nd5, int nd6, int nd7, int nd8, int nd9,
+						   NDMaterial &m, const char *type, double t,
+						   double p, double r, double b1, double b2)
+:Element (tag, ELE_TAG_NineNodeQuad),
+  theMaterial(0), connectedExternalNodes(9),
+ Q(18), applyLoad(0), pressureLoad(18), thickness(t), pressure(p), rho(r), Ki(0)
+{
+	pts[0][0] = -0.7745966692414834;
+	pts[0][1] = -0.7745966692414834;
+	pts[1][0] =  0.7745966692414834;
+	pts[1][1] = -0.7745966692414834;
+	pts[2][0] =  0.7745966692414834;
+	pts[2][1] =  0.7745966692414834;
+	pts[3][0] = -0.7745966692414834;
+	pts[3][1] =  0.7745966692414834;
+	pts[4][0] =  0.0;
+	pts[4][1] = -0.7745966692414834;
+	pts[5][0] =  0.7745966692414834;
+	pts[5][1] =  0.0;
+	pts[6][0] =  0.0;
+	pts[6][1] =  0.7745966692414834;
+	pts[7][0] = -0.7745966692414834;
+	pts[7][1] =  0.0;
+	pts[8][0] =  0.0;
+	pts[8][1] =  0.0;
+
+	wts[0] = 0.30864197530864196;
+	wts[1] = 0.30864197530864196;
+	wts[2] = 0.30864197530864196;
+	wts[3] = 0.30864197530864196;
+	wts[4] = 0.49382716049382713;
+	wts[5] = 0.49382716049382713;
+	wts[6] = 0.49382716049382713;
+	wts[7] = 0.49382716049382713;
+	wts[8] = 0.7901234567901234;
+
+	if (strcmp(type,"PlaneStrain") != 0 && strcmp(type,"PlaneStress") != 0
+	    && strcmp(type,"PlaneStrain2D") != 0 && strcmp(type,"PlaneStress2D") != 0) {
+	  opserr << "NineNodeQuad::NineNodeQuad -- improper material type: " << type << "for NineNodeQuad\n";
+	  exit(-1);
+	}
+
+	// Body forces
+	b[0] = b1;
+	b[1] = b2;
+
+    // Allocate arrays of pointers to NDMaterials
+    theMaterial = new NDMaterial *[9];
+
+    if (theMaterial == 0) {
+      opserr << "NineNodeQuad::NineNodeQuad - failed allocate material model pointer\n";
+      exit(-1);
+    }
+
+	int i;
+    for (i = 0; i < 9; i++) {
+
+      // Get copies of the material model for each integration point
+      theMaterial[i] = m.getCopy(type);
+
+      // Check allocation
+      if (theMaterial[i] == 0) {
+	opserr << "NineNodeQuad::NineNodeQuad -- failed to get a copy of material model\n";
+	exit(-1);
+      }
+    }
+
+    // Set connected external node IDs
+    connectedExternalNodes(0) = nd1;
+    connectedExternalNodes(1) = nd2;
+    connectedExternalNodes(2) = nd3;
+    connectedExternalNodes(3) = nd4;
+    connectedExternalNodes(4) = nd5;
+    connectedExternalNodes(5) = nd6;
+    connectedExternalNodes(6) = nd7;
+    connectedExternalNodes(7) = nd8;
+    connectedExternalNodes(8) = nd9;
+
+    for (i=0; i<9; i++)
+      theNodes[i] = 0;
+}
+
+NineNodeQuad::NineNodeQuad()
+:Element (0,ELE_TAG_NineNodeQuad),
+  theMaterial(0), connectedExternalNodes(9),
+ Q(18), applyLoad(0), pressureLoad(18), thickness(0.0), pressure(0.0), Ki(0)
+{
+	pts[0][0] = -0.7745966692414834;
+	pts[0][1] = -0.7745966692414834;
+	pts[1][0] =  0.7745966692414834;
+	pts[1][1] = -0.7745966692414834;
+	pts[2][0] =  0.7745966692414834;
+	pts[2][1] =  0.7745966692414834;
+	pts[3][0] = -0.7745966692414834;
+	pts[3][1] =  0.7745966692414834;
+	pts[4][0] =  0.0;
+	pts[4][1] = -0.7745966692414834;
+	pts[5][0] =  0.7745966692414834;
+	pts[5][1] =  0.0;
+	pts[6][0] =  0.0;
+	pts[6][1] =  0.7745966692414834;
+	pts[7][0] = -0.7745966692414834;
+	pts[7][1] =  0.0;
+	pts[8][0] =  0.0;
+	pts[8][1] =  0.0;
+
+	wts[0] = 0.30864197530864196;
+	wts[1] = 0.30864197530864196;
+	wts[2] = 0.30864197530864196;
+	wts[3] = 0.30864197530864196;
+	wts[4] = 0.49382716049382713;
+	wts[5] = 0.49382716049382713;
+	wts[6] = 0.49382716049382713;
+	wts[7] = 0.49382716049382713;
+	wts[8] = 0.7901234567901234;
+
+    for (int i=0; i<9; i++)
+      theNodes[i] = 0;
+}
+
+NineNodeQuad::~NineNodeQuad()
+{
+  for (int i = 0; i < 9; i++) {
+    if (theMaterial[i])
+      delete theMaterial[i];
+  }
+
+  // Delete the array of pointers to NDMaterial pointer arrays
+  if (theMaterial)
+    delete [] theMaterial;
+
+  if (Ki != 0)
+    delete Ki;
+}
+
+int
+NineNodeQuad::getNumExternalNodes() const
+{
+    return 9;
+}
+
+const ID&
+NineNodeQuad::getExternalNodes()
+{
+    return connectedExternalNodes;
+}
+
+
+Node **
+NineNodeQuad::getNodePtrs(void)
+{
+  return theNodes;
+}
+
+int
+NineNodeQuad::getNumDOF()
+{
+    return 18;
+}
+
+void
+NineNodeQuad::setDomain(Domain *theDomain)
+{
+	// Check Domain is not null - invoked when object removed from a domain
+    if (theDomain == 0) {
+	theNodes[0] = 0;
+	theNodes[1] = 0;
+	theNodes[2] = 0;
+	theNodes[3] = 0;
+	theNodes[4] = 0;
+	theNodes[5] = 0;
+	theNodes[6] = 0;
+	theNodes[7] = 0;
+	theNodes[8] = 0;
+	return;
+    }
+
+    int Nd1 = connectedExternalNodes(0);
+    int Nd2 = connectedExternalNodes(1);
+    int Nd3 = connectedExternalNodes(2);
+    int Nd4 = connectedExternalNodes(3);
+    int Nd5 = connectedExternalNodes(4);
+    int Nd6 = connectedExternalNodes(5);
+    int Nd7 = connectedExternalNodes(6);
+    int Nd8 = connectedExternalNodes(7);
+    int Nd9 = connectedExternalNodes(8);
+
+    theNodes[0] = theDomain->getNode(Nd1);
+    theNodes[1] = theDomain->getNode(Nd2);
+    theNodes[2] = theDomain->getNode(Nd3);
+    theNodes[3] = theDomain->getNode(Nd4);
+    theNodes[4] = theDomain->getNode(Nd5);
+    theNodes[5] = theDomain->getNode(Nd6);
+    theNodes[6] = theDomain->getNode(Nd7);
+    theNodes[7] = theDomain->getNode(Nd8);
+    theNodes[8] = theDomain->getNode(Nd9);
+
+    if (theNodes[0] == 0 || theNodes[1] == 0 || theNodes[2] == 0 || theNodes[3] == 0 ||
+		theNodes[4] == 0 || theNodes[5] == 0 || theNodes[6] == 0 || theNodes[7] == 0 ||
+		theNodes[8] == 0) {
+	//opserr << "FATAL ERROR NineNodeQuad (tag: %d), node not found in domain",
+	//	this->getTag());
+
+	return;
+    }
+
+    int dofNd1 = theNodes[0]->getNumberDOF();
+    int dofNd2 = theNodes[1]->getNumberDOF();
+    int dofNd3 = theNodes[2]->getNumberDOF();
+    int dofNd4 = theNodes[3]->getNumberDOF();
+    int dofNd5 = theNodes[4]->getNumberDOF();
+    int dofNd6 = theNodes[5]->getNumberDOF();
+    int dofNd7 = theNodes[6]->getNumberDOF();
+    int dofNd8 = theNodes[7]->getNumberDOF();
+    int dofNd9 = theNodes[8]->getNumberDOF();
+
+    if (dofNd1 != 2 || dofNd2 != 2 || dofNd3 != 2 || dofNd4 != 2 ||
+		dofNd5 != 2 || dofNd6 != 2 || dofNd7 != 2 || dofNd8 != 2 || dofNd9 != 2) {
+	//opserr << "FATAL ERROR NineNodeQuad (tag: %d), has differing number of DOFs at its nodes",
+	//	this->getTag());
+
+	return;
+    }
+    this->DomainComponent::setDomain(theDomain);
+
+    // Compute consistent nodal loads due to pressure
+    this->setPressureLoadAtNodes();
+}
+
+int
+NineNodeQuad::commitState()
+{
+    int retVal = 0;
+
+    // call element commitState to do any base class stuff
+    if ((retVal = this->Element::commitState()) != 0) {
+      opserr << "NineNodeQuad::commitState () - failed in base class";
+    }
+
+    // Loop over the integration points and commit the material states
+    for (int i = 0; i < 9; i++)
+      retVal += theMaterial[i]->commitState();
+
+    return retVal;
+}
+
+int
+NineNodeQuad::revertToLastCommit()
+{
+    int retVal = 0;
+
+    // Loop over the integration points and revert to last committed state
+    for (int i = 0; i < 9; i++)
+		retVal += theMaterial[i]->revertToLastCommit();
+
+    return retVal;
+}
+
+int
+NineNodeQuad::revertToStart()
+{
+    int retVal = 0;
+
+    // Loop over the integration points and revert states to start
+    for (int i = 0; i < 9; i++)
+		retVal += theMaterial[i]->revertToStart();
+
+    return retVal;
+}
+
+
+int
+NineNodeQuad::update()
+{
+	const Vector &disp1 = theNodes[0]->getTrialDisp();
+	const Vector &disp2 = theNodes[1]->getTrialDisp();
+	const Vector &disp3 = theNodes[2]->getTrialDisp();
+	const Vector &disp4 = theNodes[3]->getTrialDisp();
+	const Vector &disp5 = theNodes[4]->getTrialDisp();
+	const Vector &disp6 = theNodes[5]->getTrialDisp();
+	const Vector &disp7 = theNodes[6]->getTrialDisp();
+	const Vector &disp8 = theNodes[7]->getTrialDisp();
+	const Vector &disp9 = theNodes[8]->getTrialDisp();
+
+	static double u[2][9];
+
+	u[0][0] = disp1(0);
+	u[1][0] = disp1(1);
+	u[0][1] = disp2(0);
+	u[1][1] = disp2(1);
+	u[0][2] = disp3(0);
+	u[1][2] = disp3(1);
+	u[0][3] = disp4(0);
+	u[1][3] = disp4(1);
+	u[0][4] = disp5(0);
+	u[1][4] = disp5(1);
+	u[0][5] = disp6(0);
+	u[1][5] = disp6(1);
+	u[0][6] = disp7(0);
+	u[1][6] = disp7(1);
+	u[0][7] = disp8(0);
+	u[1][7] = disp8(1);
+	u[0][8] = disp9(0);
+	u[1][8] = disp9(1);
+
+	static Vector eps(3);
+
+	int ret = 0;
+
+	// Loop over the integration points
+	for (int i = 0; i < 9; i++) {
+
+		// Determine Jacobian for this integration point
+		this->shapeFunction(pts[i][0], pts[i][1]);
+
+		// Interpolate strains
+		//eps = B*u;
+		//eps.addMatrixVector(0.0, B, u, 1.0);
+		eps.Zero();
+		for (int beta = 0; beta < 9; beta++) {
+			eps(0) += shp[0][beta]*u[0][beta];
+			eps(1) += shp[1][beta]*u[1][beta];
+			eps(2) += shp[0][beta]*u[1][beta] + shp[1][beta]*u[0][beta];
+		}
+
+		// Set the material strain
+		ret += theMaterial[i]->setTrialStrain(eps);
+	}
+
+	return ret;
+}
+
+
+const Matrix&
+NineNodeQuad::getTangentStiff()
+{
+
+	K.Zero();
+
+	double dvol;
+	double DB[3][2];
+
+	// Loop over the integration points
+	for (int i = 0; i < 9; i++) {
+
+	  // Determine Jacobian for this integration point
+	  dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+	  dvol *= (thickness*wts[i]);
+
+	  // Get the material tangent
+	  const Matrix &D = theMaterial[i]->getTangent();
+
+	  // Perform numerical integration
+	  //K = K + (B^ D * B) * intWt(i)*intWt(j) * detJ;
+	  //K.addMatrixTripleProduct(1.0, B, D, intWt(i)*intWt(j)*detJ);
+
+	  double D00 = D(0,0); double D01 = D(0,1); double D02 = D(0,2);
+	  double D10 = D(1,0); double D11 = D(1,1); double D12 = D(1,2);
+	  double D20 = D(2,0); double D21 = D(2,1); double D22 = D(2,2);
+
+	  //	  for (int beta = 0, ib = 0, colIb =0, colIbP1 = 8;
+	  //   beta < 4;
+	  //   beta++, ib += 2, colIb += 16, colIbP1 += 16) {
+
+	  for (int alpha = 0, ia = 0; alpha < 9; alpha++, ia += 2) {
+	    for (int beta = 0, ib = 0; beta < 9; beta++, ib += 2) {
+
+	      DB[0][0] = dvol * (D00 * shp[0][beta] + D02 * shp[1][beta]);
+	      DB[1][0] = dvol * (D10 * shp[0][beta] + D12 * shp[1][beta]);
+	      DB[2][0] = dvol * (D20 * shp[0][beta] + D22 * shp[1][beta]);
+	      DB[0][1] = dvol * (D01 * shp[1][beta] + D02 * shp[0][beta]);
+	      DB[1][1] = dvol * (D11 * shp[1][beta] + D12 * shp[0][beta]);
+	      DB[2][1] = dvol * (D21 * shp[1][beta] + D22 * shp[0][beta]);
+
+	      K(ia,ib) += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	      K(ia,ib+1) += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	      K(ia+1,ib) += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	      K(ia+1,ib+1) += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+	      //	      matrixData[colIb   +   ia] += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	      //matrixData[colIbP1 +   ia] += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	      //matrixData[colIb   + ia+1] += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	      //matrixData[colIbP1 + ia+1] += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+
+	    }
+	  }
+	}
+
+	return K;
+}
+
+
+const Matrix&
+NineNodeQuad::getInitialStiff()
+{
+  if (Ki != 0)
+    return *Ki;
+
+  K.Zero();
+
+  double dvol;
+  double DB[3][2];
+
+  // Loop over the integration points
+  for (int i = 0; i < 9; i++) {
+
+    // Determine Jacobian for this integration point
+    dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+    dvol *= (thickness*wts[i]);
+
+    // Get the material tangent
+    const Matrix &D = theMaterial[i]->getInitialTangent();
+
+    double D00 = D(0,0); double D01 = D(0,1); double D02 = D(0,2);
+    double D10 = D(1,0); double D11 = D(1,1); double D12 = D(1,2);
+    double D20 = D(2,0); double D21 = D(2,1); double D22 = D(2,2);
+
+    // Perform numerical integration
+    //K = K + (B^ D * B) * intWt(i)*intWt(j) * detJ;
+    //K.addMatrixTripleProduct(1.0, B, D, intWt(i)*intWt(j)*detJ);
+    for (int beta = 0, ib = 0, colIb =0, colIbP1 = 8;
+	 beta < 9;
+	 beta++, ib += 2, colIb += 16, colIbP1 += 16) {
+
+      for (int alpha = 0, ia = 0; alpha < 9; alpha++, ia += 2) {
+
+	DB[0][0] = dvol * (D00 * shp[0][beta] + D02 * shp[1][beta]);
+	DB[1][0] = dvol * (D10 * shp[0][beta] + D12 * shp[1][beta]);
+	DB[2][0] = dvol * (D20 * shp[0][beta] + D22 * shp[1][beta]);
+	DB[0][1] = dvol * (D01 * shp[1][beta] + D02 * shp[0][beta]);
+	DB[1][1] = dvol * (D11 * shp[1][beta] + D12 * shp[0][beta]);
+	DB[2][1] = dvol * (D21 * shp[1][beta] + D22 * shp[0][beta]);
+
+	matrixData[colIb   +   ia] += shp[0][alpha]*DB[0][0] + shp[1][alpha]*DB[2][0];
+	matrixData[colIbP1 +   ia] += shp[0][alpha]*DB[0][1] + shp[1][alpha]*DB[2][1];
+	matrixData[colIb   + ia+1] += shp[1][alpha]*DB[1][0] + shp[0][alpha]*DB[2][0];
+	matrixData[colIbP1 + ia+1] += shp[1][alpha]*DB[1][1] + shp[0][alpha]*DB[2][1];
+      }
+    }
+  }
+
+  Ki = new Matrix(K);
+  return K;
+}
+
+const Matrix&
+NineNodeQuad::getMass()
+{
+	K.Zero();
+
+	int i;
+	static double rhoi[9];
+	double sum = 0.0;
+	for (i = 0; i < 9; i++) {
+	  if (rho == 0)
+	    rhoi[i] = theMaterial[i]->getRho();
+	  else
+	    rhoi[i] = rho;
+	  sum += rhoi[i];
+	}
+
+	if (sum == 0.0)
+	  return K;
+
+	double rhodvol, Nrho;
+
+	// Compute a lumped mass matrix
+	for (i = 0; i < 9; i++) {
+
+		// Determine Jacobian for this integration point
+		rhodvol = this->shapeFunction(pts[i][0], pts[i][1]);
+
+		// Element plus material density ... MAY WANT TO REMOVE ELEMENT DENSITY
+		rhodvol *= (rhoi[i]*thickness*wts[i]);
+
+		for (int alpha = 0, ia = 0; alpha < 9; alpha++, ia++) {
+			Nrho = shp[2][alpha]*rhodvol;
+			K(ia,ia) += Nrho;
+			ia++;
+			K(ia,ia) += Nrho;
+		}
+	}
+
+	return K;
+}
+
+void
+NineNodeQuad::zeroLoad(void)
+{
+	Q.Zero();
+
+	applyLoad = 0;
+
+	appliedB[0] = 0.0;
+	appliedB[1] = 0.0;
+
+  	return;
+}
+
+int
+NineNodeQuad::addLoad(ElementalLoad *theLoad, double loadFactor)
+{
+	// Added option for applying body forces in load pattern: C.McGann, U.Washington
+	int type;
+	const Vector &data = theLoad->getData(type, loadFactor);
+
+	if (type == LOAD_TAG_SelfWeight) {
+		applyLoad = 1;
+		appliedB[0] += loadFactor*data(0)*b[0];
+		appliedB[1] += loadFactor*data(1)*b[1];
+		return 0;
+	} else {
+		opserr << "NineNodeQuad::addLoad - load type unknown for ele with tag: " << this->getTag() << endln;
+		return -1;
+	}
+
+	return -1;
+}
+
+int
+NineNodeQuad::addInertiaLoadToUnbalance(const Vector &accel)
+{
+  int i;
+  static double rhoi[9];
+  double sum = 0.0;
+  for (i = 0; i < 9; i++) {
+    rhoi[i] = theMaterial[i]->getRho();
+    sum += rhoi[i];
+  }
+
+  if (sum == 0.0)
+    return 0;
+
+  // Get R * accel from the nodes
+  const Vector &Raccel1 = theNodes[0]->getRV(accel);
+  const Vector &Raccel2 = theNodes[1]->getRV(accel);
+  const Vector &Raccel3 = theNodes[2]->getRV(accel);
+  const Vector &Raccel4 = theNodes[3]->getRV(accel);
+  const Vector &Raccel5 = theNodes[4]->getRV(accel);
+  const Vector &Raccel6 = theNodes[5]->getRV(accel);
+  const Vector &Raccel7 = theNodes[6]->getRV(accel);
+  const Vector &Raccel8 = theNodes[7]->getRV(accel);
+  const Vector &Raccel9 = theNodes[8]->getRV(accel);
+
+  if (2 != Raccel1.Size() || 2 != Raccel2.Size() || 2 != Raccel3.Size() ||
+      2 != Raccel4.Size() || 2 != Raccel5.Size() || 2 != Raccel6.Size() ||
+	  2 != Raccel7.Size() || 2 != Raccel8.Size() || 2 != Raccel9.Size()) {
+    opserr << "NineNodeQuad::addInertiaLoadToUnbalance matrix and vector sizes are incompatible\n";
+    return -1;
+  }
+
+  static double ra[18];
+
+  ra[0] = Raccel1(0);
+  ra[1] = Raccel1(1);
+  ra[2] = Raccel2(0);
+  ra[3] = Raccel2(1);
+  ra[4] = Raccel3(0);
+  ra[5] = Raccel3(1);
+  ra[6] = Raccel4(0);
+  ra[7] = Raccel4(1);
+  ra[8] = Raccel5(0);
+  ra[9] = Raccel5(1);
+  ra[10] = Raccel6(0);
+  ra[11] = Raccel6(1);
+  ra[12] = Raccel7(0);
+  ra[13] = Raccel7(1);
+  ra[14] = Raccel8(0);
+  ra[15] = Raccel8(1);
+  ra[16] = Raccel9(0);
+  ra[17] = Raccel9(1);
+
+  // Compute mass matrix
+  this->getMass();
+
+  // Want to add ( - fact * M R * accel ) to unbalance
+  // Take advantage of lumped mass matrix
+  for (i = 0; i < 18; i++)
+    Q(i) += -K(i,i)*ra[i];
+
+  return 0;
+}
+
+const Vector&
+NineNodeQuad::getResistingForce()
+{
+	P.Zero();
+
+	double dvol;
+
+	// Loop over the integration points
+	for (int i = 0; i < 9; i++) {
+
+		// Determine Jacobian for this integration point
+		dvol = this->shapeFunction(pts[i][0], pts[i][1]);
+		dvol *= (thickness*wts[i]);
+
+		// Get material stress response
+		const Vector &sigma = theMaterial[i]->getStress();
+
+		// Perform numerical integration on internal force
+		//P = P + (B^ sigma) * intWt(i)*intWt(j) * detJ;
+		//P.addMatrixTransposeVector(1.0, B, sigma, intWt(i)*intWt(j)*detJ);
+		for (int alpha = 0, ia = 0; alpha < 9; alpha++, ia += 2) {
+
+			P(ia) += dvol*(shp[0][alpha]*sigma(0) + shp[1][alpha]*sigma(2));
+
+			P(ia+1) += dvol*(shp[1][alpha]*sigma(1) + shp[0][alpha]*sigma(2));
+
+			// Subtract equiv. body forces from the nodes
+			//P = P - (N^ b) * intWt(i)*intWt(j) * detJ;
+			//P.addMatrixTransposeVector(1.0, N, b, -intWt(i)*intWt(j)*detJ);
+			if (applyLoad == 0) {
+				P(ia) -= dvol*(shp[2][alpha]*b[0]);
+				P(ia+1) -= dvol*(shp[2][alpha]*b[1]);
+			} else {
+				P(ia) -= dvol*(shp[2][alpha]*appliedB[0]);
+				P(ia+1) -= dvol*(shp[2][alpha]*appliedB[1]);
+			}
+		}
+	}
+
+	// Subtract pressure loading from resisting force
+	if (pressure != 0.0) {
+		//P = P - pressureLoad;
+		P.addVector(1.0, pressureLoad, -1.0);
+	}
+
+	// Subtract other external nodal loads ... P_res = P_int - P_ext
+	//P = P - Q;
+	P.addVector(1.0, Q, -1.0);
+
+	return P;
+}
+
+const Vector&
+NineNodeQuad::getResistingForceIncInertia()
+{
+	int i;
+	static double rhoi[9];
+	double sum = 0.0;
+	for (i = 0; i < 9; i++) {
+	  rhoi[i] = theMaterial[i]->getRho();
+	  sum += rhoi[i];
+	}
+
+	// if no mass terms .. just add damping terms
+	if (sum == 0.0) {
+	  this->getResistingForce();
+
+	  // add the damping forces if rayleigh damping
+	  if (betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	    P += this->getRayleighDampingForces();
+
+	  return P;
+	}
+
+	const Vector &accel1 = theNodes[0]->getTrialAccel();
+	const Vector &accel2 = theNodes[1]->getTrialAccel();
+	const Vector &accel3 = theNodes[2]->getTrialAccel();
+	const Vector &accel4 = theNodes[3]->getTrialAccel();
+	const Vector &accel5 = theNodes[4]->getTrialAccel();
+	const Vector &accel6 = theNodes[5]->getTrialAccel();
+	const Vector &accel7 = theNodes[6]->getTrialAccel();
+	const Vector &accel8 = theNodes[7]->getTrialAccel();
+	const Vector &accel9 = theNodes[8]->getTrialAccel();
+
+	static double a[18];
+
+	a[0] = accel1(0);
+	a[1] = accel1(1);
+	a[2] = accel2(0);
+	a[3] = accel2(1);
+	a[4] = accel3(0);
+	a[5] = accel3(1);
+	a[6] = accel4(0);
+	a[7] = accel4(1);
+	a[8] = accel5(0);
+	a[9] = accel5(1);
+	a[10] = accel6(0);
+	a[11] = accel6(1);
+	a[12] = accel7(0);
+	a[13] = accel7(1);
+	a[14] = accel8(0);
+	a[15] = accel8(1);
+	a[16] = accel9(0);
+	a[17] = accel9(1);
+
+	// Compute the current resisting force
+	this->getResistingForce();
+
+	// Compute the mass matrix
+	this->getMass();
+
+	// Take advantage of lumped mass matrix
+	for (i = 0; i < 18; i++)
+		P(i) += K(i,i)*a[i];
+
+	// add the damping forces if rayleigh damping
+	if (alphaM != 0.0 || betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	  P += this->getRayleighDampingForces();
+
+	return P;
+}
+
+int
+NineNodeQuad::sendSelf(int commitTag, Channel &theChannel)
+{
+  int res = 0;
+
+  // note: we don't check for dataTag == 0 for Element
+  // objects as that is taken care of in a commit by the Domain
+  // object - don't want to have to do the check if sending data
+  int dataTag = this->getDbTag();
+
+  // Quad packs its data into a Vector and sends this to theChannel
+  // along with its dbTag and the commitTag passed in the arguments
+  static Vector data(9);
+  data(0) = this->getTag();
+  data(1) = thickness;
+  data(2) = b[0];
+  data(3) = b[1];
+  data(4) = pressure;
+
+  data(5) = alphaM;
+  data(6) = betaK;
+  data(7) = betaK0;
+  data(8) = betaKc;
+
+  res += theChannel.sendVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr << "WARNING NineNodeQuad::sendSelf() - " << this->getTag() << " failed to send Vector\n";
+    return res;
+  }
+
+
+  // Now quad sends the ids of its materials
+  int matDbTag;
+
+  static ID idData(27);
+
+  int i;
+  for (i = 0; i < 9; i++) {
+    idData(i) = theMaterial[i]->getClassTag();
+    matDbTag = theMaterial[i]->getDbTag();
+    // NOTE: we do have to ensure that the material has a database
+    // tag if we are sending to a database channel.
+    if (matDbTag == 0) {
+      matDbTag = theChannel.getDbTag();
+			if (matDbTag != 0)
+			  theMaterial[i]->setDbTag(matDbTag);
+    }
+    // idData(i+4) = matDbTag;
+    idData(i+9) = matDbTag;
+  }
+
+  for( i = 0; i < 9; i++)
+	idData(18+i) = connectedExternalNodes(i);
+
+  res += theChannel.sendID(dataTag, commitTag, idData);
+  if (res < 0) {
+    opserr << "WARNING NineNodeQuad::sendSelf() - " << this->getTag() << " failed to send ID\n";
+    return res;
+  }
+
+  // Finally, quad asks its material objects to send themselves
+  for (i = 0; i < 9; i++) {
+    res += theMaterial[i]->sendSelf(commitTag, theChannel);
+    if (res < 0) {
+      opserr << "WARNING NineNodeQuad::sendSelf() - " << this->getTag() << " failed to send its Material\n";
+      return res;
+    }
+  }
+
+  return res;
+}
+
+int
+NineNodeQuad::recvSelf(int commitTag, Channel &theChannel,
+                       FEM_ObjectBroker &theBroker)
+{
+  int res = 0;
+
+  int dataTag = this->getDbTag();
+
+  // Quad creates a Vector, receives the Vector and then sets the
+  // internal data with the data in the Vector
+  static Vector data(9);
+  res += theChannel.recvVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr << "WARNING NineNodeQuad::recvSelf() - failed to receive Vector\n";
+    return res;
+  }
+
+  this->setTag((int)data(0));
+  thickness = data(1);
+  b[0] = data(2);
+  b[1] = data(3);
+  pressure = data(4);
+
+  alphaM = data(5);
+  betaK = data(6);
+  betaK0 = data(7);
+  betaKc = data(8);
+
+  static ID idData(27);
+  // Quad now receives the tags of its nine external nodes
+  res += theChannel.recvID(dataTag, commitTag, idData);
+  if (res < 0) {
+    opserr << "WARNING NineNodeQuad::recvSelf() - " << this->getTag() << " failed to receive ID\n";
+    return res;
+  }
+
+  for( int i = 0; i < 9; i++)
+    connectedExternalNodes(i) = idData(18+i);
+
+  if (theMaterial == 0) {
+    // Allocate new materials
+    theMaterial = new NDMaterial *[9];
+    if (theMaterial == 0) {
+      opserr << "NineNodeQuad::recvSelf() - Could not allocate NDMaterial* array\n";
+      return -1;
+    }
+    for (int i = 0; i < 9; i++) {
+      int matClassTag = idData(i);
+      int matDbTag = idData(i+9);
+      // Allocate new material with the sent class tag
+      theMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+      if (theMaterial[i] == 0) {
+	    opserr << "NineNodeQuad::recvSelf() - Broker could not create NDMaterial of class type " << matClassTag << endln;
+	    return -1;
+      }
+      // Now receive materials into the newly allocated space
+      theMaterial[i]->setDbTag(matDbTag);
+      res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+      if (res < 0) {
+        opserr << "NineNodeQuad::recvSelf() - material " << i << "failed to recv itself\n";
+	    return res;
+      }
+    }
+  }
+
+  // materials exist , ensure materials of correct type and recvSelf on them
+  else {
+    for (int i = 0; i < 9; i++) {
+      int matClassTag = idData(i);
+      int matDbTag = idData(i+9);
+      // Check that material is of the right type; if not,
+      // delete it and create a new one of the right type
+      if (theMaterial[i]->getClassTag() != matClassTag) {
+	    delete theMaterial[i];
+	    theMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+	    if (theMaterial[i] == 0) {
+          opserr << "NineNodeQuad::recvSelf() - material " << i << "failed to create\n";
+	      return -1;
+	    }
+      }
+      // Receive the material
+      theMaterial[i]->setDbTag(matDbTag);
+      res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+      if (res < 0) {
+        opserr << "NineNodeQuad::recvSelf() - material " << i << "failed to recv itself\n";
+	    return res;
+      }
+    }
+  }
+
+  return res;
+}
+
+void
+NineNodeQuad::Print(OPS_Stream &s, int flag)
+{
+  if (flag == 2) {
+
+    s << "#NineNodeQuad\n";
+
+    int i;
+    const int numNodes = 9;
+    const int nstress = 3 ;
+
+    for (i=0; i<numNodes; i++) {
+      const Vector &nodeCrd = theNodes[i]->getCrds();
+      const Vector &nodeDisp = theNodes[i]->getDisp();
+      s << "#NODE " << nodeCrd(0) << " " << nodeCrd(1) << " " << endln;
+     }
+
+    // spit out the section location & invoke print on the scetion
+    // const int numMaterials = 4;
+    const int numMaterials = 9;
+
+    static Vector avgStress(nstress);
+    static Vector avgStrain(nstress);
+    avgStress.Zero();
+    avgStrain.Zero();
+    for (i=0; i<numMaterials; i++) {
+      avgStress += theMaterial[i]->getStress();
+      avgStrain += theMaterial[i]->getStrain();
+    }
+    avgStress /= numMaterials;
+    avgStrain /= numMaterials;
+
+    s << "#AVERAGE_STRESS ";
+    for (i=0; i<nstress; i++)
+      s << avgStress(i) << " " ;
+    s << endln;
+
+    s << "#AVERAGE_STRAIN ";
+    for (i=0; i<nstress; i++)
+      s << avgStrain(i) << " " ;
+    s << endln;
+  }
+
+  if (flag == OPS_PRINT_CURRENTSTATE) {
+    s << "\nNineNodeQuad, element id:  " << this->getTag() << endln;
+	s << "\tConnected external nodes:  " << connectedExternalNodes;
+	s << "\tthickness:  " << thickness << endln;
+	s << "\tsurface pressure:  " << pressure << endln;
+    s << "\tmass density:  " << rho << endln;
+    s << "\tbody forces:  " << b[0] << " " << b[1] << endln;
+	theMaterial[0]->Print(s,flag);
+	s << "\tStress (xx yy xy)" << endln;
+	for (int i = 0; i < 9; i++)
+		s << "\t\tGauss point " << i+1 << ": " << theMaterial[i]->getStress();
+  }
+
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+      s << "\t\t\t{";
+      s << "\"name\": " << this->getTag() << ", ";
+      s << "\"type\": \"NineNodeQuad\", ";
+      s << "\"nodes\": [" << connectedExternalNodes(0) << ", ";
+      s << connectedExternalNodes(1) << ", ";
+      s << connectedExternalNodes(2) << ", ";
+      s << connectedExternalNodes(3) << ", ";
+      s << connectedExternalNodes(4) << ", ";
+      s << connectedExternalNodes(5) << ", ";
+      s << connectedExternalNodes(6) << ", ";
+      s << connectedExternalNodes(7) << ", ";
+      s << connectedExternalNodes(8) << "], ";
+      s << "\"thickness\": " << thickness << ", ";
+      s << "\"surfacePressure\": " << pressure << ", ";
+      s << "\"masspervolume\": " << rho << ", ";
+      s << "\"bodyForces\": [" << b[0] << ", " << b[1] << "], ";
+      s << "\"material\": \"" << theMaterial[0]->getTag() << "\"}";
+  }
+}
+
+int
+NineNodeQuad::displaySelf(Renderer &theViewer, int displayMode, float fact, const char **modes, int numMode)
+{
+
+    // first set the quantity to be displayed at the nodes;
+    // if displayMode is 1 through 3 we will plot material stresses otherwise 0.0
+
+    static Vector values(9);
+
+    for (int j=0; j<9; j++)
+	   values(j) = 0.0;
+
+    if (displayMode < 9 && displayMode > 0) {
+	for (int i=0; i<9; i++) {
+	  const Vector &stress = theMaterial[i]->getStress();
+	  values(i) = stress(displayMode-1);
+	}
+    }
+
+    // now  determine the end points of the quad based on
+    // the display factor (a measure of the distorted image)
+    // store this information in 4 3d vectors v1 through v4
+    const Vector &end1Crd = theNodes[0]->getCrds();
+    const Vector &end2Crd = theNodes[1]->getCrds();
+    const Vector &end3Crd = theNodes[2]->getCrds();
+    const Vector &end4Crd = theNodes[3]->getCrds();
+    const Vector &end5Crd = theNodes[4]->getCrds();
+    const Vector &end6Crd = theNodes[5]->getCrds();
+    const Vector &end7Crd = theNodes[6]->getCrds();
+    const Vector &end8Crd = theNodes[7]->getCrds();
+    const Vector &end9Crd = theNodes[8]->getCrds();
+
+    static Matrix coords(9,3);
+
+    if (displayMode >= 0) {
+
+      const Vector &end1Disp = theNodes[0]->getDisp();
+      const Vector &end2Disp = theNodes[1]->getDisp();
+      const Vector &end3Disp = theNodes[2]->getDisp();
+      const Vector &end4Disp = theNodes[3]->getDisp();
+      const Vector &end5Disp = theNodes[4]->getDisp();
+      const Vector &end6Disp = theNodes[5]->getDisp();
+      const Vector &end7Disp = theNodes[6]->getDisp();
+      const Vector &end8Disp = theNodes[7]->getDisp();
+      const Vector &end9Disp = theNodes[8]->getDisp();
+
+      for (int i = 0; i < 2; i++) {
+	coords(0,i) = end1Crd(i) + end1Disp(i)*fact;
+	coords(1,i) = end2Crd(i) + end2Disp(i)*fact;
+	coords(2,i) = end3Crd(i) + end3Disp(i)*fact;
+	coords(3,i) = end4Crd(i) + end4Disp(i)*fact;
+	coords(4,i) = end5Crd(i) + end5Disp(i)*fact;
+	coords(5,i) = end6Crd(i) + end6Disp(i)*fact;
+	coords(6,i) = end7Crd(i) + end7Disp(i)*fact;
+	coords(7,i) = end8Crd(i) + end8Disp(i)*fact;
+	coords(8,i) = end9Crd(i) + end9Disp(i)*fact;
+      }
+    } else {
+      int mode = displayMode * -1;
+      const Matrix &eigen1 = theNodes[0]->getEigenvectors();
+      const Matrix &eigen2 = theNodes[1]->getEigenvectors();
+      const Matrix &eigen3 = theNodes[2]->getEigenvectors();
+      const Matrix &eigen4 = theNodes[3]->getEigenvectors();
+      const Matrix &eigen5 = theNodes[4]->getEigenvectors();
+      const Matrix &eigen6 = theNodes[5]->getEigenvectors();
+      const Matrix &eigen7 = theNodes[6]->getEigenvectors();
+      const Matrix &eigen8 = theNodes[7]->getEigenvectors();
+      const Matrix &eigen9 = theNodes[8]->getEigenvectors();
+      if (eigen1.noCols() >= mode) {
+	for (int i = 0; i < 2; i++) {
+	  coords(0,i) = end1Crd(i) + eigen1(i,mode-1)*fact;
+	  coords(1,i) = end2Crd(i) + eigen2(i,mode-1)*fact;
+	  coords(2,i) = end3Crd(i) + eigen3(i,mode-1)*fact;
+	  coords(3,i) = end4Crd(i) + eigen4(i,mode-1)*fact;
+	  coords(4,i) = end5Crd(i) + eigen5(i,mode-1)*fact;
+	  coords(5,i) = end6Crd(i) + eigen6(i,mode-1)*fact;
+	  coords(6,i) = end7Crd(i) + eigen7(i,mode-1)*fact;
+	  coords(7,i) = end8Crd(i) + eigen8(i,mode-1)*fact;
+	  coords(8,i) = end9Crd(i) + eigen9(i,mode-1)*fact;
+	}
+      } else {
+	for (int i = 0; i < 2; i++) {
+	  coords(0,i) = end1Crd(i);
+	  coords(1,i) = end2Crd(i);
+	  coords(2,i) = end3Crd(i);
+	  coords(3,i) = end4Crd(i);
+	  coords(4,i) = end5Crd(i);
+	  coords(5,i) = end6Crd(i);
+	  coords(6,i) = end7Crd(i);
+	  coords(7,i) = end8Crd(i);
+	  coords(8,i) = end9Crd(i);
+	}
+      }
+    }
+
+    int error = 0;
+
+    // finally we  the element using drawPolygon
+    error += theViewer.drawPolygon (coords, values, this->getTag());
+
+    return error;
+}
+
+Response*
+NineNodeQuad::setResponse(const char **argv, int argc,
+			  OPS_Stream &output)
+{
+  Response *theResponse =0;
+
+  output.tag("ElementOutput");
+  output.attr("eleType","NineNodeQuad");
+  output.attr("eleTag",this->getTag());
+  output.attr("node1",connectedExternalNodes[0]);
+  output.attr("node2",connectedExternalNodes[1]);
+  output.attr("node3",connectedExternalNodes[2]);
+  output.attr("node4",connectedExternalNodes[3]);
+  output.attr("node5",connectedExternalNodes[4]);
+  output.attr("node6",connectedExternalNodes[5]);
+  output.attr("node7",connectedExternalNodes[6]);
+  output.attr("node8",connectedExternalNodes[7]);
+  output.attr("node9",connectedExternalNodes[8]);
+
+  // tutaj check out ??? test recorder for 'force'
+  char dataOut[20];
+  // char dataOut[32];
+  if (strcmp(argv[0],"force") == 0 || strcmp(argv[0],"forces") == 0) {
+
+    for (int i=1; i<=9; i++) {
+      sprintf(dataOut,"P1_%d",i);
+      output.tag("ResponseType",dataOut);
+      sprintf(dataOut,"P2_%d",i);
+      output.tag("ResponseType",dataOut);
+    }
+
+    theResponse =  new ElementResponse(this, 1, P);
+  }
+
+  else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"integrPoint") == 0) {
+
+    int pointNum = atoi(argv[1]);
+    if (pointNum > 0 && pointNum <= 9) {
+
+      output.tag("GaussPoint");
+      output.attr("number",pointNum);
+      output.attr("eta",pts[pointNum-1][0]);
+      output.attr("neta",pts[pointNum-1][1]);
+
+      theResponse =  theMaterial[pointNum-1]->setResponse(&argv[2], argc-2, output);
+
+      output.endTag();
+
+    }
+  }
+  else if ((strcmp(argv[0],"stresses") ==0) || (strcmp(argv[0],"stress") ==0)) {
+    for (int i=0; i<9; i++) {
+      output.tag("GaussPoint");
+      output.attr("number",i+1);
+      output.attr("eta",pts[i][0]);
+      output.attr("neta",pts[i][1]);
+
+      output.tag("NdMaterialOutput");
+      output.attr("classType", theMaterial[i]->getClassTag());
+      output.attr("tag", theMaterial[i]->getTag());
+
+      output.tag("ResponseType","sigma11");
+      output.tag("ResponseType","sigma22");
+      output.tag("ResponseType","sigma12");
+
+      output.endTag(); // GaussPoint
+      output.endTag(); // NdMaterialOutput
+      }
+    theResponse =  new ElementResponse(this, 3, Vector(27));
+  }
+
+  else if ((strcmp(argv[0],"strain") ==0) || (strcmp(argv[0],"strains") ==0)) {
+    for (int i=0; i<9; i++) {
+      output.tag("GaussPoint");
+      output.attr("number",i+1);
+      output.attr("eta",pts[i][0]);
+      output.attr("neta",pts[i][1]);
+
+      output.tag("NdMaterialOutput");
+      output.attr("classType", theMaterial[i]->getClassTag());
+      output.attr("tag", theMaterial[i]->getTag());
+
+      output.tag("ResponseType","eta11");
+      output.tag("ResponseType","eta22");
+      output.tag("ResponseType","eta12");
+
+      output.endTag(); // GaussPoint
+      output.endTag(); // NdMaterialOutput
+      }
+    theResponse =  new ElementResponse(this, 4, Vector(27));
+  }
+
+  output.endTag(); // ElementOutput
+
+  return theResponse;
+}
+
+int
+NineNodeQuad::getResponse(int responseID, Information &eleInfo)
+{
+  if (responseID == 1) {
+
+    return eleInfo.setVector(this->getResistingForce());
+
+  } else if (responseID == 3) {
+
+    // Loop over the integration points
+    static Vector stresses(27);
+    int cnt = 0;
+    for (int i = 0; i < 9; i++) {
+
+      // Get material stress response
+      const Vector &sigma = theMaterial[i]->getStress();
+      stresses(cnt) = sigma(0);
+      stresses(cnt+1) = sigma(1);
+      stresses(cnt+2) = sigma(2);
+      cnt += 3;
+    }
+
+    return eleInfo.setVector(stresses);
+
+  } else if (responseID == 4) {
+
+    // Loop over the integration points
+    static Vector stresses(27);
+    int cnt = 0;
+    for (int i = 0; i < 9; i++) {
+
+      // Get material stress response
+      const Vector &sigma = theMaterial[i]->getStrain();
+      stresses(cnt) = sigma(0);
+      stresses(cnt+1) = sigma(1);
+      stresses(cnt+2) = sigma(2);
+      cnt += 3;
+    }
+
+    return eleInfo.setVector(stresses);
+
+  } else
+
+    return -1;
+}
+
+int
+NineNodeQuad::setParameter(const char **argv, int argc, Parameter &param)
+{
+  if (argc < 1)
+    return -1;
+
+  int res = -1;
+
+  // quad pressure loading
+  if (strcmp(argv[0],"pressure") == 0) {
+    return param.addObject(2, this);
+  }
+  // a material parameter
+  else if ((strstr(argv[0],"material") != 0) && (strcmp(argv[0],"materialState") != 0)) {
+
+    if (argc < 3)
+      return -1;
+
+    int pointNum = atoi(argv[1]);
+    if (pointNum > 0 && pointNum <= 9)
+      return theMaterial[pointNum-1]->setParameter(&argv[2], argc-2, param);
+    else
+      return -1;
+  }
+
+  // otherwise it could be just a forall material parameter
+  else {
+
+    int matRes = res;
+    for (int i=0; i<9; i++) {
+
+      matRes =  theMaterial[i]->setParameter(argv, argc, param);
+
+      if (matRes != -1)
+	res = matRes;
+    }
+  }
+
+  return res;
+}
+
+int
+NineNodeQuad::updateParameter(int parameterID, Information &info)
+{
+	int res = -1;
+		int matRes = res;
+  switch (parameterID) {
+    case -1:
+      return -1;
+
+	case 1:
+
+		for (int i = 0; i<9; i++) {
+		matRes = theMaterial[i]->updateParameter(parameterID, info);
+		}
+		if (matRes != -1) {
+			res = matRes;
+		}
+		return res;
+
+	case 2:
+		pressure = info.theDouble;
+		this->setPressureLoadAtNodes();	// update consistent nodal loads
+		return 0;
+
+	default:
+	  /*
+	  if (parameterID >= 100) { // material parameter
+	    int pointNum = parameterID/100;
+	    if (pointNum > 0 && pointNum <= 4)
+	      return theMaterial[pointNum-1]->updateParameter(parameterID-100*pointNum, info);
+	    else
+	      return -1;
+	  } else // unknown
+	  */
+	    return -1;
+  }
+}
+
+double NineNodeQuad::shapeFunction(double s, double t)
+{
+	const Vector &nd1Crds = theNodes[0]->getCrds();
+	const Vector &nd2Crds = theNodes[1]->getCrds();
+	const Vector &nd3Crds = theNodes[2]->getCrds();
+	const Vector &nd4Crds = theNodes[3]->getCrds();
+	const Vector &nd5Crds = theNodes[4]->getCrds();
+	const Vector &nd6Crds = theNodes[5]->getCrds();
+	const Vector &nd7Crds = theNodes[6]->getCrds();
+	const Vector &nd8Crds = theNodes[7]->getCrds();
+	const Vector &nd9Crds = theNodes[8]->getCrds();
+
+	double N1 =  (1-s)*(1-t)*s*t/4;
+	double N2 = -(1+s)*(1-t)*s*t/4;
+	double N3 =  (1+s)*(1+t)*s*t/4;
+	double N4 = -(1-s)*(1+t)*s*t/4;
+
+	double N5 = -(1-s*s)*(1-t)*t/2;
+	double N6 =  (1+s)*(1-t*t)*s/2;
+	double N7 =  (1-s*s)*(1+t)*t/2;
+	double N8 = -(1-s)*(1-t*t)*s/2;
+
+	double N9 = (1-s*s)*(1-t*t);
+
+	// alternative
+	// double N9 = (1-s*s)*(1-t*t);
+	// double N1 = -(1-s)*(1-t)*(1+s+t)/4 + N9/4;
+	// double N2 = -(1+s)*(1-t)*(1-s+t)/4 + N9/4;
+	// double N3 = -(1+s)*(1+t)*(1-s-t)/4 + N9/4;
+	// double N4 = -(1-s)*(1+t)*(1+s-t)/4 + N9/4;
+
+	// double N5 = (1-s*s)*(1-t)/2 - N9/2;
+	// double N6 = (1+s)*(1-t*t)/2 - N9/2;
+	// double N7 = (1-s*s)*(1+t)/2 - N9/2;
+	// double N8 = (1-s)*(1-t*t)/2 - N9/2;
+
+	shp[2][0] = N1;
+	shp[2][1] = N2;
+	shp[2][2] = N3;
+	shp[2][3] = N4;
+	shp[2][4] = N5;
+	shp[2][5] = N6;
+	shp[2][6] = N7;
+	shp[2][7] = N8;
+	shp[2][8] = N9;
+
+	// derivatives
+	double N91 = -2*s*(1-t*t);
+	double N92 = -2*t*(1-s*s);
+
+	double N11 =  t*(1-t)*(1-2*s)/4;
+	double N12 =  s*(1-s)*(1-2*t)/4;
+	double N21 = -t*(1-t)*(1+2*s)/4;
+	double N22 = -s*(1+s)*(1-2*t)/4;
+	double N31 =  t*(1+t)*(1+2*s)/4;
+	double N32 =  s*(1+s)*(1+2*t)/4;
+	double N41 = -t*(1+t)*(1-2*s)/4;
+	double N42 = -s*(1-s)*(1+2*t)/4;
+	double N51 =  s*t*(1-t);
+	double N52 = -(1-s*s)*(1-2*t)/2;
+	double N61 =  (1-t*t)*(1+2*s)/2;
+	double N62 = -s*t*(1+s);
+	double N71 = -s*t*(1+t);
+	double N72 =  (1-s*s)*(1+2*t)/2;
+	double N81 =  -(1-t*t)*(1-2*s)/2;
+	double N82 =  s*t*(1-s);
+
+	// alternative
+	// double N11 = -1*(-(1-t)*(1+s+t)+(1-s)*(1-t))/4 - s*(1-t*t)/2;
+	// double N21 = -1*((1-t)*(1-s+t)-(1+s)*(1-t))/4 - s*(1-t*t)/2;
+	// double N31 = -1*((1+t)*(1-s-t)-(1+s)*(1+t))/4 - s*(1-t*t)/2;
+	// double N41 = -1*(-(1+t)*(1+s-t)+(1-s)*(1+t))/4 - s*(1-t*t)/2;
+	// double N51 = -s*(1-t) + s*(1-t*t);
+	// double N61 = (1-t*t)/2 + s*(1-t*t);
+	// double N71 = -s*(1+t) + s*(1-t*t);
+	// double N81 = -1*(1-t*t)/2 + s*(1-t*t);
+	// double N91 = -2*s*(1-t*t);
+
+	// double N12 = -1*(-(1-s)*(1+s+t)+(1-s)*(1-t))/4 - t*(1-s*s)/2;
+	// double N22 = -1*(-(1+s)*(1-s+t)+(1+s)*(1-t))/4 - t*(1-s*s)/2;
+	// double N32 = -1*((1+s)*(1-s-t)-(1+s)*(1+t))/4 - t*(1-s*s)/2;
+	// double N42 = -1*((1-s)*(1+s-t)-(1-s)*(1+t))/4 - t*(1-s*s)/2;
+	// double N52 = -1*(1-s*s)/2 + t*(1-s*s);
+	// double N62 = -t*(1+s) + t*(1-s*s);
+	// double N72 = (1-s*s)/2 + t*(1-s*s);
+	// double N82 = -t*(1-s) + t*(1-s*s);
+	// double N92 = -2*t*(1-s*s);
+
+	// remains the same 2x2 matrix Cook Malkus Plesha 6.6, p. 180
+	double J[2][2];
+
+	J[0][0] = nd1Crds(0)*N11 + nd2Crds(0)*N21 + nd3Crds(0)*N31 + nd4Crds(0)*N41 +
+	  nd5Crds(0)*N51 + nd6Crds(0)*N61 + nd7Crds(0)*N71 + nd8Crds(0)*N81 + nd9Crds(0)*N91;
+
+	J[0][1] = nd1Crds(0)*N12 + nd2Crds(0)*N22 + nd3Crds(0)*N32 + nd4Crds(0)*N42 +
+	  nd5Crds(0)*N52 + nd6Crds(0)*N62 + nd7Crds(0)*N72 + nd8Crds(0)*N82 + nd9Crds(0)*N92;
+
+	J[1][0] = nd1Crds(1)*N11 + nd2Crds(1)*N21 + nd3Crds(1)*N31 + nd4Crds(1)*N41 +
+	  nd5Crds(1)*N51 + nd6Crds(1)*N61 + nd7Crds(1)*N71 + nd8Crds(1)*N81 + nd9Crds(1)*N91;
+
+	J[1][1] = nd1Crds(1)*N12 + nd2Crds(1)*N22 + nd3Crds(1)*N32 + nd4Crds(1)*N42 +
+	  nd5Crds(1)*N52 + nd6Crds(1)*N62 + nd7Crds(1)*N72 + nd8Crds(1)*N82 + nd9Crds(1)*N92;
+
+	double detJ = J[0][0]*J[1][1] - J[0][1]*J[1][0];
+
+	double oneOverdetJ = 1/detJ;
+	double L[2][2];
+
+	// L = inv(J)
+	L[0][0] =  J[1][1]*oneOverdetJ;
+	L[1][0] = -J[0][1]*oneOverdetJ;
+	L[0][1] = -J[1][0]*oneOverdetJ;
+	L[1][1] =  J[0][0]*oneOverdetJ;
+
+    double L00 = L[0][0];
+    double L10 = L[1][0];
+    double L01 = L[0][1];
+    double L11 = L[1][1];
+
+    shp[0][0] = L00*N11 + L01*N12;
+    shp[0][1] = L00*N21 + L01*N22;
+    shp[0][2] = L00*N31 + L01*N32;
+    shp[0][3] = L00*N41 + L01*N42;
+    shp[0][4] = L00*N51 + L01*N52;
+    shp[0][5] = L00*N61 + L01*N62;
+    shp[0][6] = L00*N71 + L01*N72;
+    shp[0][7] = L00*N81 + L01*N82;
+    shp[0][8] = L00*N91 + L01*N92;
+
+    shp[1][0] = L10*N11 + L11*N12;
+    shp[1][1] = L10*N21 + L11*N22;
+    shp[1][2] = L10*N31 + L11*N32;
+    shp[1][3] = L10*N41 + L11*N42;
+    shp[1][4] = L10*N51 + L11*N52;
+    shp[1][5] = L10*N61 + L11*N62;
+    shp[1][6] = L10*N71 + L11*N72;
+    shp[1][7] = L10*N81 + L11*N82;
+    shp[1][8] = L10*N91 + L11*N92;
+
+    return detJ;
+}
+
+void
+NineNodeQuad::setPressureLoadAtNodes(void)
+{
+        pressureLoad.Zero();
+
+	if (pressure == 0.0)
+		return;
+
+	const Vector &node1 = theNodes[0]->getCrds();
+	const Vector &node2 = theNodes[1]->getCrds();
+	const Vector &node3 = theNodes[2]->getCrds();
+	const Vector &node4 = theNodes[3]->getCrds();
+	const Vector &node5 = theNodes[4]->getCrds();
+	const Vector &node6 = theNodes[5]->getCrds();
+	const Vector &node7 = theNodes[6]->getCrds();
+	const Vector &node8 = theNodes[7]->getCrds();
+	// center node has no pressure commponents
+	// const Vector &node9 = theNodes[8]->getCrds();
+
+	double x1 = node1(0);
+	double y1 = node1(1);
+	double x2 = node2(0);
+	double y2 = node2(1);
+	double x3 = node3(0);
+	double y3 = node3(1);
+	double x4 = node4(0);
+	double y4 = node4(1);
+	double x5 = node5(0);
+	double y5 = node5(1);
+	double x6 = node6(0);
+	double y6 = node6(1);
+	double x7 = node7(0);
+	double y7 = node7(1);
+	double x8 = node8(0);
+	double y8 = node8(1);
+	// double x9 = node9(0);
+	// double y9 = node9(1);
+
+	double dx15 = x5-x1;
+	double dy15 = y5-y1;
+	double dx52 = x2-x5;
+	double dy52 = y2-y5;
+	double dx26 = x6-x2;
+	double dy26 = y6-y2;
+	double dx63 = x3-x6;
+	double dy63 = y3-y6;
+	double dx37 = x7-x3;
+	double dy37 = y7-y3;
+	double dx74 = x4-x7;
+	double dy74 = y4-y7;
+	double dx48 = x8-x4;
+	double dy48 = y8-y4;
+	double dx81 = x1-x8;
+	double dy81 = y1-y8;
+
+	double fac1 = 0.3333333333333333;
+	double fac2 = 0.6666666666666667;
+
+	// Contribution from side 15
+	pressureLoad(0) += pressure*fac1*dy15;
+	pressureLoad(8) += pressure*fac2*dy15;
+	pressureLoad(1) += pressure*fac1*-dx15;
+	pressureLoad(9) += pressure*fac2*-dx15;
+
+	// Contribution from side 52
+	pressureLoad(8) += pressure*fac2*dy52;
+	pressureLoad(2) += pressure*fac1*dy52;
+	pressureLoad(9) += pressure*fac2*-dx52;
+	pressureLoad(3) += pressure*fac1*-dx52;
+
+	// Contribution from side 26
+	pressureLoad(2) += pressure*fac1*dy26;
+	pressureLoad(10) += pressure*fac2*dy26;
+	pressureLoad(3) += pressure*fac1*-dx26;
+	pressureLoad(11) += pressure*fac2*-dx26;
+
+	// Contribution from side 63
+	pressureLoad(10) += pressure*fac2*dy63;
+	pressureLoad(4) += pressure*fac1*dy63;
+	pressureLoad(11) += pressure*fac2*-dx63;
+	pressureLoad(5) += pressure*fac1*-dx63;
+
+	// Contribution from side 37
+	pressureLoad(4) += pressure*fac1*dy37;
+	pressureLoad(12) += pressure*fac2*dy37;
+	pressureLoad(5) += pressure*fac1*-dx37;
+	pressureLoad(13) += pressure*fac2*-dx37;
+
+	// Contribution from side 74
+	pressureLoad(12) += pressure*fac2*dy74;
+	pressureLoad(6) += pressure*fac1*dy74;
+	pressureLoad(13) += pressure*fac2*-dx74;
+	pressureLoad(7) += pressure*fac1*-dx74;
+
+	// Contribution from side 48
+	pressureLoad(6) += pressure*fac1*dy48;
+	pressureLoad(14) += pressure*fac2*dy48;
+	pressureLoad(7) += pressure*fac1*-dx48;
+	pressureLoad(15) += pressure*fac2*-dx48;
+
+	// Contribution from side 81
+	pressureLoad(14) += pressure*fac2*dy81;
+	pressureLoad(0) += pressure*fac1*dy81;
+	pressureLoad(15) += pressure*fac2*-dx81;
+	pressureLoad(1) += pressure*fac1*-dx81;
+
+	//pressureLoad = pressureLoad*thickness;
+}

--- a/SRC/element/fourNodeQuad/NineNodeQuad.h
+++ b/SRC/element/fourNodeQuad/NineNodeQuad.h
@@ -1,0 +1,137 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+//
+// based on FourNodeQuad by MHS
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: Aug 2020
+//
+// Description: This file contains the class definition for NineNodeQuad.
+
+#ifndef NineNodeQuad_h
+#define NineNodeQuad_h
+
+#ifndef _bool_h
+#include "bool.h"
+#endif
+
+#include <Element.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <Vector.h>
+
+class Node;
+class NDMaterial;
+class Response;
+
+class NineNodeQuad : public Element {
+public:
+  NineNodeQuad(int tag, int nd1, int nd2, int nd3, int nd4, int nd5, int nd6,
+               int nd7, int nd8, int nd9, NDMaterial &m, const char *type, double t,
+               double pressure = 0.0, double rho = 0.0, double b1 = 0.0,
+               double b2 = 0.0);
+  NineNodeQuad();
+  ~NineNodeQuad();
+
+  const char *getClassType(void) const { return "NineNodeQuad"; };
+
+  int getNumExternalNodes(void) const;
+  const ID &getExternalNodes(void);
+  Node **getNodePtrs(void);
+
+  int getNumDOF(void);
+  void setDomain(Domain *theDomain);
+
+  // public methods to set the state of the element
+  int commitState(void);
+  int revertToLastCommit(void);
+  int revertToStart(void);
+  int update(void);
+
+  // public methods to obtain stiffness, mass, damping and residual information
+  const Matrix &getTangentStiff(void);
+  const Matrix &getInitialStiff(void);
+  const Matrix &getMass(void);
+
+  void zeroLoad();
+  int addLoad(ElementalLoad *theLoad, double loadFactor);
+  int addInertiaLoadToUnbalance(const Vector &accel);
+
+  const Vector &getResistingForce(void);
+  const Vector &getResistingForceIncInertia(void);
+
+  // public methods for element output
+  int sendSelf(int commitTag, Channel &theChannel);
+  int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
+
+  int displaySelf(Renderer &, int mode, float fact,
+                  const char **displayModes = 0, int numModes = 0);
+  void Print(OPS_Stream &s, int flag = 0);
+
+  Response *setResponse(const char **argv, int argc, OPS_Stream &s);
+
+  int getResponse(int responseID, Information &eleInformation);
+
+  int setParameter(const char **argv, int argc, Parameter &param);
+  int updateParameter(int parameterID, Information &info);
+
+  // RWB; PyLiq1 & TzLiq1 need to see the excess pore pressure and initial
+  // stresses.
+  friend class PyLiq1;
+  friend class TzLiq1;
+
+protected:
+private:
+  // private attributes - a copy for each object of the class
+
+  NDMaterial **theMaterial; // pointer to the ND material objects
+
+  ID connectedExternalNodes; // Tags of quad nodes
+
+  Node *theNodes[9];
+
+  // static double matrixData[64]; // array data for matrix
+  static double matrixData[324]; // array data for matrix
+  static Matrix K;              // Element stiffness, damping, and mass Matrix
+  static Vector P;              // Element resisting force vector
+  Vector Q;                     // Applied nodal loads
+  double b[2];                  // Body forces
+
+  double appliedB[2]; // Body forces applied with load pattern, C.McGann,
+                      // U.Washington
+  int applyLoad;      // flag for body force in load, C.McGann, U.Washington
+
+  Vector pressureLoad; // Pressure load at nodes
+
+  double thickness; // Element thickness
+  double pressure;  // Normal surface traction (pressure) over entire element
+                   // Note: positive for outward normal
+  double rho;
+  static double shp[3][9]; // Stores shape functions and derivatives (overwritten)
+  static double pts[9][2]; // Stores quadrature points
+  static double wts[9];    // Stores quadrature weights
+
+  // private member functions - only objects of this class can call these
+  double shapeFunction(double xi, double eta);
+  void setPressureLoadAtNodes(void);
+
+  Matrix *Ki;
+};
+
+#endif

--- a/SRC/element/fourNodeQuad/TclFourNodeQuadCommand.cpp
+++ b/SRC/element/fourNodeQuad/TclFourNodeQuadCommand.cpp
@@ -42,6 +42,8 @@
 #include <ConstantPressureVolumeQuad.h>
 #include <EnhancedQuad.h>
 #include <NineNodeMixedQuad.h>
+#include <NineNodeQuad.h>
+#include <EightNodeQuad.h>
 
 #include <TclModelBuilder.h>
 
@@ -672,6 +674,331 @@ TclModelBuilder_addFourNodeQuadWithSensitivity(ClientData clientData, Tcl_Interp
       opserr << "WARNING could not add element to the domain\n";
       opserr << "FourNodeQuadWithSensitivity element: " << FourNodeQuadId << endln;
       delete theFourNodeQuadWithSensitivity;
+      return TCL_ERROR;
+  }
+
+  // if get here we have successfully created the element and added it to the domain
+  return TCL_OK;
+}
+
+// Regular nine node quad
+
+int
+TclModelBuilder_addNineNodeQuad(ClientData clientData, Tcl_Interp *interp,  
+				int argc, 
+				TCL_Char **argv, 
+				Domain*theTclDomain,
+				TclModelBuilder *theTclBuilder)
+{
+  // ensure the destructor has not been called - 
+  if (theTclBuilder == 0) {
+    opserr << "WARNING builder has been destroyed\n";    
+    return TCL_ERROR;
+  }
+
+	if (theTclBuilder->getNDM() != 2 || theTclBuilder->getNDF() != 2) {
+		opserr << "WARNING -- model dimensions and/or nodal DOF not compatible with quad element\n";
+		return TCL_ERROR;
+	}
+
+  // check the number of arguments is correct
+  int argStart = 2;
+
+  if ((argc-argStart) < 13) {
+    opserr << "WARNING insufficient arguments\n";
+    printCommand(argc, argv);
+    opserr << "Want: element NineNodeQuad eleTag? iNode? jNode? kNode? lNode? nNode? mNode? pNode? qNode? cNode? thk? type? matTag? <pressure? rho? b1? b2?>\n";
+    return TCL_ERROR;
+  }    
+
+  // get the id and end nodes
+  int NineNodeQuadId, iNode, jNode, kNode, lNode;
+  int nNode, mNode, pNode, qNode, cNode, matID;
+  double thickness = 1.0;
+  double p = 0.0;		// uniform normal traction (pressure)
+  double rho = 0.0;		// mass density
+  double b1 = 0.0;
+  double b2 = 0.0;
+
+  if (Tcl_GetInt(interp, argv[argStart], &NineNodeQuadId) != TCL_OK) {
+    opserr << "WARNING invalid NineNodeQuad eleTag" << endln;
+    return TCL_ERROR;
+  }
+  if (Tcl_GetInt(interp, argv[1+argStart], &iNode) != TCL_OK) {
+    opserr << "WARNING invalid iNode\n";
+    opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+    return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[2+argStart], &jNode) != TCL_OK) {
+     opserr << "WARNING invalid jNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[3+argStart], &kNode) != TCL_OK) {
+     opserr << "WARNING invalid kNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[4+argStart], &lNode) != TCL_OK) {
+     opserr << "WARNING invalid lNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[5+argStart], &nNode) != TCL_OK) {
+    opserr << "WARNING invalid nNode\n";
+    opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+    return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[6+argStart], &mNode) != TCL_OK) {
+     opserr << "WARNING invalid mNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[7+argStart], &pNode) != TCL_OK) {
+     opserr << "WARNING invalid pNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[8+argStart], &qNode) != TCL_OK) {
+     opserr << "WARNING invalid qNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[9+argStart], &cNode) != TCL_OK) {
+     opserr << "WARNING invalid cNode\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetDouble(interp, argv[10+argStart], &thickness) != TCL_OK) {
+     opserr << "WARNING invalid thickness\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }  
+  
+  TCL_Char *type = argv[11+argStart];
+  
+  if (Tcl_GetInt(interp, argv[12+argStart], &matID) != TCL_OK) {
+     opserr << "WARNING invalid matID\n";
+     opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if ((argc-argStart) > 16) {
+    if (Tcl_GetDouble(interp, argv[13+argStart], &p) != TCL_OK) {
+      opserr << "WARNING invalid pressure\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[14+argStart], &rho) != TCL_OK) {
+      opserr << "WARNING invalid b1\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[15+argStart], &b1) != TCL_OK) {
+      opserr << "WARNING invalid b1\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[16+argStart], &b2) != TCL_OK) {
+      opserr << "WARNING invalid b2\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+  }
+
+  NDMaterial *theMaterial = OPS_getNDMaterial(matID);
+
+  if (theMaterial == 0) {
+      opserr << "WARNING material not found\n";
+      opserr << "Material: " << matID;
+      opserr << "\nNineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+  }
+
+  // now create the NineNodeQuad and add it to the Domain
+  NineNodeQuad *theNineNodeQuad = 
+	new NineNodeQuad(NineNodeQuadId,iNode,jNode,kNode,lNode,
+					 nNode,mNode,pNode,qNode,cNode,
+					 *theMaterial, type, thickness, p, rho, b1, b2);
+  if (theNineNodeQuad == 0) {
+      opserr << "WARNING ran out of memory creating element\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      return TCL_ERROR;
+  }
+
+  if (theTclDomain->addElement(theNineNodeQuad) == false) {
+      opserr << "WARNING could not add element to the domain\n";
+      opserr << "NineNodeQuad element: " << NineNodeQuadId << endln;
+      delete theNineNodeQuad;
+      return TCL_ERROR;
+  }
+
+  // if get here we have successfully created the element and added it to the domain
+  return TCL_OK;
+}
+
+
+// Regular eight node quad
+
+int
+TclModelBuilder_addEightNodeQuad(ClientData clientData, Tcl_Interp *interp,  
+				int argc, 
+				TCL_Char **argv, 
+				Domain*theTclDomain,
+				TclModelBuilder *theTclBuilder)
+{
+  // ensure the destructor has not been called - 
+  if (theTclBuilder == 0) {
+    opserr << "WARNING builder has been destroyed\n";    
+    return TCL_ERROR;
+  }
+
+	if (theTclBuilder->getNDM() != 2 || theTclBuilder->getNDF() != 2) {
+		opserr << "WARNING -- model dimensions and/or nodal DOF not compatible with quad element\n";
+		return TCL_ERROR;
+	}
+
+  // check the number of arguments is correct
+  int argStart = 2;
+
+  if ((argc-argStart) < 12) {
+    opserr << "WARNING insufficient arguments\n";
+    printCommand(argc, argv);
+    opserr << "Want: element EightNodeQuad eleTag? iNode? jNode? kNode? lNode? nNode? mNode? pNode? qNode? thk? type? matTag? <pressure? rho? b1? b2?>\n";
+    return TCL_ERROR;
+  }    
+
+  // get the id and end nodes
+  int EightNodeQuadId, iNode, jNode, kNode, lNode;
+  int nNode, mNode, pNode, qNode, matID;
+  double thickness = 1.0;
+  double p = 0.0;		// uniform normal traction (pressure)
+  double rho = 0.0;		// mass density
+  double b1 = 0.0;
+  double b2 = 0.0;
+
+  if (Tcl_GetInt(interp, argv[argStart], &EightNodeQuadId) != TCL_OK) {
+    opserr << "WARNING invalid EightNodeQuad eleTag" << endln;
+    return TCL_ERROR;
+  }
+  if (Tcl_GetInt(interp, argv[1+argStart], &iNode) != TCL_OK) {
+    opserr << "WARNING invalid iNode\n";
+    opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+    return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[2+argStart], &jNode) != TCL_OK) {
+     opserr << "WARNING invalid jNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[3+argStart], &kNode) != TCL_OK) {
+     opserr << "WARNING invalid kNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[4+argStart], &lNode) != TCL_OK) {
+     opserr << "WARNING invalid lNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[5+argStart], &nNode) != TCL_OK) {
+    opserr << "WARNING invalid nNode\n";
+    opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+    return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[6+argStart], &mNode) != TCL_OK) {
+     opserr << "WARNING invalid mNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[7+argStart], &pNode) != TCL_OK) {
+     opserr << "WARNING invalid pNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetInt(interp, argv[8+argStart], &qNode) != TCL_OK) {
+     opserr << "WARNING invalid qNode\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if (Tcl_GetDouble(interp, argv[9+argStart], &thickness) != TCL_OK) {
+     opserr << "WARNING invalid thickness\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }  
+  
+  TCL_Char *type = argv[10+argStart];
+  
+  if (Tcl_GetInt(interp, argv[11+argStart], &matID) != TCL_OK) {
+     opserr << "WARNING invalid matID\n";
+     opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+     return TCL_ERROR;
+  }
+
+  if ((argc-argStart) > 15) {
+    if (Tcl_GetDouble(interp, argv[12+argStart], &p) != TCL_OK) {
+      opserr << "WARNING invalid pressure\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[13+argStart], &rho) != TCL_OK) {
+      opserr << "WARNING invalid b1\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[14+argStart], &b1) != TCL_OK) {
+      opserr << "WARNING invalid b1\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+    if (Tcl_GetDouble(interp, argv[15+argStart], &b2) != TCL_OK) {
+      opserr << "WARNING invalid b2\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+    }
+  }
+
+  NDMaterial *theMaterial = OPS_getNDMaterial(matID);
+
+  if (theMaterial == 0) {
+      opserr << "WARNING material not found\n";
+      opserr << "Material: " << matID;
+      opserr << "\nEightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+  }
+
+  // now create the EightNodeQuad and add it to the Domain
+  EightNodeQuad *theEightNodeQuad = 
+	new EightNodeQuad(EightNodeQuadId,iNode,jNode,kNode,lNode,
+					  nNode,mNode,pNode,qNode,
+					 *theMaterial, type, thickness, p, rho, b1, b2);
+  if (theEightNodeQuad == 0) {
+      opserr << "WARNING ran out of memory creating element\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      return TCL_ERROR;
+  }
+
+  if (theTclDomain->addElement(theEightNodeQuad) == false) {
+      opserr << "WARNING could not add element to the domain\n";
+      opserr << "EightNodeQuad element: " << EightNodeQuadId << endln;
+      delete theEightNodeQuad;
       return TCL_ERROR;
   }
 

--- a/SRC/interpreter/OpenSeesElementCommands.cpp
+++ b/SRC/interpreter/OpenSeesElementCommands.cpp
@@ -165,6 +165,8 @@ void* OPS_FourNodeQuadWithSensitivity();
 void* OPS_EnhancedQuad();
 void* OPS_ConstantPressureVolumeQuad();
 void* OPS_NineNodeMixedQuad();
+void* OPS_NineNodeQuad();
+void* OPS_EightNodeQuad();
 void* OPS_FourNodeQuadUP();
 void* OPS_BrickUP();
 void* OPS_NineFourNodeQuadUP();
@@ -544,6 +546,8 @@ namespace {
 	functionMap.insert(std::make_pair("quadWithSensitivity", &OPS_FourNodeQuadWithSensitivity));
 	functionMap.insert(std::make_pair("quad", &OPS_FourNodeQuad));
 	functionMap.insert(std::make_pair("stdQuad", &OPS_FourNodeQuad));
+	functionMap.insert(std::make_pair("quad9n", &OPS_NineNodeQuad));
+	functionMap.insert(std::make_pair("quad8n", &OPS_EightNodeQuad));
 	functionMap.insert(std::make_pair("dispBeamColumnWithSensitivity", &OPS_DispBeamColumnWithSensitivity));
 	functionMap.insert(std::make_pair("elasticForceBeamColumn", &OPS_ElasticForceBeamColumn));
 	functionMap.insert(std::make_pair("dispBeamColumnThermal", &OPS_DispBeamColumnThermal));

--- a/SRC/material/nD/reinforcedConcretePlaneStress/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/material/nD/reinforcedConcretePlaneStress/FEM_ObjectBrokerAllClasses.cpp
@@ -158,6 +158,8 @@
 #include <FourNodeQuad.h>
 #include <EnhancedQuad.h>
 #include <NineNodeMixedQuad.h>
+#include <NineNodeQuad.h>
+#include <EightNodeQuad.h>
 #include <ConstantPressureVolumeQuad.h>
 #include <ElasticBeam2d.h>
 #include <ElasticBeam3d.h>
@@ -495,6 +497,12 @@ FEM_ObjectBrokerAllClasses::getNewElement(int classTag)
 	case ELE_TAG_FourNodeQuad:  
 	     return new FourNodeQuad(); 	     
 	     
+	case ELE_TAG_NineNodeQuad:
+	     return new NineNodeQuad();
+
+	case ELE_TAG_EightNodeQuad:
+	     return new EightNodeQuad();
+
 	case ELE_TAG_ElasticBeam2d:
 		return new ElasticBeam2d();
 

--- a/SRC/recorder/GmshRecorder.cpp
+++ b/SRC/recorder/GmshRecorder.cpp
@@ -1313,6 +1313,8 @@ GmshRecorder::setGMSHType()
     gmshtypes[ELE_TAG_EnhancedQuad] = GMSH_QUAD;
     gmshtypes[ELE_TAG_ConstantPressureVolumeQuad] = GMSH_QUAD;
     gmshtypes[ELE_TAG_NineNodeMixedQuad] = GMSH_POLY_VERTEX;
+    gmshtypes[ELE_TAG_NineNodeQuad] = GMSH_POLY_VERTEX;
+    gmshtypes[ELE_TAG_EightNodeQuad] = GMSH_POLY_VERTEX;
     gmshtypes[ELE_TAG_DispBeamColumn2d] = GMSH_LINE;
     gmshtypes[ELE_TAG_TimoshenkoBeamColumn2d] = GMSH_LINE;
     gmshtypes[ELE_TAG_DispBeamColumn3d] = GMSH_LINE;

--- a/SRC/recorder/MPCORecorder.cpp
+++ b/SRC/recorder/MPCORecorder.cpp
@@ -3764,6 +3764,7 @@ namespace mpco {
 				else if (
 					// ./quad
 					elem_class_tag == ELE_TAG_NineNodeMixedQuad ||
+					elem_class_tag == ELE_TAG_NineNodeQuad ||
 					// ./shell
 					elem_class_tag == ELE_TAG_ShellMITC9 ||
 					// ./up

--- a/SRC/recorder/PVDRecorder.cpp
+++ b/SRC/recorder/PVDRecorder.cpp
@@ -1854,6 +1854,8 @@ PVDRecorder::setVTKType()
     vtktypes[ELE_TAG_EnhancedQuad] = VTK_QUAD;
     vtktypes[ELE_TAG_ConstantPressureVolumeQuad] = VTK_QUAD;
     vtktypes[ELE_TAG_NineNodeMixedQuad] = VTK_POLY_VERTEX;
+    vtktypes[ELE_TAG_NineNodeQuad] = VTK_POLY_VERTEX;
+    vtktypes[ELE_TAG_EightNodeQuad] = VTK_POLY_VERTEX;
     vtktypes[ELE_TAG_DispBeamColumn2d] = VTK_LINE;
     vtktypes[ELE_TAG_TimoshenkoBeamColumn2d] = VTK_LINE;
     vtktypes[ELE_TAG_DispBeamColumn3d] = VTK_LINE;

--- a/SRC/recorder/VTK_Recorder.cpp
+++ b/SRC/recorder/VTK_Recorder.cpp
@@ -1049,6 +1049,8 @@ VTK_Recorder::setVTKType()
     vtktypes[ELE_TAG_EnhancedQuad] = VTK_QUAD;
     vtktypes[ELE_TAG_ConstantPressureVolumeQuad] = VTK_QUAD;
     vtktypes[ELE_TAG_NineNodeMixedQuad] = VTK_POLY_VERTEX;
+    vtktypes[ELE_TAG_NineNodeQuad] = VTK_POLY_VERTEX;
+    vtktypes[ELE_TAG_EightNodeQuad] = VTK_POLY_VERTEX;
     vtktypes[ELE_TAG_DispBeamColumn2d] = VTK_LINE;
     vtktypes[ELE_TAG_TimoshenkoBeamColumn2d] = VTK_LINE;
     vtktypes[ELE_TAG_DispBeamColumn3d] = VTK_LINE;


### PR DESCRIPTION
This PR adds two quadrilateral elements: 9-node (Lagrange quadratic) and 8-node ("serendipity") types. The implementations are based on Cook, Malkus and Plesha book and existing quad (FourNodeQuad) .h and .cpp files. The order of nodes agrees with the order of nodes described in the block2d command: 1-4 corner nodes, 5-8 nodes in the middle of quad sides, 9 - center node. Quad8n does not have the center node. 

In the PR, I add a example (Python and Tcl scripts) showing the usage and testing the elements.

The pictures below show the results of a cantilever beam (5x1) under bending (pair of horizontal forces +-100 applied at the right free end). The results of using one quad9n element (max vert. displacement 0.0075 and bottom/top stress_xx 60,000) agree with Euler-Bernoulli beam results.

Limitation: Note that the pressureLoad at nodes is implemented for the case where the 5-8 nodes are in the middle of sides.

Please review it.

![bending_1_quad9n_model](https://user-images.githubusercontent.com/12695169/92384498-7bfa6680-f110-11ea-930d-f47caf4d3a12.png)

![bending_1_quad9n_defo](https://user-images.githubusercontent.com/12695169/92384497-7b61d000-f110-11ea-8540-353239278804.png)

![bending_1_quad9n_sxx](https://user-images.githubusercontent.com/12695169/92384495-7ac93980-f110-11ea-949b-3796dd37206e.png)
