### PR TITLE
improving and generalizing truss output

### DIFF
--- a/SRC/element/truss/CorotTruss.cpp
+++ b/SRC/element/truss/CorotTruss.cpp
@@ -1107,10 +1107,41 @@ CorotTruss::setResponse(const char **argv, int argc, OPS_Stream &output)
             output.tag("ResponseType", "U");
             theResponse = new ElementResponse(this, 3, 0.0);
 
-    // a material quantity
-    } else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
+            // a material quantity
+    }
+    else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
+        output.tag("GaussPointOutput");
+        output.attr("number", 1);
+        output.attr("eta", 0.0);
 
-        theResponse =  theMaterial->setResponse(&argv[1], argc-1, output);
+        if (argc > 1) {
+            // we need at least one more argument otherwise 
+            // there is no need to forward this call to the material
+            if (argc > 2) {
+                // if we have 2 or more extra arguments, the first one 
+                // could be an integer. In this case we check to see if it is the section id
+                // (only 1 in this case)
+                int sectionNum = atoi(argv[1]);
+                if (sectionNum == 0) {
+                    // if it is not a number we forward the call to the section as usual
+                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                }
+                else {
+                    // it is a number. Now we have to make sure it is within the allowed range
+                    // for this element (in this case it can only be 1)
+                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+                    // uses this call to understand how many fibers we have in a section
+                    if (sectionNum == 1) {
+                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
+                    }
+                }
+            }
+            else {
+                // otherwise forward it as usual
+                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            }
+        }
+        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/CorotTruss2.cpp
+++ b/SRC/element/truss/CorotTruss2.cpp
@@ -942,10 +942,41 @@ CorotTruss2::setResponse(const char **argv, int argc, OPS_Stream &output)
             output.tag("ResponseType", "U");
             theResponse = new ElementResponse(this, 3, 0.0);
 
-    // a material quantity
-    } else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
+            // a material quantity
+    }
+    else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
+        output.tag("GaussPointOutput");
+        output.attr("number", 1);
+        output.attr("eta", 0.0);
 
-        theResponse =  theMaterial->setResponse(&argv[1], argc-1, output);
+        if (argc > 1) {
+            // we need at least one more argument otherwise 
+            // there is no need to forward this call to the material
+            if (argc > 2) {
+                // if we have 2 or more extra arguments, the first one 
+                // could be an integer. In this case we check to see if it is the section id
+                // (only 1 in this case)
+                int sectionNum = atoi(argv[1]);
+                if (sectionNum == 0) {
+                    // if it is not a number we forward the call to the section as usual
+                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                }
+                else {
+                    // it is a number. Now we have to make sure it is within the allowed range
+                    // for this element (in this case it can only be 1)
+                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+                    // uses this call to understand how many fibers we have in a section
+                    if (sectionNum == 1) {
+                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
+                    }
+                }
+            }
+            else {
+                // otherwise forward it as usual
+                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            }
+        }
+        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/N4BiaxialTruss.cpp
+++ b/SRC/element/truss/N4BiaxialTruss.cpp
@@ -1311,14 +1311,59 @@ N4BiaxialTruss::setResponse(const char **argv, int argc, OPS_Stream &output)
 
 		// a material quantity
 	} else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
-         CompositeResponse *theCResponse = new CompositeResponse();
-		 Response *theResponse1 =  theMaterial_1->setResponse(&argv[1], argc-1, output);
-		 Response *theResponse2 =  theMaterial_2->setResponse(&argv[1], argc-1, output);
-		
-		theCResponse->addResponse(theResponse1);
-		theCResponse->addResponse(theResponse2);
-		
-		theResponse = theCResponse;
+		output.tag("GaussPointOutput");
+		output.attr("number", 1);
+		output.attr("eta", 0.0);
+
+		if (argc > 1) {
+			// we need at least one more argument otherwise 
+			// there is no need to forward this call to the material
+			if (argc > 2) {
+				// if we have 2 or more extra arguments, the first one 
+				// could be an integer. In this case we check to see if it is the section id
+				// (only 1 in this case)
+				int sectionNum = atoi(argv[1]);
+				if (sectionNum == 0) {
+					// if it is not a number we forward the call to the section as usual
+					CompositeResponse* theCResponse = new CompositeResponse();
+					Response* theResponse1 = theMaterial_1->setResponse(&argv[1], argc - 1, output);
+					Response* theResponse2 = theMaterial_2->setResponse(&argv[1], argc - 1, output);
+
+					theCResponse->addResponse(theResponse1);
+					theCResponse->addResponse(theResponse2);
+
+					theResponse = theCResponse;
+				}
+				else {
+					// it is a number. Now we have to make sure it is within the allowed range
+					// for this element (in this case it can only be 1)
+					// If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+					// uses this call to understand how many fibers we have in a section
+					if (sectionNum == 1) {
+						CompositeResponse* theCResponse = new CompositeResponse();
+						Response* theResponse1 = theMaterial_1->setResponse(&argv[2], argc - 2, output);
+						Response* theResponse2 = theMaterial_2->setResponse(&argv[2], argc - 2, output);
+
+						theCResponse->addResponse(theResponse1);
+						theCResponse->addResponse(theResponse2);
+
+						theResponse = theCResponse;
+					}
+				}
+			}
+			else {
+				// otherwise forward it as usual
+				CompositeResponse* theCResponse = new CompositeResponse();
+				Response* theResponse1 = theMaterial_1->setResponse(&argv[1], argc - 1, output);
+				Response* theResponse2 = theMaterial_2->setResponse(&argv[1], argc - 1, output);
+
+				theCResponse->addResponse(theResponse1);
+				theCResponse->addResponse(theResponse2);
+
+				theResponse = theCResponse;
+			}
+		}
+		output.endTag();
 	}
 
 	output.endTag();

--- a/SRC/element/truss/Truss.cpp
+++ b/SRC/element/truss/Truss.cpp
@@ -1199,8 +1199,38 @@ Truss::setResponse(const char **argv, int argc, OPS_Stream &output)
 	    
     // a material quantity
     } else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
+        output.tag("GaussPointOutput");
+        output.attr("number", 1);
+        output.attr("eta", 0.0);
 
-        theResponse =  theMaterial->setResponse(&argv[1], argc-1, output);
+        if (argc > 1) {
+            // we need at least one more argument otherwise 
+			// there is no need to forward this call to the material
+            if (argc > 2) {
+                // if we have 2 or more extra arguments, the first one 
+                // could be an integer. In this case we check to see if it is the section id
+                // (only 1 in this case)
+                int sectionNum = atoi(argv[1]);
+                if (sectionNum == 0) {
+                    // if it is not a number we forward the call to the section as usual
+                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                }
+                else {
+                    // it is a number. Now we have to make sure it is within the allowed range
+                    // for this element (in this case it can only be 1)
+                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+                    // uses this call to understand how many fibers we have in a section
+                    if (sectionNum == 1) {
+                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
+                    }
+                }
+            }
+            else {
+                // otherwise forward it as usual
+                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            }
+        }
+        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/Truss2.cpp
+++ b/SRC/element/truss/Truss2.cpp
@@ -1216,11 +1216,41 @@ Response*
 
 			output.tag("ResponseType", "U");
 			theResponse = new ElementResponse(this, 3, 0.0);
-
 			// a material quantity
-	} else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
+	}
+	else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
+		output.tag("GaussPointOutput");
+		output.attr("number", 1);
+		output.attr("eta", 0.0);
 
-		theResponse =  theMaterial->setResponse(&argv[1], argc-1, output);
+		if (argc > 1) {
+			// we need at least one more argument otherwise 
+			// there is no need to forward this call to the material
+			if (argc > 2) {
+				// if we have 2 or more extra arguments, the first one 
+				// could be an integer. In this case we check to see if it is the section id
+				// (only 1 in this case)
+				int sectionNum = atoi(argv[1]);
+				if (sectionNum == 0) {
+					// if it is not a number we forward the call to the section as usual
+					theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+				}
+				else {
+					// it is a number. Now we have to make sure it is within the allowed range
+					// for this element (in this case it can only be 1)
+					// If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+					// uses this call to understand how many fibers we have in a section
+					if (sectionNum == 1) {
+						theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
+					}
+				}
+			}
+			else {
+				// otherwise forward it as usual
+				theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+			}
+		}
+		output.endTag();
 	}
 
 	output.endTag();

--- a/SRC/element/truss/TrussSection.cpp
+++ b/SRC/element/truss/TrussSection.cpp
@@ -1142,12 +1142,39 @@ TrussSection::setResponse(const char **argv, int argc, OPS_Stream &output)
             theResponse = new ElementResponse(this, 4, Matrix(1,1));
 
     // a section quantity
-    }  else if (strcmp(argv[0],"section") ==0) {
-      int secNum = atoi(argv[1]);
-      if (secNum == 0)
-        theResponse = theSection->setResponse(&argv[1], argc-1, output);
-      else
-	theResponse = theSection->setResponse(&argv[2], argc-2, output);
+    } else if (strcmp(argv[0], "section") == 0) {
+        output.tag("GaussPointOutput");
+        output.attr("number", 1);
+        output.attr("eta", 0.0);
+        
+        if (argc > 1) {
+            // we need at least one more argument otherwise 
+            // there is no need to forward this call to the section
+            if (argc > 2) {
+                // if we have 2 or more extra arguments, the first one 
+                // could be an integer. In this case we check to see if it is the section id
+                // (only 1 in this case)
+                int sectionNum = atoi(argv[1]);
+                if (sectionNum == 0) {
+                    // if it is not a number we forward the call to the section as usual
+                    theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+                }
+                else {
+                    // it is a number. Now we have to make sure it is within the allowed range
+                    // for this element (in this case it can only be 1)
+                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
+                    // uses this call to understand how many fibers we have in a section
+                    if (sectionNum == 1) {
+                        theResponse = theSection->setResponse(&argv[2], argc - 2, output);
+                    }
+                }
+            }
+            else {
+                // otherwise forward it as usual
+                theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+            }
+        }
+        output.endTag();
     }
 
     output.endTag();


### PR DESCRIPTION
Dear @fmckenna @mhscott, with this PR I would like to improve and generalized the output response of some truss elements.

Now truss elements accept the **material** (or **section**) keyword to understand that the user wants a response form the underlying material (or section).

Since the truss has only 1 gauss point, it assumes that there is no integer tag between the material keyword and the following result keyword. However this is not compliant with the general case of elements with multiple gauss points.

Here we add the support for the optional integer tag between the material keyword and the following result keyword. Of course, backward-compatibility is guaranteed, so that now one can ask for both:

- material **1** stress
- material stress

and the result will be the same
