### PR TITLE
fixing compilation in VS

### DIFF
--- a/SRC/element/fourNodeQuad/SixNodeTri.cpp
+++ b/SRC/element/fourNodeQuad/SixNodeTri.cpp
@@ -151,9 +151,6 @@ SixNodeTri::SixNodeTri(int tag, int nd1, int nd2, int nd3, int nd4,
 	b[0] = b1;
 	b[1] = b2;
 
-	nip = 3;
-	nnodes = 6;
-
     // Allocate arrays of pointers to NDMaterials
     theMaterial = new NDMaterial *[nip];
 

--- a/SRC/element/fourNodeQuad/SixNodeTri.h
+++ b/SRC/element/fourNodeQuad/SixNodeTri.h
@@ -132,8 +132,8 @@ private:
 
   Matrix *Ki;
 
-  int nip; // number of integration/Gauss points
-  int nnodes; // number of nodes
+  static constexpr int nip = 3; // number of integration/Gauss points
+  static constexpr int nnodes = 6; // number of nodes
 };
 
 #endif

--- a/Win32/proj/analysis/analysis.vcxproj
+++ b/Win32/proj/analysis/analysis.vcxproj
@@ -203,6 +203,8 @@
     <ClCompile Include="..\..\..\SRC\analysis\integrator\TRBDF3.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\integrator\TransientIntegrator.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\integrator\WilsonTheta.cpp" />
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.cpp" />
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedNewmark.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\numberer\PlainNumberer.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\handler\ConstraintHandler.cpp" />
@@ -314,6 +316,8 @@
     <ClInclude Include="..\..\..\SRC\analysis\integrator\TRBDF3.h" />
     <ClInclude Include="..\..\..\SRC\analysis\integrator\TransientIntegrator.h" />
     <ClInclude Include="..\..\..\SRC\analysis\integrator\WilsonTheta.h" />
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.h" />
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedNewmark.h" />
     <ClInclude Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.h" />
     <ClInclude Include="..\..\..\SRC\analysis\numberer\PlainNumberer.h" />
     <ClInclude Include="..\..\..\SRC\analysis\handler\ConstraintHandler.h" />

--- a/Win32/proj/analysis/analysis.vcxproj.filters
+++ b/Win32/proj/analysis/analysis.vcxproj.filters
@@ -293,6 +293,12 @@
     <ClCompile Include="..\..\..\SRC\analysis\integrator\WilsonTheta.cpp">
       <Filter>integrator</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.cpp">
+      <Filter>integrator</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedNewmark.cpp">
+      <Filter>integrator</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.cpp">
       <Filter>numberer</Filter>
     </ClCompile>
@@ -620,6 +626,12 @@
       <Filter>integrator</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\analysis\integrator\WilsonTheta.h">
+      <Filter>integrator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.h">
+      <Filter>integrator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedNewmark.h">
       <Filter>integrator</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.h">

--- a/Win32/proj/element/element.vcxproj
+++ b/Win32/proj/element/element.vcxproj
@@ -212,6 +212,7 @@
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.cpp" />
@@ -468,6 +469,7 @@
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.h" />
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.h" />
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.h" />

--- a/Win32/proj/element/element.vcxproj.filters
+++ b/Win32/proj/element/element.vcxproj.filters
@@ -254,6 +254,9 @@
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp">
       <Filter>quad</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp">
+      <Filter>quad</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp">
       <Filter>quad</Filter>
     </ClCompile>
@@ -1004,6 +1007,9 @@
       <Filter>quad</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h">
+      <Filter>quad</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h">
       <Filter>quad</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h">

--- a/Win64/proj/analysis/analysis.vcxproj
+++ b/Win64/proj/analysis/analysis.vcxproj
@@ -293,6 +293,8 @@
     <ClCompile Include="..\..\..\SRC\analysis\integrator\TRBDF3.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\integrator\TransientIntegrator.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\integrator\WilsonTheta.cpp" />
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.cpp" />
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedNewmark.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\numberer\PlainNumberer.cpp" />
     <ClCompile Include="..\..\..\SRC\analysis\handler\ConstraintHandler.cpp" />
@@ -405,6 +407,8 @@
     <ClInclude Include="..\..\..\SRC\analysis\integrator\TRBDF3.h" />
     <ClInclude Include="..\..\..\SRC\analysis\integrator\TransientIntegrator.h" />
     <ClInclude Include="..\..\..\SRC\analysis\integrator\WilsonTheta.h" />
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.h" />
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedNewmark.h" />
     <ClInclude Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.h" />
     <ClInclude Include="..\..\..\SRC\analysis\numberer\PlainNumberer.h" />
     <ClInclude Include="..\..\..\SRC\analysis\handler\ConstraintHandler.h" />

--- a/Win64/proj/analysis/analysis.vcxproj.filters
+++ b/Win64/proj/analysis/analysis.vcxproj.filters
@@ -293,6 +293,12 @@
     <ClCompile Include="..\..\..\SRC\analysis\integrator\WilsonTheta.cpp">
       <Filter>integrator</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.cpp">
+      <Filter>integrator</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\analysis\integrator\StagedNewmark.cpp">
+      <Filter>integrator</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.cpp">
       <Filter>numberer</Filter>
     </ClCompile>
@@ -623,6 +629,12 @@
       <Filter>integrator</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\analysis\integrator\WilsonTheta.h">
+      <Filter>integrator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedLoadControl.h">
+      <Filter>integrator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\analysis\integrator\StagedNewmark.h">
       <Filter>integrator</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\analysis\numberer\DOF_Numberer.h">

--- a/Win64/proj/element/element.vcxproj
+++ b/Win64/proj/element/element.vcxproj
@@ -302,6 +302,7 @@
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp" />
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.cpp" />
@@ -563,6 +564,7 @@
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.h" />
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.h" />
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.h" />

--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -251,6 +251,9 @@
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp">
       <Filter>quad</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp">
+      <Filter>quad</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp">
       <Filter>quad</Filter>
     </ClCompile>
@@ -1013,6 +1016,9 @@
       <Filter>quad</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h">
+      <Filter>quad</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h">
       <Filter>quad</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h">


### PR DESCRIPTION
@fmckenna @mhscott 
With the latest changes, **VS projects do not compile**, due to missing files in VS projects and a misuse of a local variable in constant expressions.

The following classes were missing in the VS project files:
- **StagedLoadControl** (integrator)
- **StagedNewmark** (integrator)
- **SixNodeTri** (quad) [I know it is a triangle, but the author put those files in the fourNodeQuad folder, so I put them in the quad subfolder of the element project file]

The following class has a compilation error due to a misuse of a class **member variable in constant expressions**. I simply changed the declaration adding an inline initialization.
- SixNodeTri
