### PR TITLE
Bug fixes

### DIFF
--- a/OTHER/Triangle/triangle.c
+++ b/OTHER/Triangle/triangle.c
@@ -231,7 +231,7 @@
 /* If yours is not a Unix system, define the NO_TIMER compiler switch to     */
 /*   remove the Unix-specific timing code.                                   */
 
-/* #define NO_TIMER */
+#define NO_TIMER
 
 /* To insert lots of self-checks for internal errors, define the SELF_CHECK  */
 /*   symbol.  This will slow down the program significantly.  It is best to  */

--- a/SRC/element/RockingBC/RockingBC.cpp
+++ b/SRC/element/RockingBC/RockingBC.cpp
@@ -1424,10 +1424,10 @@ RockingBC::setResponse(const char **argv, int argc, OPS_Stream &output)
 
 	else{
 		std::string fstr = argv[0];
-		Yup_file = std::ofstream(fstr + "_Yup.txt");
-		Up_file = std::ofstream(fstr + "_Up.txt");
-		Ys_file = std::ofstream(fstr + "_Ys.txt");
-		S_file = std::ofstream(fstr + "_S.txt");
+		Yup_file.open(fstr + "_Yup.txt");
+		Up_file.open(fstr + "_Up.txt");
+		Ys_file.open(fstr + "_Ys.txt");
+		S_file.open(fstr + "_S.txt");
 
 		theResponse = new ElementResponse(this, 20, Vector(1));
 
@@ -2473,7 +2473,7 @@ int RockingBC::NL_solve_dyn()
 
 void
 RockingBC::writedbgfile() {
-	std::ofstream NLFfile = std::ofstream("NLsolvefailure.txt");
+	std::ofstream NLFfile("NLsolvefailure.txt");
 
 	if (useUelNM) {
 		Ys_com = interval_join(Ysi_com);

--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -287,15 +287,15 @@ initopensees(void)
     Py_INCREF(st->error);
     PyModule_AddObject(pymodule, "OpenSeesError", st->error);
 
-    char version[10];
-    const char *py_version = ".6";
-    for (int i = 0; i < 5; ++i) {
-        version[i] = OPS_VERSION[i];
-    }
-    for (int i = 0; i < 3; ++i) {
-        version[5 + i] = py_version[i];
-    }
-    PyModule_AddStringConstant(pymodule, "__version__", version);
+    // char version[10];
+    // const char *py_version = ".6";
+    // for (int i = 0; i < 5; ++i) {
+    //     version[i] = OPS_VERSION[i];
+    // }
+    // for (int i = 0; i < 3; ++i) {
+    //     version[5 + i] = py_version[i];
+    // }
+    // PyModule_AddStringConstant(pymodule, "__version__", version);
 
     sserr.setError(st->error);
 

--- a/SRC/material/uniaxial/ASD_SMA_3K.cpp
+++ b/SRC/material/uniaxial/ASD_SMA_3K.cpp
@@ -54,7 +54,7 @@ ASD_SMA_3K matTag? k1? k2? k3? sigF? beta?
 #include <Information.h>
 #include <Parameter.h>
 
-#include <math.h>
+#include <cmath>
 #include <float.h>
 #include <elementAPI.h>
 #include <iostream>


### PR DESCRIPTION
Bug fixes for few things:

1. nodeMass accepts dof in OpenSeesPy
2. remove timing codes from 2D triangulation
3. RockingBC should open files instead of copying ofstream objects.
4. ASD_SMA_3K should include <cmath> instead of <math.h>. Needed versions of abs is defined in <cmath>