### PR TITLE
Update TclForceBeamColumnCommand.cpp

### DIFF
--- a/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
+++ b/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
@@ -1278,7 +1278,7 @@ TclModelBuilder_addForceBeamColumn(ClientData clientData, Tcl_Interp *interp,
 	opserr << argv[1] << " element: " << eleTag << endln;
 	return TCL_ERROR;
       }
-      argi += 3;
+      argi += 2;
     } else if (strcmp(argv[argi],"-mass") == 0) {
       if (argc < argi+2) {
 	opserr << "WARNING not enough -mass args need -mass mass?\n";
@@ -1290,13 +1290,11 @@ TclModelBuilder_addForceBeamColumn(ClientData clientData, Tcl_Interp *interp,
 	opserr << argv[1] << " element: " << eleTag << endln;
 	return TCL_ERROR;
       }
-      argi += 2;
+      argi += 1;
     } else if ((strcmp(argv[argi],"-lMass") == 0 || strcmp(argv[argi],"lMass") == 0)) {
       cMass = 0;
-      argi++;
     } else if ((strcmp(argv[argi],"-cMass") == 0 || strcmp(argv[argi],"cMass") == 0)) {
       cMass = 1;
-      argi++;
     }
     argi += 1;
   }


### PR DESCRIPTION
The **-cMass** option is not considered due to a bug in the incrementation of the **iarg** variable while iterating on optional arguments.

In fact the **iarg** is incremented by 1, at the end of the while loop, and this is fine for arguments that are not supported.
However, for supported arguments, it is incremented by the correct value (for example 2 for -mass and 3 for -iter). However this is not correct, since at the end of the while loop it will be incremented anyway once more.