### PR TITLE
Adding ASD_SMA_3K Uniaxial Material

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -706,6 +706,7 @@ MATERIAL_LIBS   =  $(FE)/material/Material.o \
 	$(FE)/material/uniaxial/ParallelMaterial.o \
 	$(FE)/material/uniaxial/SeriesMaterial.o \
 	$(FE)/material/uniaxial/Neoprene.o \
+	$(FE)/material/uniaxial/ASD_SMA_3K.o \
 	$(FE)/material/uniaxial/Concrete01.o \
 	$(FE)/material/uniaxial/Concrete02.o \
 	$(FE)/material/uniaxial/Concrete02IS.o \

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -64,6 +64,7 @@
 #include "Elastic2Material.h"
 #include "ElasticPPMaterial.h"
 #include "ParallelMaterial.h"
+#include "ASD_SMA_3K.h"
 #include "Concrete01.h"
 #include "Concrete02.h"
 #include "Concrete04.h"
@@ -1096,6 +1097,9 @@ FEM_ObjectBrokerAllClasses::getNewUniaxialMaterial(int classTag)
 
     case MAT_TAG_ParallelMaterial:
 	     return new ParallelMaterial();
+
+	case MAT_TAG_ASD_SMA_3K:  
+	     return new ASD_SMA_3K();
 
 	case MAT_TAG_Concrete01:  
 	     return new Concrete01();

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -229,6 +229,7 @@
 #define MAT_TAG_SteelBRB                     213
 #define MAT_TAG_PySimple3                    214
 #define MAT_TAG_PlateBearingConnectionThermal 215
+#define MAT_TAG_ASD_SMA_3K                    216
 
 
 #define MAT_TAG_FedeasMaterial    1000

--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -122,6 +122,7 @@ void* OPS_PathIndependentMaterial();
 void* OPS_Pinching4Material();
 void* OPS_ECC01();
 void* OPS_SelfCenteringMaterial();
+void* OPS_ASD_SMA_3K();
 void* OPS_ViscousMaterial();
 void* OPS_BoucWenMaterial();
 void* OPS_BWBN();
@@ -280,6 +281,7 @@ namespace {
 	uniaxialMaterialsMap.insert(std::make_pair("Pinching4", &OPS_Pinching4Material));
 	uniaxialMaterialsMap.insert(std::make_pair("ECC01", &OPS_ECC01));
 	uniaxialMaterialsMap.insert(std::make_pair("SelfCentering", &OPS_SelfCenteringMaterial));
+    uniaxialMaterialsMap.insert(std::make_pair("ASD_SMA_3K", &OPS_ASD_SMA_3K));
 	uniaxialMaterialsMap.insert(std::make_pair("Viscous", &OPS_ViscousMaterial));
 	uniaxialMaterialsMap.insert(std::make_pair("BoucWen", &OPS_BoucWenMaterial));
 	uniaxialMaterialsMap.insert(std::make_pair("BWBN", &OPS_BWBN));

--- a/SRC/material/uniaxial/ASD_SMA_3K.cpp
+++ b/SRC/material/uniaxial/ASD_SMA_3K.cpp
@@ -1,0 +1,625 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.0 $
+// $Date: 2020-09-01 11:29:01 $
+// $Source: /usr/local/cvs/OpenSees/SRC/material/uniaxial/ASD_SMA_3K.cpp,v $
+
+// Written: Luca Aceto
+// Created: Aug
+// Revision: A
+//
+// Description: This file contains the class implementation for ASD_SMA_3K. 
+
+/*
+ASD_SMA_3K is written by Eng. Luca Aceto (luca.aceto@unich.it), University of Chieti-Pescara, InGeo department in collaboration with ASDEA Software Technology: https://asdeasoft.net
+
+
+This material is a modified version of Self Centering Material written by JAE at Oct 2007
+With ASD_SMA_3K it is possible to replicate the behavior of SMA material with a different unloading stiffness (k3)
+
+        k1 = Load stiffness
+        k2 = Post-Activation Stiffness (0<$k2<$k1)
+        k3 = Unload stiffness
+        sigAct = Forward Activation Stress/Force
+        beta= Ratio of Forward to Reverse Activation Stress/Force
+
+
+ASD_SMA_3K matTag? k1? k2? k3? sigF? beta?
+
+*/
+
+
+#include <ASD_SMA_3K.h>
+#include <Vector.h>
+#include <Channel.h>
+#include <Matrix.h>
+#include <Information.h>
+#include <Parameter.h>
+
+#include <math.h>
+#include <float.h>
+#include <elementAPI.h>
+#include <iostream>
+
+/* static class instance counter */
+static int ASD_SMA3K_counter = 0;
+
+void* OPS_ASD_SMA_3K()
+{
+
+
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 5) {
+	opserr << "WARNING: Insufficient arguments\n";
+	opserr << "Want: uniaxialMaterial ASD_SMA_3K matTag? k1? k2? k3? sigF? beta?";
+	return 0;
+    }
+
+    int tag;
+    numdata = 1;
+    if (OPS_GetIntInput(&numdata,&tag) < 0) {
+	opserr << "WARNING invalid tag\n";
+	return 0;
+    }
+
+    double data[5] = {0,0,0,0,0};
+    numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata > 5) {
+	numdata = 5;
+    }
+    if (OPS_GetDoubleInput(&numdata,data)) {
+	opserr << "WARNING invalid double inputs\n";
+	return 0;
+    }
+
+    UniaxialMaterial* mat = new ASD_SMA_3K(tag,data[0],data[1],data[2],data[3],data[4]);
+    if (mat == 0) {
+	opserr << "WARNING: failed to create ASD_SMA_3K material\n";
+	return 0;
+    }
+
+    return mat;
+}
+
+ASD_SMA_3K::ASD_SMA_3K(int tag, double K1, double K2, double K3,
+					     double fa, double b)
+  : UniaxialMaterial(tag,MAT_TAG_ASD_SMA_3K),
+    k1(K1), k2(K2), k3(K3), ActF(fa), beta(b)
+{
+    // on first call
+    if (ASD_SMA3K_counter == 0) {
+        ASD_SMA3K_counter++;
+        opserr <<
+            "\n*******************************************************************************************\n"
+            "* ASD_SMA_3K - Written by Eng. Luca Aceto, University of Chieti-Pescara, InGeo department *\n"
+            "* in collaboration with ASDEA Software Technology                                         *\n"
+            "* Eng. Luca Aceto luca.aceto@unich.it                                                     *\n"
+            "* ASDEA Software Technology: https://asdeasoft.net                                        *\n"
+            "* STKO (Scientific ToolKit for OpenSees): https://asdeasoft.net/stko/                     *\n"
+            "*******************************************************************************************\n"
+            ;
+    }
+  // Find Equivalent Slip Force
+  ActDef = ActF / k1;
+
+  
+  // Initialize variables
+  this->revertToStart();
+  
+}
+
+ASD_SMA_3K::ASD_SMA_3K()
+  : UniaxialMaterial(0,MAT_TAG_ASD_SMA_3K),
+    k1(0.0), k2(0.0), k3(0.0), ActF(0.0), beta(0.0)
+{
+  // Initialize variables
+  ActDef = 0;
+  
+  this->revertToStart();
+  
+}
+
+ASD_SMA_3K::~ASD_SMA_3K()
+{
+  
+}
+
+int 
+
+ASD_SMA_3K::setTrialStrain(double strain, double strainRate)
+{
+
+
+    diffStrain = strain - Cstrain;
+
+    if (fabs(diffStrain) < DBL_EPSILON)
+        return 0;
+
+    // Set total strain
+    Tstrain = strain;
+    // Tstrain = Tstrain - CslipStrain;
+
+    // Middle Elastic Portion (outside any upper or lower activation)
+    //     Entirely elastic response
+    if (fabs(Tstrain) <= ((1 - beta) * ActF / k1)) {
+
+        Tstress = k1 * Tstrain;
+        Ttangent = k1;
+
+        
+
+        TupperStrainPos = ActDef;
+        TupperStressPos = ActF;
+
+        TupperStrainNeg = -ActDef;
+        TupperStressNeg = -ActF;
+
+        No_Y_Pos = 0;
+        No_Y_Neg = 0;
+
+    }
+    else {
+
+        // Positive Quadrant (Top Right) where strain >= 0
+        if (Tstrain >= 0) {
+
+            TupperStrainNeg = -ActDef;
+            TupperStressNeg = -ActF;
+
+                 // Linear range movement (no upper or lower activation)  
+            if ((Tstrain >= ClowerStrainPos) &&
+                (Tstrain <= CupperStrainPos)) {
+
+                if (diffStrain < DBL_EPSILON) {
+                    if (No_Y_Pos == 1) {
+                        Tstress = Cstress + diffStrain * k3;
+                        Ttangent = k3;
+
+                        TupperStrainPos = (k1 * Tstrain - Tstress - k2 * ActDef + ActF) / (k1 - k2);
+                        TupperStressPos = k2 * TupperStrainPos - k2 * ActDef + ActF;
+                    }
+                    else {
+                        Tstress = std::fmin(Cstress + diffStrain * k1, Tstrain * k1);
+                        Ttangent = k1;
+                    }
+                }
+                else if (diffStrain > DBL_EPSILON) {
+
+                    if (No_Y_Pos == 1) {
+                        Tstress = std::fmin(Cstress + diffStrain * k1,Tstrain * k1);
+                        Ttangent = k1;
+                        No_k2_Pos = 0;
+
+                        TupperStrainPos = (k1 * Tstrain - Tstress - k2 * ActDef + ActF) / (k1 - k2);
+                        TupperStressPos = k2 * TupperStrainPos - k2 * ActDef + ActF;
+
+                    } else if (No_Y_Pos == 0) {
+
+                        Tstress = std::fmin((Tstrain - CactivStrainPos) * k1,Tstrain*k1);
+                        Ttangent = k1;
+                        No_k2_Pos = 0;
+                    }
+
+
+                }
+
+            }
+            // Upper Activation 
+            else if (Tstrain > CupperStrainPos) {
+
+                No_Y_Pos = 1;
+
+                TupperStressPos = CupperStressPos + (Tstrain - CupperStrainPos) * k2;
+                TupperStrainPos = Tstrain;
+
+                X = (-k3 * TupperStrainPos + TupperStressPos) / (k1 - k3);
+                Y = k1 * ((-k3 * TupperStrainPos + TupperStressPos) / (k1 - k3));
+
+                TlowerStrainPos = (TupperStressPos - TupperStrainPos * k3 - ActF * (1 - beta) * (1 - (k2 / k1))) / (k2 - k3);
+                TlowerStressPos = k2 * ((TupperStressPos - TupperStrainPos * k3 - ActF * (1 - beta) * (1 - (k2 / k1))) / (k2 - k3)) + ActF * (1 - beta) * (1 - (k2 / k1));
+                No_k2_Pos = 0;
+
+                if (TlowerStrainPos < X) {
+                    TlowerStrainPos = X;
+                    TlowerStressPos = Y;
+                    No_k2_Pos = 1;
+                }
+
+                Tstress = TupperStressPos;
+                TactivStrainPos = TupperStrainPos - Tstress / k3;
+
+                Ttangent = k2;
+
+
+            }
+
+            else { // Tstrain < ClowerStrainPos
+
+                if (k1 * Tstrain <= ClowerStressPos && No_k2_Pos == 1) {
+                    Tstress = std::fmin((Tstrain - CactivStrainPos) * k1, Tstrain * k1);
+                    Ttangent = k1;
+
+                    TupperStrainPos = ActDef;
+                    TupperStressPos = ActF;
+
+                    TactivStrainPos = Tstrain - Tstress / k1;
+
+
+                }
+                else {
+                    TlowerStressPos = ClowerStressPos +
+                        (Tstrain - ClowerStrainPos) * k2;
+                    TlowerStrainPos = Tstrain;
+                    TupperStrainPos = Tstrain + beta * ActF / k1;
+                    TupperStressPos = TlowerStressPos + beta * ActF;
+                    Tstress = TlowerStressPos;
+                    TactivStrainPos = TlowerStrainPos - Tstress / k1;
+
+                    Ttangent = k2;
+                }
+            }
+        }
+
+        // Negative Quadrant (Bottom Left) where strain < 0
+        else { // Tstrain < 0)
+
+            TupperStrainPos = ActDef;
+            TupperStressPos = ActF;
+
+            // Linear range movement (no upper or
+            //     lower activation)
+            if ((Tstrain <= ClowerStrainNeg) &&
+                (Tstrain >= CupperStrainNeg)) {
+
+                if (diffStrain > DBL_EPSILON) {
+                    if (No_Y_Neg == 1) {
+                        Tstress = Cstress+ diffStrain * k3;
+                        Ttangent = k3;
+
+                        TupperStrainNeg = (k1 * Tstrain - Tstress + k2 * ActDef - ActF) / (k1 - k2);
+                        TupperStressNeg = k2 * TupperStrainNeg + k2 * ActDef - ActF;
+                    }
+                    else {
+                        Tstress = std::fmax(Cstress + diffStrain * k1, Tstrain * k1);
+                        Ttangent = k1;
+                    }
+                }
+                else if (diffStrain < DBL_EPSILON) {
+
+                    if (No_Y_Neg == 1) {
+                        Tstress = std::fmax(Cstress + diffStrain * k1, Tstrain * k1);
+                        Ttangent = k1;
+                        No_k2_Neg = 0;
+
+                        TupperStrainNeg = (k1 * Tstrain - Tstress + k2 * ActDef - ActF) / (k1 - k2);
+                        TupperStressNeg = k2 * TupperStrainNeg + k2 * ActDef - ActF;
+
+                    }
+                    else if (No_Y_Neg == 0) {
+                        Tstress = std::fmax((Tstrain - CactivStrainNeg) * k1, Tstrain * k1);
+                        Ttangent = k1;
+                        No_k2_Neg = 0;
+
+
+                    }
+                }
+
+            }
+            // Upper Activation
+            else if (Tstrain < CupperStrainNeg) {
+
+                No_Y_Neg = 1;
+
+                TupperStressNeg = CupperStressNeg + (Tstrain - CupperStrainNeg) * k2;
+                TupperStrainNeg = Tstrain;
+
+                X = (-k3 * TupperStrainNeg + TupperStressNeg) / (k1 - k3);
+                Y = k1 * ((-k3 * TupperStrainNeg + TupperStressNeg) / (k1 - k3));
+
+                TlowerStrainNeg = (TupperStressNeg - TupperStrainNeg * k3 + ActF * (1 - beta) * (1 - (k2 / k1))) / (k2 - k3);
+                TlowerStressNeg = k2 * ((TupperStressNeg - TupperStrainNeg * k3 + ActF * (1 - beta) * (1 - (k2 / k1))) / (k2 - k3)) - ActF * (1 - beta) * (1 - (k2 / k1));
+
+
+                No_k2_Neg = 0;
+
+                if (TlowerStrainNeg > X) {
+                    TlowerStrainNeg = X;
+                    TlowerStressNeg = Y;
+                    No_k2_Neg = 1;
+                }
+
+                Tstress = TupperStressNeg;
+                TactivStrainNeg = TupperStrainNeg - Tstress / k3;
+
+                Ttangent = k2;
+            }
+            // Lower Activation
+            else { // Tstrain > ClowerStrainNeg
+
+
+                if (k1 * Tstrain >= ClowerStressNeg && No_k2_Neg == 1) {
+                    Tstress = std::fmax((Tstrain - CactivStrainNeg) * k1, Tstrain * k1);
+                    Ttangent = k1;
+
+                    TupperStrainNeg = -ActDef;
+                    TupperStressNeg = -ActF;
+
+                    TactivStrainNeg = Tstrain - Tstress / k1;
+
+
+                }
+                else {
+                    TlowerStressNeg = ClowerStressNeg + (Tstrain - ClowerStrainNeg) * k2;
+                    TlowerStrainNeg = Tstrain;
+                    TupperStrainNeg = Tstrain - beta * ActF / k1;
+                    TupperStressNeg = TlowerStressNeg - beta * ActF;
+                    Tstress = TlowerStressNeg;
+                    TactivStrainNeg = TlowerStrainNeg - Tstress / k1;
+
+                    Ttangent = k2;
+                }
+
+
+
+            }
+        }
+
+    }
+
+
+
+    return 0;
+}
+
+double 
+ASD_SMA_3K::getStress(void)
+{
+  return Tstress;
+}
+
+double 
+ASD_SMA_3K::getTangent(void)
+{
+  return Ttangent;
+}
+
+double 
+ASD_SMA_3K::getStrain(void)
+{
+  return Tstrain;
+}
+
+int 
+ASD_SMA_3K::commitState(void)
+{
+
+      // Commit trial history variables
+      CactivStrainPos = TactivStrainPos;
+      CactivStrainNeg = TactivStrainNeg;
+      CupperStrainPos = TupperStrainPos;
+      ClowerStrainPos = TlowerStrainPos;	
+      CupperStressPos = TupperStressPos;
+      ClowerStressPos = TlowerStressPos;
+      CupperStrainNeg = TupperStrainNeg;
+      ClowerStrainNeg = TlowerStrainNeg;
+      CupperStressNeg = TupperStressNeg;
+      ClowerStressNeg = TlowerStressNeg;
+      Cstrain = Tstrain;
+      Cstress = Tstress;
+      Ctangent = Ttangent;
+
+      CLastStrain = TLastStrain;
+  
+      return 0;
+}
+
+int 
+ASD_SMA_3K::revertToLastCommit(void)
+{
+  Tstrain = Cstrain;
+  Tstress = Cstress;
+  Ttangent = Ctangent;
+
+  return 0;
+}
+
+int 
+ASD_SMA_3K::revertToStart(void)
+{
+  // Reset committed history variables
+  CactivStrainPos = 0.0;
+  CactivStrainNeg = 0.0;
+  CupperStrainPos = ActDef;
+  ClowerStrainPos = (1-beta) * ActDef;	
+  CupperStressPos = ActF;
+  ClowerStrainPos = (1 - beta) * ActDef;
+  CupperStrainNeg = -CupperStrainPos;
+  ClowerStrainNeg = -ClowerStrainPos;
+  CupperStressNeg = -CupperStressPos;
+  ClowerStressNeg = -ClowerStressPos;
+
+  CLastStrain = 0.0;
+  
+  // Reset trial history variables
+  TactivStrainPos = 0.0;
+  TactivStrainNeg = 0.0;
+  TupperStrainPos = ActDef;
+  TlowerStrainPos = (1-beta) * ActDef;	
+  TupperStressPos = ActF;
+  TlowerStressPos = (1-beta) * ActF;
+  TupperStrainNeg = -CupperStrainPos;
+  TlowerStrainNeg = -ClowerStrainPos;
+  TupperStressNeg = -CupperStressPos;
+  TlowerStressNeg = -ClowerStressPos;
+
+  TLastStrain = 0.0;
+  
+  // Initialize state variables
+  Tstrain = 0.0;
+  Tstress = 0.0;
+  Ttangent = k1;
+  
+  Cstrain = 0.0;
+
+  No_k2_Pos = 0;
+  No_k2_Neg = 0;
+  No_Y_Pos = 0;
+  No_Y_Neg = 0;
+  
+  return 0;
+}
+
+UniaxialMaterial *
+ASD_SMA_3K::getCopy(void)
+{
+  ASD_SMA_3K *theCopy =
+    new ASD_SMA_3K(this->getTag(), k1, k2, k3, ActF, beta);
+  
+  // Copy committed history variables
+  theCopy->CactivStrainPos = CactivStrainPos;
+  theCopy->CactivStrainNeg = CactivStrainNeg;
+  theCopy->CupperStrainPos = CupperStrainPos;
+  theCopy->ClowerStrainPos = ClowerStrainPos;	
+  theCopy->CupperStressPos = CupperStressPos;
+  theCopy->ClowerStressPos = ClowerStressPos;
+  theCopy->CupperStrainNeg = CupperStrainNeg;
+  theCopy->ClowerStrainNeg = ClowerStrainNeg;
+  theCopy->CupperStressNeg = CupperStressNeg;
+  theCopy->ClowerStressNeg = ClowerStressNeg;
+
+  theCopy->CLastStrain = CLastStrain;
+  
+  // Copy trial history variables
+  theCopy->TactivStrainPos = TactivStrainPos;
+  theCopy->TactivStrainNeg = TactivStrainNeg;
+  theCopy->TupperStrainPos = TupperStrainPos;
+  theCopy->TlowerStrainPos = TlowerStrainPos;	
+  theCopy->TupperStressPos = TupperStressPos;
+  theCopy->TlowerStressPos = TlowerStressPos;
+  theCopy->TupperStrainNeg = TupperStrainNeg;
+  theCopy->TlowerStrainNeg = TlowerStrainNeg;
+  theCopy->TupperStressNeg = TupperStressNeg;
+  theCopy->TlowerStressNeg = TlowerStressNeg;
+
+  theCopy->TLastStrain = TLastStrain;
+  
+  // Copy trial state variables
+  theCopy->Tstrain = Tstrain;
+  theCopy->Tstress = Tstress;
+  theCopy->Ttangent = Ttangent;
+  
+  theCopy->Cstrain = Cstrain;
+  
+  return theCopy;
+}
+
+int 
+ASD_SMA_3K::sendSelf(int cTag, Channel &theChannel)
+{
+  int res = 0;
+  
+  static Vector data(23);
+  
+  data(0) = this->getTag();
+  data(1) = k1;
+  data(2) = k2;
+  data(3) = k3;
+  data(4) = ActF;
+  data(5) = beta;
+  data(6) = ActDef;
+  data(7) = CactivStrainPos;
+  data(8) = CactivStrainNeg;
+  data(9) = CupperStrainPos;
+  data(10) = ClowerStrainPos;
+  data(11) = CupperStressPos;
+  data(12) = ClowerStressPos;
+  data(13) = CupperStrainNeg;
+  data(14) = ClowerStrainNeg;
+  data(15) = CupperStressNeg;
+  data(16) = ClowerStressNeg;
+  data(17) = Tstrain;
+  data(18) = Tstress;
+  data(19) = Ttangent;
+  data(20) = Cstrain;
+  data(21) = TLastStrain;
+  data(22) = CLastStrain;
+  
+  res = theChannel.sendVector(this->getDbTag(), cTag, data);
+  if (res < 0) 
+    opserr << "ASD_SMA_3K::sendSelf() - failed to send data\n";
+
+  return res;
+}
+
+int 
+ASD_SMA_3K::recvSelf(int cTag, Channel &theChannel,
+			       FEM_ObjectBroker &theBroker)
+{
+  int res = 0;
+  
+  static Vector data(23);
+  res = theChannel.recvVector(this->getDbTag(), cTag, data);
+  
+  if (res < 0) {
+      opserr << "ASD_SMA_3K::recvSelf() - failed to receive data\n";
+      this->setTag(0);      
+  }
+  else {
+    this->setTag((int)data(0));
+    k1 = data(1);
+	k2 = data(2);
+    k3 = data(3);
+	ActF = data(4);
+	beta = data(5);
+	ActDef = data(6);
+	CactivStrainPos = data(7);
+	CactivStrainNeg = data(8);
+	CupperStrainPos = data(9);
+	ClowerStrainPos = data(10);
+	CupperStressPos = data(11);
+	ClowerStressPos = data(12);
+	CupperStrainNeg = data(13);
+	ClowerStrainNeg = data(14);
+	CupperStressNeg = data(15);
+	ClowerStressNeg = data(16);
+    Tstrain = data(17);
+	Tstress = data(18);
+	Ttangent = data(19);
+	Cstrain = data(20);
+    TLastStrain = data(21) ;
+    CLastStrain=data(22) ;
+  }
+    
+  return res;
+}
+
+void 
+ASD_SMA_3K::Print(OPS_Stream &s, int flag)
+{
+    s << "ASD_SMA_3K, tag: " << this->getTag() << endln;
+    s << "  k1: " << k1 << endln;
+    s << "  k2: " << k2 << endln;
+    s << "  k3: " << k3 << endln;
+    s << "  ActF: " << ActF << endln;
+    s << "  beta: " << beta << endln;
+}
+

--- a/SRC/material/uniaxial/ASD_SMA_3K.h
+++ b/SRC/material/uniaxial/ASD_SMA_3K.h
@@ -1,0 +1,148 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.0 $
+// $Date: 2020-09-01 11:29:01 $
+// $Source: /usr/local/cvs/OpenSees/SRC/material/uniaxial/ASD_SMA_3K.cpp,v $
+
+// Written: Luca Aceto
+// Created: Aug
+// Revision: A
+//
+// Description: This file contains the class implementation for ASD_SMA_3K. 
+
+#ifndef ASD_SMA_3K_h
+#define ASD_SMA_3K_h
+
+/*
+ASD_SMA_3K is written by Eng. Luca Aceto (luca.aceto@unich.it), University of Chieti-Pescara, InGeo department in collaboration with ASDEA Software Technology: https://asdeasoft.net
+
+
+This material is a modified version of Self Centering Material written by JAE at Oct 2007
+With ASD_SMA_3K it is possible to replicate the behavior of SMA material with a different unloading stiffness (k3)
+
+        k1 = Load stiffness
+        k2 = Post-Activation Stiffness (0<$k2<$k1)
+        k3 = Unload stiffness
+        sigAct = Forward Activation Stress/Force
+        beta= Ratio of Forward to Reverse Activation Stress/Force
+
+
+ASD_SMA_3K matTag? k1? k2? k3? sigF? beta?
+
+*/
+
+#include <UniaxialMaterial.h>
+
+class ASD_SMA_3K : public UniaxialMaterial
+{
+  public:
+    ASD_SMA_3K(int tag, double k1, double k2, double k3,
+		      double ActF, double beta);
+    ASD_SMA_3K();
+    ~ASD_SMA_3K();
+
+    const char *getClassType(void) const {return "ASD_SMA_3K";};
+
+    int setTrialStrain(double strain, double strainRate = 0.0); 
+    double getStrain(void);          
+    double getStress(void);
+    double getTangent(void);
+    double getInitialTangent(void) {return k1;};
+
+    int commitState(void);
+    int revertToLastCommit(void);    
+    int revertToStart(void);  
+
+    UniaxialMaterial *getCopy(void);
+    
+    int sendSelf(int commitTag, Channel &theChannel);  
+    int recvSelf(int commitTag, Channel &theChannel, 
+		 FEM_ObjectBroker &theBroker);    
+    
+    void Print(OPS_Stream &s, int flag =0);
+
+  protected:
+    
+  private:
+    // Material parameters (from input)
+    double k1;		// Precompression Stiffness
+    double k2;		// Prestress Stiffness
+    double k3;		// Unloading Stiffness
+    double ActF;	// Activation Stress/Force
+    double beta;	// Flag-Shape Parameter
+    
+    // Extra Calculated Material Parameters
+    double ActDef;	// Actvation Strain/Deformation
+    
+    double diffStrain;		// Difference of strain from last step
+    
+    // Committed history variables
+    double CactivStrainPos;	// Committed activation strain (Pos Quad)
+    double CactivStrainNeg;	// Committed activation strain (Neg Quad)
+    double CupperStrainPos;	// Committed upper activation strain (Pos Quad)
+    double ClowerStrainPos;	// Committed lower activation strain (Pos Quad)
+    double CupperStressPos;	// Committed upper activation stress (Pos Quad)
+    double ClowerStressPos;	// Committed lower activation stress (Pos Quad)
+    double CupperStrainNeg;	// Committed upper activation strain (Neg Quad)
+    double ClowerStrainNeg;	// Committed lower activation strain (Neg Quad)
+    double CupperStressNeg;	// Committed upper activation stress (Neg Quad)
+    double ClowerStressNeg;	// Committed lower activation stress (Neg Quad)
+
+    double CLastStrain;
+    
+    // Trial history variables
+    double TactivStrainPos;	// Trial activation strain (Pos Quad)
+    double TactivStrainNeg;	// Trial activation strain (Neg Quad)
+    double TupperStrainPos;	// Trial upper activation strain (Pos Quad)
+    double TlowerStrainPos;	// Trial lower activation strain (Pos Quad)
+    double TupperStressPos;	// Trial upper activation stress (Pos Quad)
+    double TlowerStressPos;	// Trial lower activation stress (Pos Quad)
+    double TupperStrainNeg;	// Trial upper activation strain (Neg Quad)
+    double TlowerStrainNeg;	// Trial lower activation strain (Neg Quad)
+    double TupperStressNeg;	// Trial upper activation stress (Neg Quad)
+    double TlowerStressNeg;	// Trial lower activation stress (Neg Quad)
+
+    double TLastStrain;
+    
+    // Trial state variables
+    double Tstrain;		// Trial strain
+    double Tstress;		// Trial stress
+    double Ttangent;	// Trial tangent
+    
+    // Committed State Variables
+    double Cstrain;		// Committed Strain
+    double Cstress;		// Committed Strain
+    double Ctangent;		// Committed Strain
+
+    // Intermediate Value
+    double X;
+    double Y;
+
+    int No_k2_Pos;
+    int No_k2_Neg;
+    int No_Y_Pos;
+    int No_Y_Neg;
+
+};
+
+
+#endif
+

--- a/SRC/material/uniaxial/Makefile
+++ b/SRC/material/uniaxial/Makefile
@@ -35,6 +35,7 @@ OBJS       = UniaxialMaterial.o \
 	Cast.o \
         HardeningMaterial.o \
         HardeningMaterial2.o \
+	ASD_SMA_3K.o \
 	Concrete01.o \
 	Concrete02Thermal.o \
 	Steel02Thermal.o \

--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -62,6 +62,7 @@
 #include <SteelBRB.h>             //Quan & Michele
 #include <SmoothPSConcrete.h>      //Quan & Michele
 #include <SelfCenteringMaterial.h> //JAE
+#include <ASD_SMA_3K.h> //LA
 
 #include <KikuchiAikenHDR.h>
 #include <KikuchiAikenLRB.h>
@@ -137,7 +138,7 @@ extern void *OPS_SteelECThermal(void); // L.Jiang [SIF]
 extern void *OPS_ConcreteECThermal(void);// L.Jiang [SIF]
 extern void *OPS_ElasticMaterialThermal(void); //L.Jiang[SIF]
 //extern void *OPS_PlateBearingConnectionThermal(void);
-
+extern void* OPS_ASD_SMA_3K(void); // Luca Aceto
 extern void *OPS_BWBN(void);
 extern void *OPS_IMKPeakOriented(void);
 extern void *OPS_IMKBilin(void);
@@ -2594,6 +2595,15 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
       
       theMaterial = new ECC01(tag, SIGT0, EPST0, SIGT1, EPST1, EPST2, SIGC0, EPSC0, EPSC1, 
 			      ALPHAT1, ALPHAT2, ALPHAC, ALPHACU, BETAT, BETAC);
+    }
+
+
+    else if (strcmp(argv[1], "ASD_SMA_3K") == 0) {
+      void *theMat = OPS_ASD_SMA_3K();
+      if (theMat != 0)
+        theMaterial = (UniaxialMaterial *)theMat;
+      else
+        return TCL_ERROR;
     }
 
 

--- a/Win32/proj/material/material.vcxproj
+++ b/Win32/proj/material/material.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\CFSWSWP.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\CableMaterial.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Cast.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01WithSITC.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete02.cpp" />
@@ -605,6 +606,7 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\CFSWSWP.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\CableMaterial.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Cast.h" />
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01WithSITC.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete02.h" />

--- a/Win32/proj/material/material.vcxproj.filters
+++ b/Win32/proj/material/material.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Cast.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
@@ -1379,6 +1382,9 @@
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Cast.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01.h">

--- a/Win64/proj/material/material.vcxproj
+++ b/Win64/proj/material/material.vcxproj
@@ -266,6 +266,7 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\CFSWSWP.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\CableMaterial.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Cast.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01WithSITC.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete02.cpp" />
@@ -680,6 +681,7 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\CFSWSWP.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\CableMaterial.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Cast.h" />
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01WithSITC.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete02.h" />

--- a/Win64/proj/material/material.vcxproj.filters
+++ b/Win64/proj/material/material.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Cast.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Concrete01.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
@@ -1385,6 +1388,9 @@
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Cast.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\ASD_SMA_3K.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\Concrete01.h">


### PR DESCRIPTION
@fmckenna @mhscott 
With this PR I would like to add a new uniaxial material to OpenSees.

**ASD_SMA_3K** is written by Eng. Luca Aceto (luca.aceto@unich.it), University of Chieti-Pescara, InGeo department, in collaboration with ASDEA Software Technology: https://asdeasoft.net.

It is a modified version of the **Self Centering Material** written by JAE (2007)
With **ASD_SMA_3K** it is possible to replicate the behavior of SMA material with a different unloading stiffness (k3)

- **k1** = Loading stiffness
- **k2** = Post-Activation Stiffness (0<$k2<$k1)
- **k3** = Unloading stiffness
- **sigAct** = Forward Activation Stress/Force
- **beta**= Ratio of Forward to Reverse Activation Stress/Force

![image](https://user-images.githubusercontent.com/26160906/93439851-55d28480-f8cf-11ea-9319-ae82ddff3ccf.png)

**Command**:
`uniaxialMaterial ASD_SMA_3K $matTag $k1 $k2 $k3 $sigF $beta`

![image](https://user-images.githubusercontent.com/26160906/93440059-93371200-f8cf-11ea-8dad-833b61987e98.png)
![image](https://user-images.githubusercontent.com/26160906/93440096-96320280-f8cf-11ea-9209-134c7d70467f.png)
