### PR TITLE
Pisa soil

### DIFF
--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -195,6 +195,16 @@ void *OPS_TakedaUnloadingRule();
 void *OPS_EnergyUnloadingRule();
 void *OPS_KarsanUnloadingRule();
 
+// csasj
+void *OPS_PyClayPISA();
+void* OPS_MtClayPISA();
+void* OPS_HbClayPISA();
+void* OPS_MbClayPISA();
+void* OPS_PySandPISA();
+void* OPS_MtSandPISA();
+void* OPS_HbSandPISA();
+void* OPS_MbSandPISA();
+
 namespace {
 
     static UniaxialMaterial *theTestingUniaxialMaterial = 0;
@@ -336,6 +346,16 @@ namespace {
 	uniaxialMaterialsMap.insert(std::make_pair("IMKPinching", &OPS_IMKPinching));
 	uniaxialMaterialsMap.insert(std::make_pair("IMKPeakOriented", &OPS_IMKPeakOriented));
 	uniaxialMaterialsMap.insert(std::make_pair("SLModel", &OPS_SLModel));
+
+	// csasj
+	uniaxialMaterialsMap.insert(std::make_pair("PyClayPISA", &OPS_PyClayPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("MtClayPISA", &OPS_MtClayPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("HbClayPISA", &OPS_HbClayPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("MbClayPISA", &OPS_MbClayPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("PySandPISA", &OPS_PySandPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("MtSandPISA", &OPS_MtSandPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("HbSandPISA", &OPS_HbSandPISA));
+	uniaxialMaterialsMap.insert(std::make_pair("MbSandPISA", &OPS_MbSandPISA));
 
 	return 0;
     }

--- a/SRC/material/uniaxial/PISA/HbClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/HbClayPISA.cpp
@@ -1,0 +1,356 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.13 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for HbClayPISA material. 
+//				Provide the base shear load curve for clays according to PISA project. 
+
+#include <elementAPI.h>
+#include "HbClayPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the HbClayPISA class. 
+void*
+OPS_HbClayPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 5)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial HbClayPISA tag?diameter? pile embedded lenght? undrained_shear_strength? G0 A0? Au? ?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[6] = { 0, 0, 0, 0, 0, 0 };
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new HbClayPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type HbClayPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+HbClayPISA::HbClayPISA(int tag, double D, double L, double Su, double Go, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    diameter(D),
+    embedded_length(L),
+    undrained_shear_strength(Su),
+    gmax(Go),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default constructor
+HbClayPISA::HbClayPISA()
+    :UniaxialMaterial(0, 0),
+    diameter(0.0),
+    embedded_length(0.0),
+    undrained_shear_strength(0.0),
+    gmax(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default destructor
+HbClayPISA::~HbClayPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void HbClayPISA::HB_conic_function(double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+    //HB curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double vBu = 300;
+    epsilon_u = Au / A0 * vBu;
+    // Initial stiffness 
+    double k0Hb_coeff1 = -0.32;
+    double k0Hb_coeff2 = 2.58;
+    double k0Hb = k0Hb_coeff1 * (embedded_length / diameter) + k0Hb_coeff2;
+    initial_stiffness = A0 * k0Hb;
+    // Curvature  
+    double nHb_coeff1 = -0.04;
+    double nHb_coeff2 = 0.76;
+    double nHb = nHb_coeff1 * (embedded_length / diameter) + nHb_coeff2;
+    curvature = nHb;
+    if (curvature == 0.5) curvature += 1e-4; // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double hbu_coeff1 = 0.07;
+    double hbu_coeff2 = 0.59;
+    double HBu_norm = hbu_coeff1 * (embedded_length / diameter) + hbu_coeff2;
+    sigma_u = Au * HBu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double HbClayPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int HbClayPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+HbClayPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+HbClayPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+HbClayPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+HbClayPISA::getInitialTangent(void)
+{
+    return this->initial_tangent;
+}
+
+int
+HbClayPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+
+    return 0;
+}
+
+int
+HbClayPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+HbClayPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+HbClayPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+HbClayPISA::getCopy(void)
+{
+    HbClayPISA* theCopy;                 // pointer to a HbClayPISA class
+    theCopy = new HbClayPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+HbClayPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "HbClayPISA, tag: " << this->getTag() << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Undrained shear strength (kPa) : " << undrained_shear_strength << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+HbClayPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    HB_conic_function(diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the P curve
+        double hb_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = hb_norm * undrained_shear_strength * pow(diameter, 2);
+        p_F[i] = p_D;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * diameter * undrained_shear_strength / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    // really stiff curve at the start,  20% of the initial modulus to avoid numerical errors in convergence
+    initial_tangent = data(0, 4);
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = initial_tangent;
+
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/HbClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/HbClayPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.13 $
-// $Date: 17/09/2020 $
+// $Revision: 1.14 $
+// $Date: 06/10/2020 $
 //
 // Description: This file contains the class implementation for HbClayPISA material. 
 //				Provide the base shear load curve for clays according to PISA project. 
@@ -58,7 +58,7 @@ OPS_HbClayPISA()
         return 0;
     }
 
-    double dData[6] = { 0, 0, 0, 0, 0, 0 };
+    double dData[6] = { 0, 0, 0, 0, 1, 1 };
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {

--- a/SRC/material/uniaxial/PISA/HbClayPISA.h
+++ b/SRC/material/uniaxial/PISA/HbClayPISA.h
@@ -1,0 +1,101 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.13 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for HbClayPISA material. 
+//				Provide the base shear load curve for clays according to PISA project. 
+
+#ifndef HbClayPISA_h
+#define HbClayPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class HbClayPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	HbClayPISA(int tag, double D, double L, double Su, double Go, double A0, double Au);
+	// Null constructor
+	HbClayPISA();
+	// Destructor
+	~HbClayPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double diameter;						// pile outside diameter (m)
+	double embedded_length;					// embedded pile length (m)
+	double undrained_shear_strength;		// undrained shear strength (kPa)
+	double gmax;							// small-strain shear modulus (kPa)
+	double A0;								// Scaling factor for initial stiffness
+	double Au;								// Scaling factor for ultimate stress 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void HB_conic_function(double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double initial_tangent;
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/HbSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/HbSandPISA.cpp
@@ -1,0 +1,356 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.11 $
+// $Date: 21/09/2020 $
+//
+// Description: This file contains the class implementation for HbSandPISA material. 
+//				Provide the base shear load curve for sandy soils according to PISA project. 
+
+#include <elementAPI.h>
+#include "HbSandPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the HbSandPISA class. 
+void*
+OPS_HbSandPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 5)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial HbSandPISA tag? diameter? pile embedded lenght? sigma_vo_eff? G0? A0? Au?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[6] = {0, 0, 0, 0, 0, 0};
+    numData = OPS_GetNumRemainingInputArgs();;
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new HbSandPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type HbSandPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+HbSandPISA::HbSandPISA(int tag, double D, double L, double sigma, double Go, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    diameter(D),
+    embedded_length(L),
+    sigma_vo_eff(sigma),
+    gmax(Go),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default constructor
+HbSandPISA::HbSandPISA()
+    :UniaxialMaterial(0, 0),
+    diameter(0.0),
+    embedded_length(0.0),
+    sigma_vo_eff(0.0),
+    gmax(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default destructor
+HbSandPISA::~HbSandPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void HbSandPISA::HB_conic_function(double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+    //HB curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double vunorm_coeff1 = -0.29;
+    double vunorm_coeff2 = 2.31;
+    double vBu = vunorm_coeff1 * (embedded_length / diameter) + vunorm_coeff2;
+    epsilon_u = Au / A0 * vBu;
+    // Initial stiffness 
+    double k0Hb_coeff1 = -0.38;
+    double k0Hb_coeff2 = 3.02;
+    double k0Hb = k0Hb_coeff1 * (embedded_length / diameter) + k0Hb_coeff2;
+    initial_stiffness = A0 * k0Hb;
+    // Curvature  
+    double nHb_coeff1 = -0.05;
+    double nHb_coeff2 = 0.94;
+    double nHb = nHb_coeff1 * (embedded_length / diameter) + nHb_coeff2;
+    curvature = nHb;
+    if (curvature == 0.5) curvature += 1e-4; // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double hbu_coeff1 = -0.07;
+    double hbu_coeff2 = 0.62;
+    double HBu_norm = hbu_coeff1 * (embedded_length / diameter) + hbu_coeff2;
+    sigma_u = Au * HBu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double HbSandPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int HbSandPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+HbSandPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+HbSandPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+HbSandPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+HbSandPISA::getInitialTangent(void)
+{
+    return this->data(0, 4);
+}
+
+int
+HbSandPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+
+    return 0;
+}
+
+int
+HbSandPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+HbSandPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+HbSandPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+HbSandPISA::getCopy(void)
+{
+    HbSandPISA* theCopy;                 // pointer to a HbSandPISA class
+    theCopy = new HbSandPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+HbSandPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "HbSandPISA, tag: " << this->getTag() << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+HbSandPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    HB_conic_function(diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the P curve
+        double hb_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = hb_norm * sigma_vo_eff * pow(diameter,2);
+        p_F[i] = p_D;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * diameter * sigma_vo_eff / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = data(0, 4);
+
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/HbSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/HbSandPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.11 $
-// $Date: 21/09/2020 $
+// $Revision: 1.12 $
+// $Date: 07/10/2020 $
 //
 // Description: This file contains the class implementation for HbSandPISA material. 
 //				Provide the base shear load curve for sandy soils according to PISA project. 
@@ -58,7 +58,7 @@ OPS_HbSandPISA()
         return 0;
     }
 
-    double dData[6] = {0, 0, 0, 0, 0, 0};
+    double dData[6] = {0, 0, 0, 0, 1, 1};
     numData = OPS_GetNumRemainingInputArgs();;
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {
@@ -280,6 +280,8 @@ HbSandPISA::Print(OPS_Stream& s, int flag)
     s << "  Embedded pile length (m) : " << embedded_length << endln;
     s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
     s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
 }
 
 // Function to create the parameters following the APIrp2GEO method

--- a/SRC/material/uniaxial/PISA/HbSandPISA.h
+++ b/SRC/material/uniaxial/PISA/HbSandPISA.h
@@ -1,0 +1,100 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.1 $
+// $Date: 15/09/2020 $
+//
+// Description: This file contains the class implementation for HbSandPISA material. 
+//				Provide the base shear load curve for sandy soils according to PISA project. 
+
+#ifndef HbSandPISA_h
+#define HbSandPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class HbSandPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	HbSandPISA(int tag, double D, double L, double sigma, double Go, double A0, double Au);
+	// Null constructor
+	HbSandPISA();
+	// Destructor
+	~HbSandPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double diameter;			// pile outside diameter (m)
+	double embedded_length;		// embedded pile length (m)
+	double sigma_vo_eff;		// vertical effective soil stress (kPa)
+	double gmax;				// small-strain shear modulus (kPa)
+	double A0;					// Scaling factor for initial stiffness
+	double Au;					// Scaling factor for ultimate stress 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void HB_conic_function(double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/MbClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MbClayPISA.cpp
@@ -1,0 +1,353 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.14 $
+// $Date: 18/09/2020 $
+//
+// Description: This file contains the class implementation for MbClayPISA material. 
+//				Provide the base moment soil reaction for clays according to PISA project. 
+
+#include <elementAPI.h>
+#include "MbClayPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the MbClayPISA class. 
+void*
+OPS_MbClayPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 7)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial MbClayPISA tag? diameter? pile embedded lenght? undrained shear strength? G0? A0? Au?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[6] = {0, 0, 0, 0, 0, 0};
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new MbClayPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type MbClayPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+MbClayPISA::MbClayPISA(int tag, double D, double L, double Su, double Go, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    diameter(D),
+    embedded_length(L),
+    undrained_shear_strength(Su),
+    gmax(Go),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default constructor
+MbClayPISA::MbClayPISA()
+    :UniaxialMaterial(0, 0),
+    diameter(0.0),
+    embedded_length(0.0),
+    undrained_shear_strength(0.0),
+    gmax(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default destructor
+MbClayPISA::~MbClayPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void MbClayPISA::Mb_conic_function(double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+      // MB curve
+      //-----------------------------------------------------
+    // Ultimate strain 
+    double psiBu = 200.0;
+    epsilon_u = Au / A0 * psiBu;
+    // Initial stiffness 
+    double k0Mb_coeff1 = -0.002;
+    double k0Mb_coeff2 = 0.19; 
+    double k0Mb = k0Mb_coeff1 * (embedded_length / diameter) + k0Mb_coeff2; 
+    initial_stiffness = A0 * k0Mb;
+    // Curvature  
+    double nMb_coeff1 = -0.15;
+    double nMb_coeff2 = 0.99;
+    double nMb = nMb_coeff1 * (embedded_length / diameter) + nMb_coeff2; 
+    curvature = nMb;
+    if (curvature == 0.5) curvature += 1e-4; // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double mBu_coeff1 = -0.07;
+    double mBu_coeff2 = 0.65;
+    double MBu_norm = mBu_coeff1 * (embedded_length / diameter) + mBu_coeff2;
+    sigma_u = Au * MBu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double MbClayPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int MbClayPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+MbClayPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+MbClayPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+MbClayPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+MbClayPISA::getInitialTangent(void)
+{
+    return this->initial_tangent;
+}
+
+int
+MbClayPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+MbClayPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+MbClayPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+MbClayPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+MbClayPISA::getCopy(void)
+{
+    MbClayPISA* theCopy;                 // pointer to a MbClayPISA class
+    theCopy = new MbClayPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+MbClayPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "MbClayPISA, tag: " << this->getTag() << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Undrained shear strength (kPa) : " << undrained_shear_strength << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+MbClayPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    Mb_conic_function(diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the py curve (kN/m)
+        double Mb_norm = sigma_bar_ratio[i] * sigma_u;
+        double MB = Mb_norm * undrained_shear_strength * pow(diameter, 3);
+        p_F[i] = MB;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * undrained_shear_strength / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    initial_tangent = data(0, 4);
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = initial_tangent;
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/MbClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MbClayPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.14 $
-// $Date: 18/09/2020 $
+// $Revision: 1.15 $
+// $Date: 06/10/2020 $
 //
 // Description: This file contains the class implementation for MbClayPISA material. 
 //				Provide the base moment soil reaction for clays according to PISA project. 
@@ -41,7 +41,7 @@ OPS_MbClayPISA()
 {
     // Checking the number of data 
     int numdata = OPS_GetNumRemainingInputArgs();
-    if (numdata < 7)
+    if (numdata < 5)
     {
         opserr << "WARNING insufficient arguments" << endln;
         opserr << "Want: uniaxialMaterial MbClayPISA tag? diameter? pile embedded lenght? undrained shear strength? G0? A0? Au?" << endln;
@@ -58,7 +58,7 @@ OPS_MbClayPISA()
         return 0;
     }
 
-    double dData[6] = {0, 0, 0, 0, 0, 0};
+    double dData[6] = {0, 0, 0, 0, 1, 1};
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {

--- a/SRC/material/uniaxial/PISA/MbClayPISA.h
+++ b/SRC/material/uniaxial/PISA/MbClayPISA.h
@@ -1,0 +1,101 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.14 $
+// $Date: 18/09/2020 $
+//
+// Description: This file contains the class implementation for MbClayPISA material. 
+//				Provide the base moment soil reaction for clays according to PISA project. 
+
+#ifndef MbClayPISA_h
+#define MbClayPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class MbClayPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	MbClayPISA(int tag, double D, double L, double Su, double Go, double A0, double Au);
+	// Null constructor
+	MbClayPISA();
+	// Destructor
+	~MbClayPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double diameter;						// pile outside diameter (m)
+	double embedded_length;					// embedded pile length (m)
+	double undrained_shear_strength;		// vertical effective soil stress (kPa)
+	double gmax;							// small-strain shear modulus (kPa)
+	double A0;								// Scaling factor for initial stiffness
+	double Au;								// Scaling factor for ultimate stress 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Mb_conic_function(double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double initial_tangent; 
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/MbSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MbSandPISA.cpp
@@ -1,0 +1,348 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.1 $
+// $Date: 21/09/2020 $
+//
+// Description: This file contains the class implementation for MbSandPISA material. 
+//				Provide the base moment soil reaction for sands according to PISA project. 
+
+#include <elementAPI.h>
+#include "MbSandPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the MbSandPISA class. 
+void*
+OPS_MbSandPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 5)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial MbSandPISA tag? diameter? pile embedded lenght? sigma_vo_eff? G0? A0?  Au? " << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[6] = {0, 0, 0, 0, 0, 0};
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new MbSandPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type MbSandPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+MbSandPISA::MbSandPISA(int tag, double D, double L, double sigma, double Go, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    diameter(D),
+    embedded_length(L),
+    sigma_vo_eff(sigma),
+    gmax(Go),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default constructor
+MbSandPISA::MbSandPISA()
+    :UniaxialMaterial(0, 0),
+    diameter(0.0),
+    embedded_length(0.0),
+    sigma_vo_eff(0.0),
+    gmax(0.0),
+    A0(1.),
+    Au(1.)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default destructor
+MbSandPISA::~MbSandPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void MbSandPISA::Mb_conic_function(double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+      // MB curve
+      //-----------------------------------------------------
+    // Ultimate strain 
+    double psiBu = 50.0;
+    epsilon_u = Au / A0 * psiBu;
+    // Initial stiffness 
+    double k0Mb = 0.29;
+    initial_stiffness = A0 * k0Mb;
+    // Curvature  
+    double nMb = 0.89;
+    curvature = nMb;
+    if (curvature == 0.5) curvature += 1e-4; // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double mBu_coeff1 = -0.05;
+    double mBu_coeff2 = 0.38;
+    double MBu_norm = mBu_coeff1 * (embedded_length / diameter) + mBu_coeff2;
+    sigma_u = Au * MBu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double MbSandPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int MbSandPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+MbSandPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+MbSandPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+MbSandPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+MbSandPISA::getInitialTangent(void)
+{
+    return this->data(0, 4);
+}
+
+int
+MbSandPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+MbSandPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+MbSandPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+MbSandPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+MbSandPISA::getCopy(void)
+{
+    MbSandPISA* theCopy;                 // pointer to a MbSandPISA class
+    theCopy = new MbSandPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+MbSandPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "MbSandPISA, tag: " << this->getTag() << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+MbSandPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    Mb_conic_function(diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the py curve (kN/m)
+        double Mb_norm = sigma_bar_ratio[i] * sigma_u;
+        double MB = Mb_norm * sigma_vo_eff * pow(diameter,3);
+        p_F[i] = MB;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * sigma_vo_eff / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = data(0, 4);
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/MbSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MbSandPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.1 $
-// $Date: 21/09/2020 $
+// $Revision: 1.11 $
+// $Date: 07/10/2020 $
 //
 // Description: This file contains the class implementation for MbSandPISA material. 
 //				Provide the base moment soil reaction for sands according to PISA project. 
@@ -58,7 +58,7 @@ OPS_MbSandPISA()
         return 0;
     }
 
-    double dData[6] = {0, 0, 0, 0, 0, 0};
+    double dData[6] = {0, 0, 0, 0, 1, 1};
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {
@@ -273,6 +273,8 @@ MbSandPISA::Print(OPS_Stream& s, int flag)
     s << "  Embedded pile length (m) : " << embedded_length << endln;
     s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
     s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
 }
 
 // Function to create the parameters following the APIrp2GEO method

--- a/SRC/material/uniaxial/PISA/MbSandPISA.h
+++ b/SRC/material/uniaxial/PISA/MbSandPISA.h
@@ -1,0 +1,100 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.0 $
+// $Date: 15/09/2020 $
+//
+// Description: This file contains the class implementation for MbSandPISA material. 
+//				Provide the base moment soil reaction for sands according to PISA project. 
+
+#ifndef MbSandPISA_h
+#define MbSandPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class MbSandPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	MbSandPISA(int tag, double D, double L, double sigma, double Go, double A0, double Au);
+	// Null constructor
+	MbSandPISA();
+	// Destructor
+	~MbSandPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double diameter;			// pile outside diameter (m)
+	double embedded_length;		// embedded pile length (m)
+	double sigma_vo_eff;		// vertical effective soil stress (kPa)
+	double gmax;				// small-strain shear modulus (kPa)
+	double A0;					// Scaling factor for initial stiffness
+	double Au;					// Scaling factor for ultimate stress
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Mb_conic_function(double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/MtClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MtClayPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.13 $
-// $Date: 17/09/2020 $
+// $Revision: 1.14 $
+// $Date: 06/10/2020 $
 //
 // Description: This file contains the class implementation for MtClayPISA material. 
 //				Provide moment distributed spring for clays according to PISA project. 
@@ -58,7 +58,7 @@ OPS_MtClayPISA()
         return 0;
     }
 
-    double dData[7] = { 0, 0, 0, 0, 0, 0, 0 };
+    double dData[7] = { 0, 0, 0, 0, 0, 1, 1 };
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {

--- a/SRC/material/uniaxial/PISA/MtClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MtClayPISA.cpp
@@ -1,0 +1,353 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.13 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for MtClayPISA material. 
+//				Provide moment distributed spring for clays according to PISA project. 
+
+#include <elementAPI.h>
+#include "MtClayPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the MtClayPISA class. 
+void*
+OPS_MtClayPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 6)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial MtClayPISA tag? depth? diameter? undrained_shear_strength? G0? grid_spacing? A0? Au? ?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[7] = { 0, 0, 0, 0, 0, 0, 0 };
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new MtClayPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5], dData[6]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type MtClayPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+MtClayPISA::MtClayPISA(int tag, double z, double D, double Su, double Go, double gs, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    depth(z),
+    diameter(D),
+    undrained_shear_strength(Su),
+    gmax(Go),
+    grid(gs),
+    A0(A0),
+    Au(Au)
+
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+
+}
+
+//	Default constructor
+MtClayPISA::MtClayPISA()
+    :UniaxialMaterial(0, 0),
+    depth(0.0),
+    diameter(0.0),
+    undrained_shear_strength(0.0),
+    gmax(0.0),
+    grid(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default destructor
+MtClayPISA::~MtClayPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void MtClayPISA::Mt_conic_function(double depth, double diameter, double A0, double Au)
+{
+    //-----------------------------------------------------
+    // M-teta curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double tetau_norm = 10.0;
+    epsilon_u = Au / A0 * tetau_norm;
+    // Initial stiffness 
+    double k0m_coeff1 = -0.12;
+    double k0m_coeff2 = 0.98;
+    double k0m = k0m_coeff1 * (depth / diameter) + k0m_coeff2;
+    initial_stiffness = A0 * k0m;
+    // Curvature  
+    curvature = 0.0;
+    // Ultimate reaction 
+    double mu_norm_coeff1 = -0.05;
+    double mu_norm_coeff2 = 0.38;
+    double mu_norm = mu_norm_coeff1 * (depth /diameter) + mu_norm_coeff2;
+    sigma_u = Au * mu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double MtClayPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int MtClayPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+MtClayPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+MtClayPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+MtClayPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+MtClayPISA::getInitialTangent(void)
+{
+    return this->initial_tangent;
+}
+
+int
+MtClayPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+MtClayPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+MtClayPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+MtClayPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+MtClayPISA::getCopy(void)
+{
+    MtClayPISA* theCopy;                 // pointer to a MtClayPISA class
+    theCopy = new MtClayPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+MtClayPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "MtClayPISA, tag: " << this->getTag() << endln;
+    s << "  Depth (m) : " << depth << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Undrained shear strength (kPa) : " << undrained_shear_strength << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
+
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+MtClayPISA::revertToStart(void)
+{
+    Mt_conic_function(depth, diameter, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of distributed moment values for selected points in the mt curve 
+        double p_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = p_norm * undrained_shear_strength * pow(diameter,2);
+        p_F[i] = grid * p_D;
+        // List of teta-values for selected points in the mt curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * undrained_shear_strength / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    initial_tangent = data(0, 4);
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = initial_tangent;
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/MtClayPISA.h
+++ b/SRC/material/uniaxial/PISA/MtClayPISA.h
@@ -1,0 +1,102 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.11 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for MtClayPISA material. 
+//				Provide moment distributed spring for clays according to PISA project. 
+
+#ifndef MtClayPISA_h
+#define MtClayPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class MtClayPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	MtClayPISA(int tag, double z, double D, double Su, double Go, double gs, double A0, double Au);
+	// Null constructor
+	MtClayPISA();
+	// Destructor
+	~MtClayPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double depth;							// depth below the original seafloor (m)
+	double diameter;						// pile outside diameter (m)
+	double undrained_shear_strength;		// vertical effective soil stress (kPa)
+	double gmax;							// small-strain shear modulus (kPa)
+	double A0;								// Scaling factor for initial stiffness
+	double Au;								// Scaling factor for ultimate stress 
+	double grid;							// grid spacing (m) 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Mt_conic_function(double depth, double diameter, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double initial_tangent;
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/MtSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MtSandPISA.cpp
@@ -1,0 +1,361 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.11 $
+// $Date: 21/09/2020 $
+//
+// Description: This file contains the class implementation for MtSandPISA material. 
+//				Provide moment distributed spring for sands according to PISA project. 
+
+#include <elementAPI.h>
+#include "MtSandPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the MtSandPISA class. 
+void*
+OPS_MtSandPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 8)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial MtSandPISA tag? depth? diameter? pile embedded lenght? sigma_vo_eff? G0? Local distributed lateral load? grid spacing? A0? Au? ?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new MtSandPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5], dData[6], dData[7], dData[8]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type MtSandPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+MtSandPISA::MtSandPISA(int tag, double z, double D, double L, double sigma, double Go, double P, double gs, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    depth(z),
+    diameter(D),
+    embedded_length(L),
+    sigma_vo_eff(sigma),
+    gmax(Go),
+    Pvalue(P),
+    grid(gs),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default constructor
+MtSandPISA::MtSandPISA()
+    :UniaxialMaterial(0, 0),
+    depth(0.0),
+    diameter(0.0),
+    embedded_length(0.0),
+    sigma_vo_eff(0.0),
+    gmax(0.0),
+    Pvalue(0.0),
+    grid(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default destructor
+MtSandPISA::~MtSandPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void MtSandPISA::Mt_conic_function(double depth, double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+    // M-teta curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double tetau_norm = 20.0;
+    epsilon_u = Au/A0*tetau_norm;
+    // Initial stiffness 
+    double k0_coeff1 = 20.0;
+    double k0m = k0_coeff1;
+    initial_stiffness = A0 * k0m;
+    // Curvature  
+    curvature = 0.0;
+    if (curvature == 0.5) curvature += 1e-4; // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double mu_norm_coeff1 = -0.05;
+    double mu_norm_coeff2 = 0.21;
+    double mu_norm = mu_norm_coeff1 * (depth / embedded_length) + mu_norm_coeff2;
+    sigma_u = Au * mu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double MtSandPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int MtSandPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+MtSandPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+MtSandPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+MtSandPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+MtSandPISA::getInitialTangent(void)
+{
+    return this->data(0, 4);
+}
+
+int
+MtSandPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+MtSandPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+MtSandPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+MtSandPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+MtSandPISA::getCopy(void)
+{
+    MtSandPISA* theCopy;                 // pointer to a MtSandPISA class
+    theCopy = new MtSandPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+MtSandPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "  MtSandPISA, tag: " << this->getTag() << endln;
+    s << "  Depth (m) : " << depth << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+MtSandPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    if (depth == 0.0)
+    {
+        depth = 1e-6;
+        sigma_vo_eff = 1e-6;
+    }
+
+    Mt_conic_function(depth, diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 0.01;
+    double v_end = 1.11;
+    double delta = 0.01;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of distributed moment values for selected points in the mt curve 
+        double p_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = p_norm * abs(Pvalue) * diameter;
+        p_F[i] = grid * p_D;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * sigma_vo_eff / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = data(0, 4);
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/MtSandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/MtSandPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.11 $
-// $Date: 21/09/2020 $
+// $Revision: 1.12 $
+// $Date: 07/10/2020 $
 //
 // Description: This file contains the class implementation for MtSandPISA material. 
 //				Provide moment distributed spring for sands according to PISA project. 
@@ -58,7 +58,7 @@ OPS_MtSandPISA()
         return 0;
     }
 
-    double dData[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+    double dData[9] = {0, 0, 0, 0, 0, 0, 0, 1, 1};
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {
@@ -280,6 +280,9 @@ MtSandPISA::Print(OPS_Stream& s, int flag)
     s << "  Embedded pile length (m) : " << embedded_length << endln;
     s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
     s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Local lateral distributed load (kN/m) at the current depth : " << Pvalue << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
 }
 
 // Function to create the parameters following the APIrp2GEO method

--- a/SRC/material/uniaxial/PISA/MtSandPISA.h
+++ b/SRC/material/uniaxial/PISA/MtSandPISA.h
@@ -1,0 +1,103 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.1 $
+// $Date: 15/09/2020 $
+//
+// Description: This file contains the class implementation for MtSandPISA material. 
+//				Provide moment distributed spring for sands according to PISA project. 
+
+#ifndef MtSandPISA_h
+#define MtSandPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class MtSandPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	MtSandPISA(int tag, double z, double D, double L, double sigma, double Go, double P, double gs, double A0, double Au);
+	// Null constructor
+	MtSandPISA();
+	// Destructor
+	~MtSandPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double depth;				// depth below the original seafloor (m)
+	double diameter;			// pile outside diameter (m)
+	double embedded_length;		// embedded pile length (m)
+	double sigma_vo_eff;		// vertical effective soil stress (kPa)
+	double gmax;				// small-strain shear modulus (kPa)
+	double Pvalue;				// Current value of the local distributed load
+	double grid;				// grid spacing (m) 
+	double A0;					// Scaling factor for initial stiffness
+	double Au;					// Scaling factor for ultimate stress 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Mt_conic_function(double depth, double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/PyClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/PyClayPISA.cpp
@@ -1,0 +1,356 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.11 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for PyClayPISA material. 
+//				Provide p-y lateral spring for clay according to the PISA project. 
+
+#include <elementAPI.h>
+#include "PyClayPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the PyClayPISA class. 
+void*
+OPS_PyClayPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 6)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial PyClayPISA tag? depth? diameter? undrained shear strength? G0? grid spacing? A0? Au? ?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[7] = {0, 0, 0, 0, 0, 0, 0};
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) != 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new PyClayPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5], dData[6]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type PyClayPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+PyClayPISA::PyClayPISA(int tag, double z, double D, double Su, double Go, double gs, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    depth(z),
+    diameter(D),
+    undrained_shear_strength(Su),
+    gmax(Go),
+    grid(gs),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default constructor
+PyClayPISA::PyClayPISA()
+    :UniaxialMaterial(0, 0),
+    depth(0.0),
+    diameter(0.0),
+    undrained_shear_strength(0.0),
+    gmax(0.0),
+    grid(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+}
+
+//	Default destructor
+PyClayPISA::~PyClayPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void PyClayPISA::Py_conic_function(double depth, double diameter, double A0, double Au)
+{
+    //-----------------------------------------------------
+    // P-y curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double yu_norm = 200;
+    epsilon_u = Au / A0 * yu_norm;
+    // Initial stiffness 
+    double k0_coeff1 = -1.11;
+    double k0_coeff2 = 8.17;
+    double k0p = k0_coeff1 * (depth / diameter) + k0_coeff2;
+    initial_stiffness = A0 * k0p;
+    // Curvature  
+    double np_coeff1 = -0.07;
+    double np_coeff2 = 0.92;
+    double np = np_coeff1 * (depth / diameter) + np_coeff2;
+    curvature = np;
+    if (curvature == 0.5) curvature += 1e-4;    // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double pu_norm_coeff1 = 11.66;
+    double pu_norm_coeff2 = -8.64;
+    double pu_norm_coeff3 = -0.37;
+    double pu_norm = pu_norm_coeff1 + pu_norm_coeff2 * exp(pu_norm_coeff3 * depth / diameter);
+    sigma_u = Au * pu_norm;
+
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double PyClayPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int PyClayPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+PyClayPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+PyClayPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+PyClayPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+PyClayPISA::getInitialTangent(void)
+{
+    return this->initial_tangent;
+}
+
+int
+PyClayPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+PyClayPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+PyClayPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+PyClayPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+PyClayPISA::getCopy(void)
+{
+    PyClayPISA* theCopy;                 // pointer to a PyClayPISA class
+    theCopy = new PyClayPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+PyClayPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "  PyClayPISA, tag: " << this->getTag() << endln;
+    s << "  Depth (m) : " << depth << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Undrained shear strength (kPa) : " << undrained_shear_strength << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+PyClayPISA::revertToStart(void)
+{
+    // -------- Normalised parameters ------------------------
+    Py_conic_function(depth, diameter, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the py curve (kN/m)
+        double p_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = p_norm * undrained_shear_strength * diameter;
+        p_F[i] = grid * p_D;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * diameter * undrained_shear_strength / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    initial_tangent = data(0, 4);
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = initial_tangent;
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/PyClayPISA.cpp
+++ b/SRC/material/uniaxial/PISA/PyClayPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.11 $
-// $Date: 17/09/2020 $
+// $Revision: 1.12 $
+// $Date: 06/10/2020 $
 //
 // Description: This file contains the class implementation for PyClayPISA material. 
 //				Provide p-y lateral spring for clay according to the PISA project. 
@@ -58,7 +58,7 @@ OPS_PyClayPISA()
         return 0;
     }
 
-    double dData[7] = {0, 0, 0, 0, 0, 0, 0};
+    double dData[7] = {0, 0, 0, 0, 0, 1, 1};
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) != 0)
     {

--- a/SRC/material/uniaxial/PISA/PyClayPISA.h
+++ b/SRC/material/uniaxial/PISA/PyClayPISA.h
@@ -1,0 +1,102 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.10 $
+// $Date: 17/09/2020 $
+//
+// Description: This file contains the class implementation for PyClayPISA material. 
+//				Provide p-y lateral spring for clay according to the PISA project. 
+
+#ifndef PyClayPISA_h
+#define PyClayPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class PyClayPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	PyClayPISA(int tag, double z, double D, double Su, double Go, double gs, double A0, double Au);
+	// Null constructor
+	PyClayPISA();
+	// Destructor
+	~PyClayPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double depth;						// depth below the original seafloor (m)
+	double diameter;					// pile outside diameter (m)
+	double undrained_shear_strength;	// undrained shear strength (kPa)
+	double gmax;						// small-strain shear modulus (kPa)
+	double A0;							// Scaling factor for initial stiffness
+	double Au;							// Scaling factor for ultimate stress 
+	double grid;						// grid spacing (m) 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Py_conic_function(double depth, double diameter, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double initial_tangent;
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/PySandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/PySandPISA.cpp
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 
 // Written: csasj 
-// $Revision: 1.1 $
-// $Date: 21/09/2020 $
+// $Revision: 1.11 $
+// $Date: 07/10/2020 $
 //
 // Description: This file contains the class implementation for PySandPISA material. 
 //				Provide p-y lateral spring for sands according to PISA project. 
@@ -58,7 +58,7 @@ OPS_PySandPISA()
         return 0;
     }
 
-    double dData[8] = {0,0,0,0,0,0,0,0};
+    double dData[8] = {0,0,0,0,0,0,1,1};
     numData = OPS_GetNumRemainingInputArgs();
     if (OPS_GetDoubleInput(&numData, dData) < 0)
     {
@@ -279,6 +279,8 @@ PySandPISA::Print(OPS_Stream& s, int flag)
     s << "  Embedded pile length (m) : " << embedded_length << endln;
     s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
     s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+    s << "  Scaling factor for initial stiffness (-) : " << A0 << endln;
+    s << "  Scaling factor for ultimate stress (-) : " << Au << endln;
 }
 
 // Function to create the parameters following the APIrp2GEO method

--- a/SRC/material/uniaxial/PISA/PySandPISA.cpp
+++ b/SRC/material/uniaxial/PISA/PySandPISA.cpp
@@ -1,0 +1,360 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.1 $
+// $Date: 21/09/2020 $
+//
+// Description: This file contains the class implementation for PySandPISA material. 
+//				Provide p-y lateral spring for sands according to PISA project. 
+
+#include <elementAPI.h>
+#include "PySandPISA.h" 
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <vector>
+using namespace std;
+
+// Interface function between the interpreter and the PySandPISA class. 
+void*
+OPS_PySandPISA()
+{
+    // Checking the number of data 
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 7)
+    {
+        opserr << "WARNING insufficient arguments" << endln;
+        opserr << "Want: uniaxialMaterial PySandPISA tag? depth? diameter? pile embedded lenght? sigma_vo_eff? G0?  grid spacing A0? Au? ?" << endln;
+        return 0;
+    }
+
+    // parse the input line for the material parameters
+
+    int    iData[1];
+    int numData = 1;
+    if (OPS_GetIntInput(&numData, iData) != 0)
+    {
+        opserr << "WARNING invalid int inputs" << endln;
+        return 0;
+    }
+
+    double dData[8] = {0,0,0,0,0,0,0,0};
+    numData = OPS_GetNumRemainingInputArgs();
+    if (OPS_GetDoubleInput(&numData, dData) < 0)
+    {
+        opserr << "WARNING invalid double inputs" << endln;
+        return 0;
+    }
+
+    // Creating the new material
+
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial* theMaterial = 0;
+    theMaterial = new PySandPISA(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], dData[5], dData[6], dData[7]);
+
+
+    if (theMaterial == 0)
+    {
+        opserr << "WARNING could not create uniaxialMaterial of type PySandPISA" << endln;
+        return 0;
+    }
+
+    // return the material
+    return theMaterial;
+}
+
+// Full constructor with data 
+PySandPISA::PySandPISA(int tag, double z, double D, double L, double sigma, double Go, double gs, double A0, double Au)
+    :UniaxialMaterial(tag, 0),
+    depth(z),
+    diameter(D),
+    embedded_length(L),
+    sigma_vo_eff(sigma),
+    gmax(Go),
+    grid(gs),
+    A0(A0),
+    Au(Au)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default constructor
+PySandPISA::PySandPISA()
+    :UniaxialMaterial(0, 0),
+    depth(0.0),
+    diameter(0.0),
+    embedded_length(0.0),
+    sigma_vo_eff(0.0),
+    gmax(0.0),
+    grid(0.0),
+    A0(1.0),
+    Au(1.0)
+{
+    // Initialize all variables are needed for the material algorithm
+    this->revertToStart();
+    double initialTangent = data(0, 4);
+}
+
+//	Default destructor
+PySandPISA::~PySandPISA()
+{
+    // does nothing
+}
+
+/**
+ * Calculate the 4 parameters needed to define the conic expression of PISA project for the p-y curve
+ *
+ * @returns (Ultimate strain, Initial stiffness,  Curvature, Ultimate reaction)
+ */
+void PySandPISA::Py_conic_function(double depth, double diameter, double embedded_length, double A0, double Au)
+{
+    //-----------------------------------------------------
+    // P-y curve
+    //-----------------------------------------------------
+    // Ultimate strain 
+    double yu_norm = 53.1;
+    epsilon_u = Au / A0 * yu_norm;
+    // Initial stiffness 
+    double k0_coeff1 = -0.85;
+    double k0_coeff2 = 7.46;
+    double k0p = k0_coeff1 * (depth / diameter) + k0_coeff2;
+    initial_stiffness = A0 * k0p;
+    // Curvature  
+    double np = 0.944;
+    curvature = np;
+    if (curvature == 0.5) curvature += 1e-4;    // Otherwise numerical instability for n = 0.5
+    // Ultimate reaction 
+    double pu_norm_coeff1 = -0.05;
+    double pu_norm_coeff2 = 21.61;
+    double pu_norm = pu_norm_coeff1 * (depth / embedded_length) + pu_norm_coeff2;
+    sigma_u = Au * pu_norm;
+    return;
+}
+
+/**
+ * Evaluate conic function from PISA project
+ *
+ * @returns ratio of generalised normalised stress to ultimate generalised normalised stress.
+ */
+double PySandPISA::conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u)
+{
+    // Normalised roots 
+    double a = 1 - 2 * n;
+    double b = (2 * n * epsilon_ratio) - (1 - n) * (1 + k0 * epsilon_ratio * (Epsilon_u / Sigma_u));
+    double c = k0 * (1 - n) * epsilon_ratio * (Epsilon_u / Sigma_u) - n * (pow(epsilon_ratio, 2));
+    double sigma_ratio = epsilon_ratio <= 1. ? (2 * c / (-b + sqrt(pow(b, 2) - 4 * a * c))) : 1.0;
+    return sigma_ratio;
+}
+
+// Function to compute the strees and tangent from a trial strain sent by the element
+int PySandPISA::setTrialStrain(double strain, double strainRate)
+{
+    if (fabs(tStrain - strain) < DBL_EPSILON)
+        return 0;
+
+    tStrain = strain;
+    tSlope = 0;
+
+    // elastic
+    if (tStrain >= data(0, 0) && tStrain <= data(0, 1)) { // elastic
+        tSlope = 0;
+        tStress = data(0, 2) + (tStrain - data(0, 0)) * data(0, 4);
+        tTangent = data(0, 4);
+    }
+    else if (tStrain < data(0, 0)) { // search neg of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain < data(tSlope, 0))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 2) + (tStrain - data(tSlope, 0)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+    else { // search pos side of data
+        tSlope = 1;
+        while (tSlope < numSlope && tStrain > data(tSlope, 1))
+            tSlope++;
+        if (tSlope == numSlope)
+            tSlope = numSlope - 1;
+        tStress = data(tSlope, 3) + (tStrain - data(tSlope, 1)) * data(tSlope, 4);
+        tTangent = data(tSlope, 4);
+    }
+
+    return 0;
+}
+
+double
+PySandPISA::getStrain(void)
+{
+    return tStrain;
+}
+
+double
+PySandPISA::getStress(void)
+{
+    return tStress;
+}
+
+double
+PySandPISA::getTangent(void)
+{
+    return tTangent;
+}
+
+double
+PySandPISA::getInitialTangent(void)
+{
+    return this->data(0, 4);
+}
+
+int
+PySandPISA::commitState(void)
+{
+    cStrain = tStrain;
+    cStress = tStress;
+    cTangent = tTangent;
+    return 0;
+}
+
+int
+PySandPISA::revertToLastCommit(void)
+{
+    tStrain = cStrain;
+    tStress = cStress;
+    tTangent = cTangent;
+
+    return 0;
+}
+
+int
+PySandPISA::sendSelf(int cTag, Channel& theChannel)
+{
+    return -1;
+}
+
+int
+PySandPISA::recvSelf(int cTag, Channel& theChannel,
+    FEM_ObjectBroker& theBroker)
+{
+    return -1;
+}
+
+UniaxialMaterial*
+PySandPISA::getCopy(void)
+{
+    PySandPISA* theCopy;                 // pointer to a PySandPISA class
+    theCopy = new PySandPISA();          // new instance of this class
+    *theCopy = *this;                    // theCopy (dereferenced) = this (dereferenced pointer) 
+    return theCopy;
+}
+
+void
+PySandPISA::Print(OPS_Stream& s, int flag)
+{
+    s << "PySandPISA, tag: " << this->getTag() << endln;
+    s << "  Depth (m) : " << depth << endln;
+    s << "  Pile diameter (m) : " << diameter << endln;
+    s << "  Embedded pile length (m) : " << embedded_length << endln;
+    s << "  Vertical effective soil stress (kPa) : " << sigma_vo_eff << endln;
+    s << "  Small-strain shear modulus (kPa) : " << gmax << endln;
+}
+
+// Function to create the parameters following the APIrp2GEO method
+int
+PySandPISA::revertToStart(void)
+{
+    // To avoid numerical problems
+    if (depth == 0.0)
+    {
+        depth = 1e-6;
+        sigma_vo_eff = 1e-6;
+    }
+    // -------- Normalised parameters ------------------------
+    Py_conic_function(depth, diameter, embedded_length, A0, Au);
+
+    //------------- Evaluating conic function ---------------
+    // Points to discretize the curve
+    double v_start = 1e-3;
+    double delta = 1e-3;
+    double v_end = 1 + delta;
+    int const v_num = (v_end - v_start) / delta;
+    numSlope = v_num + 1;
+    vector <double> epsilon_bar_ratio(numSlope, 0.0);
+    vector <double> sigma_bar_ratio(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        epsilon_bar_ratio[i] = v_start + i * delta;
+        double sigma_ratio = conic_function(epsilon_bar_ratio[i], initial_stiffness, curvature, epsilon_u, sigma_u);
+        sigma_bar_ratio[i] = sigma_ratio;
+    }
+
+    //---------- Calculating nor normalized soil curve -------
+    vector <double> p_F(numSlope, 0.0);
+    vector <double> y(numSlope, 0.0);
+    for (int i = 0; i < numSlope; i++)
+    {
+        // List of P-values for selected points in the py curve (kN/m)
+        double p_norm = sigma_bar_ratio[i] * sigma_u;
+        double p_D = p_norm * sigma_vo_eff * diameter;
+        p_F[i] = grid * p_D;
+        // List of y-values for selected points in the py curve (m)
+        double y_norm = epsilon_bar_ratio[i] * epsilon_u;
+        y[i] = y_norm * diameter * sigma_vo_eff / gmax;
+    }
+
+    //------------- Creating data matrix--------------------
+    data.resize(numSlope, 6);
+
+    data(0, 0) = -y[0];             // neg yield strain
+    data(0, 1) = y[0];              // pos yield strain
+    data(0, 2) = -p_F[0];           // neg yield stress
+    data(0, 3) = p_F[0];            // pos yield stress
+    data(0, 4) = p_F[0] / y[0];     // slope
+    data(0, 5) = y[0];              // dist - [0-1)/2
+
+    for (int i = 1; i < numSlope; i++)
+    {
+        data(i, 0) = -y[i];
+        data(i, 1) = y[i];
+        data(i, 2) = -p_F[i];
+        data(i, 3) = p_F[i];
+        data(i, 4) = (p_F[i] - p_F[i - 1]) / (y[i] - y[i - 1]);
+        data(i, 5) = y[i] - y[i - 1];
+    }
+    tStrain = 0.0;
+    tStress = 0.0;
+    tTangent = data(0, 4);
+
+    cStrain = 0.0;
+    cStress = 0.0;
+    cTangent = tTangent;
+
+    tSlope = 0;
+
+    this->commitState();
+
+    return 0;
+}
+

--- a/SRC/material/uniaxial/PISA/PySandPISA.h
+++ b/SRC/material/uniaxial/PISA/PySandPISA.h
@@ -1,0 +1,102 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj 
+// $Revision: 1.0 $
+// $Date: 15/09/2020 $
+//
+// Description: This file contains the class implementation for PySandPISA material. 
+//				Provide p-y lateral spring for sands according to PISA project. 
+
+#ifndef PySandPISA_h
+#define PySandPISA_h
+
+#include <UniaxialMaterial.h>
+#include <Matrix.h>
+
+class PySandPISA : public UniaxialMaterial
+{
+public:
+	// Full constructor 
+	PySandPISA(int tag, double z, double D, double L, double sigma, double Go, double gs, double A0, double Au);
+	// Null constructor
+	PySandPISA();
+	// Destructor
+	~PySandPISA();
+
+	// OpenSees methods 
+	int setTrialStrain(double newy, double yRate);
+	double getStrain(void);
+	double getStress(void);
+	double getTangent(void);
+
+	double getInitialTangent(void);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	UniaxialMaterial* getCopy(void);
+
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel,
+		FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag = 0);
+
+protected:
+	// Input parameters
+	double depth;				// depth below the original seafloor (m)
+	double diameter;			// pile outside diameter (m)
+	double embedded_length;		// embedded pile length (m)
+	double sigma_vo_eff;		// vertical effective soil stress (kPa)
+	double gmax;				// small-strain shear modulus (kPa)
+	double grid;				// grid spacing (m) 
+	double A0;					// Scaling factor for initial stiffness
+	double Au;					// Scaling factor for ultimate stress 
+
+private:
+	// Functions to get normalised parameters for each soil reaction curve
+	void Py_conic_function(double depth, double diameter, double embedded_length, double A0, double Au);
+
+	// Function to evaluate conic function from PISA project
+	double conic_function(double epsilon_ratio, double k0, double n, double Epsilon_u, double Sigma_u);
+
+	// Normalised parameters for conic function
+	double epsilon_u;			// Ultimate strain 
+	double initial_stiffness;	// Initial stiffness
+	double curvature;			// Curvature 
+	double sigma_u;				// Ultimate reaction 
+
+	// Vectors to stock p-y curves 
+	Matrix data;
+	int numSlope;
+	int tSlope;
+
+	// Trial values
+	double tStrain;				// current t strain
+	double tStress;				// current t stress
+	double tTangent;			// current t tangent
+	// Commited values  
+	double cStrain;				// last ced strain
+	double cStress;				// last ced stress
+	double cTangent;			// last cted  tangent
+};
+#endif

--- a/SRC/material/uniaxial/PISA/TclPISAMaterialCommand.cpp
+++ b/SRC/material/uniaxial/PISA/TclPISAMaterialCommand.cpp
@@ -1,0 +1,599 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: csasj
+// $Revision: 1.11 $
+// $Date: 21/09/2020 $
+
+// Description: This file contains the implementation of the
+// TclModelBuilder_addPISAMaterial() function. 
+
+#include <TclModelBuilder.h>
+#include <PyClayPISA.h> // csasj
+#include <MtClayPISA.h> // csasj
+#include <HbClayPISA.h> // csasj
+#include <MbClayPISA.h> // csasj
+
+#include <PySandPISA.h> // csasj
+#include <MtSandPISA.h> // csasj
+#include <HbSandPISA.h> // csasj
+#include <MbSandPISA.h> // csasj
+
+#include <tcl.h>
+
+#include <Vector.h>
+#include <string.h>
+#include <fstream>
+using std::ifstream;
+
+#include <iomanip>
+using std::ios;
+
+
+
+static void printCommand(int argc, TCL_Char** argv)
+{
+	opserr << "Input command: ";
+	for (int i = 0; i < argc; i++)
+		opserr << argv[i] << " ";
+	opserr << endln;
+}
+
+UniaxialMaterial*
+TclModelBuilder_addPISAMaterial(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+{
+	// Make sure there is a minimum number of arguments
+	if (argc < 3) {
+		opserr << "WARNING insufficient number of arguments\n";
+		printCommand(argc, argv);
+		return 0;
+	}
+
+	int tag;
+	if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+		opserr << "WARNING invalid uniaxialMaterial tag\n";
+		printCommand(argc, argv);
+		return 0;
+	}
+
+	// Pointer to a uniaxial material that will be added to the model builder
+	UniaxialMaterial* theMaterial = 0;
+
+	// Check argv[1] for soil curve component
+	if (strcmp(argv[1], "PyClayPISA") == 0) {
+
+		if (argc < 8) {
+			opserr << "WARNING insufficient arguments\n";
+			printCommand(argc, argv);
+			opserr << "Want: uniaxialMaterial PyClayPISA tag? depth? diameter? undrained shear strength? G0? grid spacing? A0? Au? " << endln;
+			return 0;
+		}
+
+		int tag;
+		double depth, diameter, undrained_shear_strength, gmax, grid, A0, Au;
+
+		if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+			opserr << "WARNING invalid uniaxialMaterial PyClayPISA tag" << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[3], &depth) != TCL_OK) {
+			opserr << "WARNING invalid depth (m)\n";
+			opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[4], &diameter) != TCL_OK) {
+			opserr << "WARNING invalid diameter\n";
+			opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[5], &undrained_shear_strength) != TCL_OK) {
+			opserr << "WARNING invalid undrained shear strength (kPa)\n";
+			opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+			opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+			opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[7], &grid) != TCL_OK) {
+			opserr << "WARNING invalid grid (m)\n";
+			opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+			return 0;
+		}
+
+		if (argc == 8)
+		{
+			A0 = 1.0;
+			Au = 1.0;
+		}
+
+		if (argc > 8)
+		{ 
+			if (Tcl_GetDouble(interp, argv[8], &A0) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor A0\n";
+				opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+				return 0;
+			}
+			else if  (Tcl_GetDouble(interp, argv[9], &Au) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor Au\n";
+				opserr << "uniaxialMaterial PyClayPISA: " << tag << endln;
+				return 0;
+			}
+		}
+	
+		theMaterial = new PyClayPISA (tag, depth, diameter, undrained_shear_strength, gmax, grid, A0, Au);
+	}
+	
+	else if (strcmp(argv[1], "MtClayPISA") == 0) {
+
+		if (argc < 8) {
+			opserr << "WARNING insufficient arguments\n";
+			printCommand(argc, argv);
+			opserr << "Want: uniaxialMaterial MtClayPISA tag? depth? diameter? undrained shear strength? G0? grid spacing? A0? Au? " << endln;
+			return 0;
+		}
+
+		int tag;
+		double depth, diameter, undrained_shear_strength, gmax, grid, A0, Au;
+
+		if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+			opserr << "WARNING invalid uniaxialMaterial PySimple1 tag" << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[3], &depth) != TCL_OK) {
+			opserr << "WARNING invalid depth (m)\n";
+			opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[4], &diameter) != TCL_OK) {
+			opserr << "WARNING invalid diameter\n";
+			opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[5], &undrained_shear_strength) != TCL_OK) {
+			opserr << "WARNING invalid undrained shear strength (kPa)\n";
+			opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+			opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+			opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[7], &grid) != TCL_OK) {
+			opserr << "WARNING invalid grid (m)\n";
+			opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+			return 0;
+		}
+
+		if (argc == 8)
+		{
+			A0 = 1.0;
+			Au = 1.0;
+		}
+
+		if (argc > 8)
+		{
+			if (Tcl_GetDouble(interp, argv[8], &A0) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor A0\n";
+				opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+				return 0;
+			}
+			else if (Tcl_GetDouble(interp, argv[9], &Au) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor Au\n";
+				opserr << "uniaxialMaterial MtClayPISA: " << tag << endln;
+				return 0;
+			}
+		}
+
+		theMaterial = new MtClayPISA(tag, depth, diameter, undrained_shear_strength, gmax, grid, A0, Au);
+	}
+
+	else if (strcmp(argv[1], "HbClayPISA") == 0)  {
+
+	if (argc < 7) {
+		opserr << "WARNING insufficient arguments\n";
+		printCommand(argc, argv);
+		opserr << "Want: uniaxialMaterial HbClayPISA tag? diameter? embedded length? undrained shear strength? G0? A0? Au? " << endln;
+		return 0;
+	}
+
+	int tag;
+	double  diameter, embedded_length, undrained_shear_strength, gmax, A0, Au;
+
+	if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+		opserr << "WARNING invalid uniaxialMaterial HbClayPISA tag" << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[3], &diameter) != TCL_OK) {
+		opserr << "WARNING invalid diameter (m)\n";
+		opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[4], &embedded_length) != TCL_OK) {
+		opserr << "WARNING invalid embedded_length (m) \n";
+		opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[5], &undrained_shear_strength) != TCL_OK) {
+		opserr << "WARNING invalid undrained shear strength (kPa)\n";
+		opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+		opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+		opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+		return 0;
+	}
+
+	if (argc == 7)
+	{
+		A0 = 1.0;
+		Au = 1.0;
+	}
+
+	if (argc > 7)
+	{
+		if (Tcl_GetDouble(interp, argv[7], &A0) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor A0\n";
+			opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+			return 0;
+		}
+		else if (Tcl_GetDouble(interp, argv[8], &Au) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor Au\n";
+			opserr << "uniaxialMaterial HbClayPISA: " << tag << endln;
+			return 0;
+		}
+	}
+
+	theMaterial = new HbClayPISA (tag, diameter, embedded_length, undrained_shear_strength, gmax, A0, Au);
+
+	}
+	
+	else if (strcmp(argv[1], "MbClayPISA") == 0)  {
+
+		if (argc < 7) {
+			opserr << "WARNING insufficient arguments\n";
+			printCommand(argc, argv);
+			opserr << "Want: uniaxialMaterial MbClayPISA tag? diameter? embedded length? undrained shear strength? G0? A0? Au? " << endln;
+			return 0;
+		}
+
+		int tag;
+		double  diameter, embedded_length, undrained_shear_strength, gmax, A0, Au;
+
+		if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+			opserr << "WARNING invalid uniaxialMaterial MbClayPISA tag" << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[3], &diameter) != TCL_OK) {
+			opserr << "WARNING invalid diameter (m)\n";
+			opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[4], &embedded_length) != TCL_OK) {
+			opserr << "WARNING invalid embedded_length (m) \n";
+			opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[5], &undrained_shear_strength) != TCL_OK) {
+			opserr << "WARNING invalid undrained shear strength (kPa)\n";
+			opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+			opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+			opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+			return 0;
+		}
+
+		if (argc == 7)
+		{
+			A0 = 1.0;
+			Au = 1.0;
+		}
+
+		if (argc > 7)
+		{
+			if (Tcl_GetDouble(interp, argv[7], &A0) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor A0\n";
+				opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+				return 0;
+			}
+			else if (Tcl_GetDouble(interp, argv[8], &Au) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor Au\n";
+				opserr << "uniaxialMaterial MbClayPISA: " << tag << endln;
+				return 0;
+			}
+		}
+
+		theMaterial = new MbClayPISA(tag, diameter, embedded_length, undrained_shear_strength, gmax, A0, Au);
+	}
+
+	else if (strcmp(argv[1], "PySandPISA") == 0) {
+
+		if (argc < 9) {
+			opserr << "WARNING insufficient arguments\n";
+			printCommand(argc, argv);
+			opserr << " Want: uniaxialMaterial PySandPISA tag? depth? diameter? pile embedded lenght? sigma_vo_eff? G0?  grid spacing A0? Au? ? " << endln;
+			return 0;
+		}
+
+		int tag;
+		double depth, diameter, embedded_length, sigma_vo_eff, gmax, grid, A0, Au;
+
+		if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+			opserr << "WARNING invalid uniaxialMaterial PySandPISA tag" << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[3], &depth) != TCL_OK) {
+			opserr << "WARNING invalid depth (m)\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[4], &diameter) != TCL_OK) {
+			opserr << "WARNING invalid diameter\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[5], &embedded_length) != TCL_OK) {
+			opserr << "WARNING invalid pile embedded length (m)\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[6], &sigma_vo_eff) != TCL_OK) {
+			opserr << "WARNING invalid vertical effective soil stress (kPa)\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[7], &gmax) != TCL_OK) {
+			opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+		if (Tcl_GetDouble(interp, argv[8], &grid) != TCL_OK) {
+			opserr << "WARNING invalid grid (m)\n";
+			opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+			return 0;
+		}
+
+		if (argc == 9)
+		{
+			A0 = 1.0;
+			Au = 1.0;
+		}
+
+		if (argc > 9)
+		{
+			if (Tcl_GetDouble(interp, argv[9], &A0) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor A0\n";
+				opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+				return 0;
+			}
+			else if (Tcl_GetDouble(interp, argv[10], &Au) != TCL_OK) {
+				opserr << "WARNING invalid scaling factor Au\n";
+				opserr << "uniaxialMaterial PySandPISA: " << tag << endln;
+				return 0;
+			}
+		}
+
+		theMaterial = new PySandPISA(tag, depth, diameter, embedded_length, sigma_vo_eff, gmax, grid, A0, Au);
+	}
+	
+	else if (strcmp(argv[1], "MtSandPISA") == 0) {
+		
+	if (argc < 10) {
+		opserr << "WARNING insufficient arguments\n";
+		printCommand(argc, argv);
+		opserr << " Want: uniaxialMaterial MtSandPISA tag? depth? diameter? pile embedded lenght? sigma_vo_eff? G0? Local distributed lateral load? grid spacing? A0? Au? ? " << endln;
+		return 0;
+	}
+
+	int tag;
+	double depth, diameter, embedded_length, sigma_vo_eff, gmax, Pvalue, grid, A0, Au;
+
+	if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+		opserr << "WARNING invalid uniaxialMaterial MtSandPISA tag" << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[3], &depth) != TCL_OK) {
+		opserr << "WARNING invalid depth (m)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[4], &diameter) != TCL_OK) {
+		opserr << "WARNING invalid diameter\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[5], &embedded_length) != TCL_OK) {
+		opserr << "WARNING invalid pile embedded length (m)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[6], &sigma_vo_eff) != TCL_OK) {
+		opserr << "WARNING invalid vertical effective soil stress (kPa)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[7], &gmax) != TCL_OK) {
+		opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[8], &Pvalue) != TCL_OK) {
+		opserr << "WARNING invalid current value of distributed lateral load (kN/m)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[9], &grid) != TCL_OK) {
+		opserr << "WARNING invalid grid (m)\n";
+		opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+		return 0;
+	}
+
+	if (argc == 10)
+	{
+		A0 = 1.0;
+		Au = 1.0;
+	}
+
+	if (argc > 10)
+	{
+		if (Tcl_GetDouble(interp, argv[10], &A0) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor A0\n";
+			opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+			return 0;
+		}
+		else if (Tcl_GetDouble(interp, argv[11], &Au) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor Au\n";
+			opserr << "uniaxialMaterial MtSandPISA: " << tag << endln;
+			return 0;
+		}
+	}
+
+	theMaterial = new MtSandPISA(tag, depth, diameter, embedded_length, sigma_vo_eff, gmax, Pvalue, grid, A0, Au);
+
+	}
+
+	else if (strcmp(argv[1], "HbSandPISA") == 0) {
+
+	if (argc < 7) {
+		opserr << "WARNING insufficient arguments\n";
+		printCommand(argc, argv);
+		opserr << "Want: uniaxialMaterial HbSandPISA tag? diameter? pile embedded lenght? sigma_vo_eff? G0? A0? Au? " << endln;
+		return 0;
+	}
+
+	int tag;
+	double  diameter, embedded_length, sigma_vo_eff, gmax, A0, Au;
+
+	if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+		opserr << "WARNING invalid uniaxialMaterial HbSandPISA tag" << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[3], &diameter) != TCL_OK) {
+		opserr << "WARNING invalid diameter (m)\n";
+		opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[4], &embedded_length) != TCL_OK) {
+		opserr << "WARNING invalid embedded_length (m) \n";
+		opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[5], &sigma_vo_eff) != TCL_OK) {
+		opserr << "WARNING invalid vertical effective soil stress (kPa)\n";
+		opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+		opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+		opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+		return 0;
+	}
+
+	if (argc == 7)
+	{
+		A0 = 1.0;
+		Au = 1.0;
+	}
+
+	if (argc > 7)
+	{
+		if (Tcl_GetDouble(interp, argv[7], &A0) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor A0\n";
+			opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+			return 0;
+		}
+		else if (Tcl_GetDouble(interp, argv[8], &Au) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor Au\n";
+			opserr << "uniaxialMaterial HbSandPISA: " << tag << endln;
+			return 0;
+		}
+	}
+
+	theMaterial = new HbSandPISA(tag, diameter, embedded_length, sigma_vo_eff, gmax, A0, Au);
+
+	}
+
+	else if (strcmp(argv[1], "MbSandPISA") == 0) {
+
+	if (argc < 7) {
+		opserr << "WARNING insufficient arguments\n";
+		printCommand(argc, argv);
+		opserr << "Want: uniaxialMaterial MbSandPISA tag? diameter? pile embedded lenght? sigma_vo_eff? G0? A0? Au? " << endln;
+		return 0;
+	}
+
+	int tag;
+	double  diameter, embedded_length, sigma_vo_eff, gmax, A0, Au;
+
+	if (Tcl_GetInt(interp, argv[2], &tag) != TCL_OK) {
+		opserr << "WARNING invalid uniaxialMaterial MbSandPISA tag" << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[3], &diameter) != TCL_OK) {
+		opserr << "WARNING invalid diameter (m)\n";
+		opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[4], &embedded_length) != TCL_OK) {
+		opserr << "WARNING invalid embedded_length (m) \n";
+		opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[5], &sigma_vo_eff) != TCL_OK) {
+		opserr << "WARNING invalid vertical effective soil stress (kPa)\n";
+		opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+		return 0;
+	}
+	if (Tcl_GetDouble(interp, argv[6], &gmax) != TCL_OK) {
+		opserr << "WARNING invalid small-strain shear modulus (kPa)\n";
+		opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+		return 0;
+	}
+
+	if (argc == 7)
+	{
+		A0 = 1.0;
+		Au = 1.0;
+	}
+
+	if (argc > 7){
+		if (Tcl_GetDouble(interp, argv[7], &A0) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor A0\n";
+			opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+			return 0;
+		}
+		else if (Tcl_GetDouble(interp, argv[8], &Au) != TCL_OK) {
+			opserr << "WARNING invalid scaling factor Au\n";
+			opserr << "uniaxialMaterial MbSandPISA: " << tag << endln;
+			return 0;
+		}
+	}
+
+	theMaterial = new MbSandPISA(tag, diameter, embedded_length, sigma_vo_eff, gmax, A0, Au);
+
+	}
+
+	return theMaterial;
+}

--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -230,8 +230,10 @@ TclModelBuilder_addPyTzQzMaterial(ClientData clientData, Tcl_Interp *interp, int
 
 UniaxialMaterial *
 TclModelBuilder_FRPCnfinedConcrete(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv, Domain *theDomain);
-				  
 
+//csasj
+UniaxialMaterial*
+TclModelBuilder_addPISAMaterial(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
 
 int
 TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv, Domain *theDomain)
@@ -2903,6 +2905,10 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
       // LimitState
       if (theMaterial == 0)
 	theMaterial = Tcl_AddLimitStateMaterial(clientData, interp, argc, argv);
+
+      // PISA soil curves 
+      if (theMaterial == 0)
+    theMaterial = TclModelBuilder_addPISAMaterial(clientData, interp, argc, argv);
     }
 
     if (theMaterial == 0) {


### PR DESCRIPTION
# Set of 8 uniaxial materials :  PISA soil reaction curves

This commit incorporates a set of 8 new uniaxial materials, the soil reaction curves  following the [PISA](http://www2.eng.ox.ac.uk/geotech/research/PISA) project recommendations.  

1. Soil reaction curves for sands : PySandPISA, MtSandPISA, HbSandPISA, MbSandPISA
2. Soil reaction curves for clays : PyClayPISA, MtClayPISA, HbClayPISA, MbClayPISA

Note that a new filter named "PISA" should be created inside of the material\uniaxial compilation project. A new Tcl file has also committed to add the new materials and included in the _TclModelBuilderUniaxialMaterialCommand.cpp_ file.

**PISA-type lateral pile response** analysis can be conducted using a 1D beam-column finite element analysis with distributed lateral response curves, moment-rotation curves, base shear and base moment curves.

