### PR TITLE
Making centroid computation an option for fiber sections

### DIFF
--- a/SRC/material/section/FiberSection2d.h
+++ b/SRC/material/section/FiberSection2d.h
@@ -46,10 +46,10 @@ class FiberSection2d : public SectionForceDeformation
 {
   public:
     FiberSection2d(); 
-    FiberSection2d(int tag, int numFibers, Fiber **fibers);
-    FiberSection2d(int tag, int numFibers);
+    FiberSection2d(int tag, int numFibers, Fiber **fibers, bool compCentroid=true);
+    FiberSection2d(int tag, int numFibers, bool compCentroid=true);
     FiberSection2d(int tag, int numFibers, UniaxialMaterial **mats,
-		   SectionIntegration &si);
+		   SectionIntegration &si, bool compCentroid=true);
     ~FiberSection2d();
 
     const char *getClassType(void) const {return "FiberSection2d";};
@@ -102,7 +102,8 @@ class FiberSection2d : public SectionForceDeformation
     double   sData[2];               // data for s vector 
     
     double QzBar, ABar, yBar;       // Section centroid
-  
+    bool computeCentroid;
+      
     SectionIntegration *sectionIntegr;
 
     static ID code;

--- a/SRC/material/section/FiberSection2dThermal.cpp
+++ b/SRC/material/section/FiberSection2dThermal.cpp
@@ -64,10 +64,13 @@ void* OPS_FiberSection2dThermal()
 }
 
 // constructors:
-FiberSection2dThermal::FiberSection2dThermal(int tag, int num, Fiber **fibers):
+FiberSection2dThermal::FiberSection2dThermal(int tag, int num, Fiber **fibers, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection2dThermal),
-  numFibers(num), sizeFibers(num), theMaterials(0), matData(0),DataMixed(27),AverageThermalElong(2), QzBar(0.0), ABar(0.0),
-  yBar(0.0), sectionIntegr(0), e(2), eCommit(2), s(0), ks(0), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), dedh(2)//,theTemperatures(temperatures),theTemperatureFactor(0)
+  numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
+  QzBar(0.0), ABar(0.0), yBar(0.0), computeCentroid(compCentroid),
+  sectionIntegr(0), e(2), eCommit(2), s(0), ks(0),
+  DataMixed(27), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), AverageThermalElong(2),
+  dedh(2)//,theTemperatures(temperatures),theTemperatureFactor(0)
 {
   if (numFibers != 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -83,10 +86,6 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, Fiber **fibers):
       opserr << "FiberSection2dThermal::FiberSection2dThermal -- failed to allocate double array for material data\n";
       exit(-1);
     }
-
-
-    double Qz = 0.0;
-    double A  = 0.0;
 
     for (int i = 0; i < numFibers; i++) {
       Fiber *theFiber = fibers[i];
@@ -106,7 +105,8 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, Fiber **fibers):
       }
     }
 
-    yBar = QzBar/ABar;
+    if (computeCentroid)
+      yBar = QzBar/ABar;
   }
 
   s = new Vector(sData, 2);
@@ -140,12 +140,13 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, Fiber **fibers):
 }
 
 // allocate memory for fibers
-FiberSection2dThermal::FiberSection2dThermal(int tag, int num):
+FiberSection2dThermal::FiberSection2dThermal(int tag, int num, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection2dThermal),
   numFibers(0), sizeFibers(num), theMaterials(0), matData(0),
-  DataMixed(27),AverageThermalElong(2),
-  QzBar(0.0), ABar(0.0), yBar(0.0),
-  sectionIntegr(0), e(2), eCommit(2), s(0), ks(0), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), dedh(2)
+  QzBar(0.0), ABar(0.0), yBar(0.0), computeCentroid(compCentroid),
+  sectionIntegr(0), e(2), eCommit(2), s(0), ks(0),
+  DataMixed(27), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), AverageThermalElong(2),
+  dedh(2)
 {
     if(sizeFibers > 0) {
 	theMaterials = new UniaxialMaterial *[sizeFibers];
@@ -201,10 +202,13 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num):
 
 
 FiberSection2dThermal::FiberSection2dThermal(int tag, int num, UniaxialMaterial **mats,
-			       SectionIntegration &si):
+					     SectionIntegration &si, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection2dThermal),
-  numFibers(num), sizeFibers(num), theMaterials(0), matData(0),DataMixed(27),AverageThermalElong(2),
-  yBar(0.0), sectionIntegr(0), e(2), eCommit(2), s(0), ks(0), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), dedh(2)//,theTemperature(0)
+  numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
+  QzBar(0.0), ABar(0.0), yBar(0.0), computeCentroid(compCentroid),
+  sectionIntegr(0), e(2), eCommit(2), s(0), ks(0),
+  DataMixed(27), sT(0), Fiber_Tangent(0), Fiber_ElongP(0), AverageThermalElong(2),
+  dedh(2)//,theTemperature(0)
 {
   if (numFibers != 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -233,9 +237,6 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, UniaxialMaterial 
   double fiberArea[10000];
   sectionIntegr->getFiberWeights(numFibers, fiberArea);
 
-  double Qz = 0.0;
-  double A  = 0.0;
-
   for (int i = 0; i < numFibers; i++) {
 
     ABar  += fiberArea[i];
@@ -249,7 +250,8 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, UniaxialMaterial 
     }
   }
 
-  yBar = QzBar/ABar;
+  if (computeCentroid)
+    yBar = QzBar/ABar;
 
   s = new Vector(sData, 2);
   ks = new Matrix(kData, 2, 2);
@@ -285,8 +287,11 @@ FiberSection2dThermal::FiberSection2dThermal(int tag, int num, UniaxialMaterial 
 // constructor for blank object that recvSelf needs to be invoked upon
 FiberSection2dThermal::FiberSection2dThermal():
   SectionForceDeformation(0, SEC_TAG_FiberSection2dThermal),
-  numFibers(0), sizeFibers(0), theMaterials(0), matData(0),DataMixed(27),AverageThermalElong(2),
-  yBar(0.0), sectionIntegr(0), e(2), eCommit(2), s(0), ks(0), Fiber_Tangent(0), Fiber_ElongP(0), dedh(2)//, theTemperatures(0),theTemperatureFactor(0)
+  numFibers(0), sizeFibers(0), theMaterials(0), matData(0),
+  QzBar(0.0), ABar(0.0), yBar(0.0), computeCentroid(true),
+  sectionIntegr(0), e(2), eCommit(2), s(0), ks(0),
+  DataMixed(27), Fiber_Tangent(0), Fiber_ElongP(0), AverageThermalElong(2),
+  dedh(2)//, theTemperatures(0),theTemperatureFactor(0)
 {
   s = new Vector(sData, 2);
   ks = new Matrix(kData, 2, 2);
@@ -378,10 +383,12 @@ FiberSection2dThermal::addFiber(Fiber &newFiber)
     numFibers++;
 
     // Recompute centroid
-    ABar += Area;
-    QzBar += yLoc*Area;
-    yBar = QzBar/ABar;
-
+    if (computeCentroid) {
+      ABar += Area;
+      QzBar += yLoc*Area;
+      yBar = QzBar/ABar;
+    }
+    
     return 0;
 }
 
@@ -733,6 +740,8 @@ FiberSection2dThermal::getCopy(void)
   theCopy->sData[0] = sData[0];
   theCopy->sData[1] = sData[1];
 
+  theCopy->computeCentroid = computeCentroid;
+  
   if (sectionIntegr != 0)
     theCopy->sectionIntegr = sectionIntegr->getCopy();
   else
@@ -879,6 +888,7 @@ FiberSection2dThermal::sendSelf(int commitTag, Channel &theChannel)
   static ID data(3);
   data(0) = this->getTag();
   data(1) = numFibers;
+  data(2) = computeCentroid ? 1 : 0; // Now the ID data is really 3  
   int dbTag = this->getDbTag();
   res += theChannel.sendID(dbTag, commitTag, data);
   if (res < 0) {
@@ -1019,6 +1029,8 @@ FiberSection2dThermal::recvSelf(int commitTag, Channel &theChannel,
     double A  = 0.0;
     double yLoc, Area;
 
+    computeCentroid = data(2) ? true : false;
+    
     // Recompute centroid
     for (i = 0; i < numFibers; i++) {
       yLoc = matData[2*i];
@@ -1027,7 +1039,10 @@ FiberSection2dThermal::recvSelf(int commitTag, Channel &theChannel,
       Qz += yLoc*Area;
     }
 
-    yBar = Qz/A;
+    if (computeCentroid)
+      yBar = Qz/A;
+    else
+      yBar = 0.0;
   }
 
   return res;

--- a/SRC/material/section/FiberSection2dThermal.h
+++ b/SRC/material/section/FiberSection2dThermal.h
@@ -47,10 +47,10 @@ class FiberSection2dThermal : public SectionForceDeformation
 {
   public:
     FiberSection2dThermal();
-    FiberSection2dThermal(int tag, int numFibers, Fiber **fibers);
-    FiberSection2dThermal(int tag, int num);
+    FiberSection2dThermal(int tag, int numFibers, Fiber **fibers, bool compCentroid=true);
+    FiberSection2dThermal(int tag, int num, bool compCentroid=true);
     FiberSection2dThermal(int tag, int numFibers, UniaxialMaterial **mats,
-			  SectionIntegration &si);
+			  SectionIntegration &si, bool compCentroid=true);
     ~FiberSection2dThermal();
 
     const char *getClassType(void) const {return "FiberSection2dThermal";};
@@ -108,7 +108,8 @@ class FiberSection2dThermal : public SectionForceDeformation
     double   sData[2];               // data for s vector
 
     double QzBar, ABar, yBar;       // Section centroid
-
+    bool computeCentroid;
+    
     SectionIntegration *sectionIntegr;
 
     static ID code;
@@ -125,6 +126,7 @@ class FiberSection2dThermal : public SectionForceDeformation
     double *Fiber_ElongP;
     Vector AverageThermalElong;
 	//Basiclly this data stores the last committed fiber tangent for calculating thermal foreces
+
 // AddingSensitivity:BEGIN //////////////////////////////////////////
     Vector dedh; // MHS hack
 // AddingSensitivity:END ///////////////////////////////////////////

--- a/SRC/material/section/FiberSection3d.cpp
+++ b/SRC/material/section/FiberSection3d.cpp
@@ -60,34 +60,43 @@ void* OPS_FiberSection3d()
     numData = 1;
     int tag;
     if (OPS_GetIntInput(&numData, &tag) < 0) return 0;
-    
-    UniaxialMaterial *torsion = 0;
+
     if (OPS_GetNumRemainingInputArgs() < 2) {
       opserr << "WARNING torsion not specified for FiberSection\n";
       opserr << "Use either -GJ $GJ or -torsion $matTag\n";
       opserr << "\nFiberSection3d section: " << tag << endln;
       return 0;
     }
-    const char* opt = OPS_GetString();
-    numData = 1;
+    
+    UniaxialMaterial *torsion = 0;
     bool deleteTorsion = false;
-    if (strcmp(opt, "-GJ") == 0) {
-      double GJ;
-      if (OPS_GetDoubleInput(&numData, &GJ) < 0) {
-	opserr << "WARNING: failed to read GJ\n";
-	return 0;
+    bool computeCentroid = true;
+    while (OPS_GetNumRemainingInputArgs() > 0) {
+      const char* opt = OPS_GetString();
+      if (strcmp(opt,"-noCentroid") == 0) {
+	computeCentroid = false;
       }
-      torsion = new ElasticMaterial(0,GJ);
-      deleteTorsion = true;
-    }
-    if (strcmp(opt, "-torsion") == 0) {
-      int torsionTag;
-      if (OPS_GetIntInput(&numData, &torsionTag) < 0) {
-	opserr << "WARNING: failed to read torsion\n";
-	return 0;
+      if (strcmp(opt, "-GJ") == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+	numData = 1;
+	double GJ;
+	if (OPS_GetDoubleInput(&numData, &GJ) < 0) {
+	  opserr << "WARNING: failed to read GJ\n";
+	  return 0;
+	}
+	torsion = new ElasticMaterial(0,GJ);
+	deleteTorsion = true;
       }
-      torsion = OPS_getUniaxialMaterial(torsionTag);
+      if (strcmp(opt, "-torsion") == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+	numData = 1;
+	int torsionTag;
+	if (OPS_GetIntInput(&numData, &torsionTag) < 0) {
+	  opserr << "WARNING: failed to read torsion\n";
+	  return 0;
+	}
+	torsion = OPS_getUniaxialMaterial(torsionTag);
+      }
     }
+
     if (torsion == 0) {
       opserr << "WARNING torsion not specified for FiberSection\n";
       opserr << "\nFiberSection3d section: " << tag << endln;
@@ -95,17 +104,19 @@ void* OPS_FiberSection3d()
     }
     
     int num = 30;
-    SectionForceDeformation *section = new FiberSection3d(tag, num, *torsion);
+    SectionForceDeformation *section = new FiberSection3d(tag, num, *torsion, computeCentroid);
     if (deleteTorsion)
       delete torsion;
     return section;
 }
 
 // constructors:
-FiberSection3d::FiberSection3d(int tag, int num, Fiber **fibers, UniaxialMaterial &torsion): 
+FiberSection3d::FiberSection3d(int tag, int num, Fiber **fibers,
+			       UniaxialMaterial &torsion, bool compCentroid): 
   SectionForceDeformation(tag, SEC_TAG_FiberSection3d),
   numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
+  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
+  sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
 {
   if (numFibers != 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -122,9 +133,9 @@ FiberSection3d::FiberSection3d(int tag, int num, Fiber **fibers, UniaxialMateria
       exit(-1);
     }
 
+    double yLoc, zLoc, Area;
     for (int i = 0; i < numFibers; i++) {
       Fiber *theFiber = fibers[i];
-      double yLoc, zLoc, Area;
       theFiber->getFiberLocation(yLoc, zLoc);
       Area = theFiber->getArea();
 
@@ -144,8 +155,10 @@ FiberSection3d::FiberSection3d(int tag, int num, Fiber **fibers, UniaxialMateria
       }
     }
 
-    yBar = QzBar/Abar;
-    zBar = QyBar/Abar;
+    if (computeCentroid) {
+      yBar = QzBar/Abar;
+      zBar = QyBar/Abar;
+    }
   }
 
   theTorsion = torsion.getCopy();
@@ -169,10 +182,11 @@ FiberSection3d::FiberSection3d(int tag, int num, Fiber **fibers, UniaxialMateria
   code(3) = SECTION_RESPONSE_T;
 }
 
-FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial &torsion): 
+FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial &torsion, bool compCentroid): 
     SectionForceDeformation(tag, SEC_TAG_FiberSection3d),
     numFibers(0), sizeFibers(num), theMaterials(0), matData(0),
-    QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
+    QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
+    sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
 {
     if(sizeFibers != 0) {
 	theMaterials = new UniaxialMaterial *[sizeFibers];
@@ -219,10 +233,12 @@ FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial &torsion):
 }
 
 FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial **mats,
-			       SectionIntegration &si, UniaxialMaterial &torsion):
+			       SectionIntegration &si, UniaxialMaterial &torsion,
+			       bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection3d),
   numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
+  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
+  sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
 {
   if (numFibers != 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -265,10 +281,12 @@ FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial **mats,
       exit(-1);
     }
   }    
-  
-  yBar = QzBar/Abar;  
-  zBar = QyBar/Abar;  
 
+  if (computeCentroid) {
+    yBar = QzBar/Abar;  
+    zBar = QyBar/Abar;  
+  }
+  
   theTorsion = torsion.getCopy();
   if (theTorsion == 0)
     opserr << "FiberSection3d::FiberSection3d -- failed to get copy of torsion material\n";
@@ -292,7 +310,8 @@ FiberSection3d::FiberSection3d(int tag, int num, UniaxialMaterial **mats,
 FiberSection3d::FiberSection3d():
   SectionForceDeformation(0, SEC_TAG_FiberSection3d),
   numFibers(0), sizeFibers(0), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
+  QzBar(0.0), QyBar(0.0), Abar(0.0), yBar(0.0), zBar(0.0), computeCentroid(true),
+  sectionIntegr(0), e(4), s(0), ks(0), theTorsion(0)
 {
   s = new Vector(sData, 4);
   ks = new Matrix(kData, 4, 4);
@@ -370,13 +389,15 @@ FiberSection3d::addFiber(Fiber &newFiber)
   numFibers++;
 
   // Recompute centroid
-  Abar  += Area;
-  QzBar += yLoc*Area;
-  QyBar += zLoc*Area;
-
-  yBar = QzBar/Abar;
-  zBar = QyBar/Abar;
-
+  if (computeCentroid) {
+    Abar  += Area;
+    QzBar += yLoc*Area;
+    QyBar += zLoc*Area;
+    
+    yBar = QzBar/Abar;
+    zBar = QyBar/Abar;
+  }
+  
   return 0;
 }
 
@@ -445,14 +466,13 @@ FiberSection3d::setTrialSectionDeformation (const Vector &deforms)
  
   double tangent, stress;
   for (int i = 0; i < numFibers; i++) {
-    UniaxialMaterial *theMat = theMaterials[i];
     double y = yLocs[i] - yBar;
     double z = zLocs[i] - zBar;
     double A = fiberArea[i];
 
     // determine material strain and set it
     double strain = d0 - y*d1 + z*d2;
-    res += theMat->setTrial(strain, stress, tangent);
+    res += theMaterials[i]->setTrial(strain, stress, tangent);
 
     double value = tangent * A;
     double vas1 = -y*value;
@@ -513,12 +533,11 @@ FiberSection3d::getInitialTangent(void)
   }
 
   for (int i = 0; i < numFibers; i++) {
-    UniaxialMaterial *theMat = theMaterials[i];
     double y = yLocs[i] - yBar;
     double z = zLocs[i] - zBar;
     double A = fiberArea[i];
 
-    double tangent = theMat->getInitialTangent();
+    double tangent = theMaterials[i]->getInitialTangent();
 
     double value = tangent * A;
     double vas1 = -y*value;
@@ -607,7 +626,8 @@ FiberSection3d::getCopy(void)
   theCopy->Abar = Abar;
   theCopy->yBar = yBar;
   theCopy->zBar = zBar;
-
+  theCopy->computeCentroid = computeCentroid;
+  
   for (int i=0; i<16; i++)
     theCopy->kData[i] = kData[i];
 
@@ -819,7 +839,8 @@ FiberSection3d::sendSelf(int commitTag, Channel &theChannel)
     theTorsion->setDbTag(dbTag);
     data(3) = theTorsion->getClassTag();
   }
-
+  data(4) = computeCentroid ? 1 : 0; // Now the ID data is really 5
+  
   res += theChannel.sendID(dbTag, commitTag, data);
   if (res < 0) {
     opserr << "FiberSection3d::sendSelf - failed to send ID data\n";
@@ -981,8 +1002,10 @@ FiberSection3d::recvSelf(int commitTag, Channel &theChannel,
     Abar  = 0.0;
     double yLoc, zLoc, Area;
 
+    computeCentroid = data(4) ? true : false;
+    
     // Recompute centroid
-    for (i = 0; i < numFibers; i++) {
+    for (i = 0; computeCentroid && i < numFibers; i++) {
       yLoc = matData[3*i];
       zLoc = matData[3*i+1];
       Area = matData[3*i+2];
@@ -990,9 +1013,14 @@ FiberSection3d::recvSelf(int commitTag, Channel &theChannel,
       QzBar += yLoc*Area;
       QyBar += zLoc*Area;
     }
-    
-    yBar = QzBar/Abar;
-    zBar = QyBar/Abar;
+
+    if (computeCentroid) {
+      yBar = QzBar/Abar;
+      zBar = QyBar/Abar;
+    } else {
+      yBar = 0.0;
+      zBar = 0.0;      
+    }
   }    
 
   return res;
@@ -1005,7 +1033,7 @@ FiberSection3d::Print(OPS_Stream &s, int flag)
     s << "\nFiberSection3d, tag: " << this->getTag() << endln;
     s << "\tSection code: " << code;
     s << "\tNumber of Fibers: " << numFibers << endln;
-    s << "\tCentroid: (" << -yBar << ", " << zBar << ')' << endln;
+    s << "\tCentroid: (" << yBar << ", " << zBar << ')' << endln;
     if (theTorsion != 0)
         theTorsion->Print(s, flag);    
 
@@ -1037,8 +1065,8 @@ FiberSection3d::Print(OPS_Stream &s, int flag)
 	  s << "\t\t\t{";
 	  s << "\"name\": \"" << this->getTag() << "\", ";
 	  s << "\"type\": \"FiberSection3d\", ";
-      if (theTorsion != 0)
-          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+	  if (theTorsion != 0)
+	    s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
 	  s << "\"fibers\": [\n";
 	  for (int i = 0; i < numFibers; i++) {
 		  s << "\t\t\t\t{\"coord\": [" << matData[3*i] << ", " << matData[3*i+1] << "], ";
@@ -1291,7 +1319,7 @@ FiberSection3d::setResponse(const char **argv, int argc, OPS_Stream &output)
       
       if (key < numFibers && key >= 0) {
 	output.tag("FiberOutput");
-	output.attr("yLoc",-matData[3*key]);
+	output.attr("yLoc",matData[3*key]);
 	output.attr("zLoc",matData[3*key+1]);
 	output.attr("area",matData[3*key+2]);
 	
@@ -1581,14 +1609,13 @@ FiberSection3d::commitSensitivity(const Vector& defSens, int gradIndex, int numG
   double depsdh = 0;
 
   for (int i = 0; i < numFibers; i++) {
-    UniaxialMaterial *theMat = theMaterials[i];
     y = yLocs[i] - yBar;
     z = zLocs[i] - zBar;
 
     // determine material strain and set it
     depsdh = d0 - y*d1 + z*d2 - dydh[i]*e(1) + dzdh[i]*e(2);
 
-    theMat->commitSensitivity(depsdh,gradIndex,numGrads);
+    theMaterials[i]->commitSensitivity(depsdh,gradIndex,numGrads);
   }
 
   theTorsion->commitSensitivity(d3, gradIndex, numGrads);

--- a/SRC/material/section/FiberSection3d.h
+++ b/SRC/material/section/FiberSection3d.h
@@ -47,10 +47,10 @@ class FiberSection3d : public SectionForceDeformation
   public:
     FiberSection3d(); 
     FiberSection3d(int tag, int numFibers, Fiber **fibers, 
-		   UniaxialMaterial &torsion);
-    FiberSection3d(int tag, int numFibers, UniaxialMaterial &torsion);
+		   UniaxialMaterial &torsion, bool compCentroid=true);
+    FiberSection3d(int tag, int numFibers, UniaxialMaterial &torsion, bool compCentroid=true);
     FiberSection3d(int tag, int numFibers, UniaxialMaterial **mats,
-		   SectionIntegration &si, UniaxialMaterial &torsion);
+		   SectionIntegration &si, UniaxialMaterial &torsion, bool compCentroid=true);
     ~FiberSection3d();
 
     const char *getClassType(void) const {return "FiberSection3d";};
@@ -107,7 +107,8 @@ class FiberSection3d : public SectionForceDeformation
     double QzBar, QyBar, Abar;
     double yBar;       // Section centroid
     double zBar;
-  
+    bool computeCentroid;
+    
     SectionIntegration *sectionIntegr;
 
     static ID code;

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -48,11 +48,12 @@
 ID FiberSection3dThermal::code(3);
 
 // constructors:
-FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers):
+FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection3dThermal),
   numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), ABar(0.0),
-  yBar(0.0), zBar(0.0), e(3), eCommit(3), s(0), ks(0), sT(0), Fiber_T(0), Fiber_TMax(0)
+  QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
+  e(3), eCommit(3), s(0), ks(0), sT(0), Fiber_T(0), Fiber_TMax(0),
+  parameterID(0), SHVs(0)
 {
   if (numFibers != 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -68,10 +69,6 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers):
       opserr << "FiberSection3dThermal::FiberSection3dThermal -- failed to allocate double array for material data\n";
       exit(-1);
     }
-
-    double Qz = 0.0;
-    double Qy = 0.0;
-    double A  = 0.0;
 
     for (int i = 0; i < numFibers; i++) {
       Fiber *theFiber = fibers[i];
@@ -94,8 +91,10 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers):
       }
     }
 
-    yBar = -QzBar/ABar;
-    zBar = QyBar/ABar;
+    if (computeCentroid) {
+      yBar = QzBar/ABar;
+      zBar = QyBar/ABar;
+    }
   }
 
   s = new Vector(sData, 3);
@@ -133,11 +132,13 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers):
    }
 }
 
-FiberSection3dThermal::FiberSection3dThermal(int tag, int num):
+FiberSection3dThermal::FiberSection3dThermal(int tag, int num, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection3dThermal),
   numFibers(0), sizeFibers(num), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), ABar(0.0),
-  yBar(0.0), zBar(0.0), e(3), eCommit(3), s(0), ks(0), sT(0), Fiber_T(0), Fiber_TMax(0)
+  QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
+  e(3), eCommit(3), s(0), ks(0),
+  sT(0), Fiber_T(0), Fiber_TMax(0),
+  parameterID(0), SHVs(0)
 {
   if(sizeFibers != 0) {
     theMaterials = new UniaxialMaterial *[sizeFibers];
@@ -201,8 +202,10 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num):
 FiberSection3dThermal::FiberSection3dThermal():
   SectionForceDeformation(0, SEC_TAG_FiberSection3dThermal),
   numFibers(0), sizeFibers(0), theMaterials(0), matData(0),
-  QzBar(0.0), QyBar(0.0), ABar(0.0),
-  yBar(0.0), zBar(0.0), e(3), eCommit(3), s(0), ks(0), sT(0), Fiber_T(0), Fiber_TMax(0)
+  QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(true),
+  e(3), eCommit(3), s(0), ks(0),
+  sT(0), Fiber_T(0), Fiber_TMax(0),
+  parameterID(0), SHVs(0)
 {
   s = new Vector(sData, 3);
   ks = new Matrix(kData, 3, 3);
@@ -300,13 +303,15 @@ FiberSection3dThermal::addFiber(Fiber &newFiber)
   numFibers++;
 
   // Recompute centroid
-  ABar  += Area;
-  QzBar += yLoc*Area;
-  QyBar += zLoc*Area;
-
-  yBar = QzBar/ABar;
-  zBar = QyBar/ABar;
-
+  if (computeCentroid) {
+    ABar  += Area;
+    QzBar += yLoc*Area;
+    QyBar += zLoc*Area;
+    
+    yBar = QzBar/ABar;
+    zBar = QyBar/ABar;
+  }
+  
   return 0;
 }
 
@@ -565,8 +570,8 @@ FiberSection3dThermal::getTemperatureStress(const Vector& dataMixed)
       sTData[1] += FiberForce*(matData[3*i] - yBar);
 	  sTData[2] += FiberForce*(matData[3*i+1] - zBar);
   }
-  double ThermalMoment;
-  ThermalMoment = abs(sTData[1]);
+  //double ThermalMoment;
+  //ThermalMoment = abs(sTData[1]);
  // sTData[1] = ThermalMoment;
 
   return *sT;
@@ -614,9 +619,13 @@ FiberSection3dThermal::getCopy(void)
 
   theCopy->eCommit = eCommit;
   theCopy->e = e;
+  theCopy->QzBar = QzBar;
+  theCopy->QyBar = QyBar;
+  theCopy->ABar = ABar;  
   theCopy->yBar = yBar;
   theCopy->zBar = zBar;
-
+  theCopy->computeCentroid = computeCentroid;
+  
   for (int i=0; i<9; i++)
     theCopy->kData[i] = kData[i];
 
@@ -770,6 +779,7 @@ FiberSection3dThermal::sendSelf(int commitTag, Channel &theChannel)
   static ID data(3);
   data(0) = this->getTag();
   data(1) = numFibers;
+  data(2) = computeCentroid ? 1 : 0; // Now the ID data is really 3
   int dbTag = this->getDbTag();
   res += theChannel.sendID(dbTag, commitTag, data);
   if (res < 0) {
@@ -908,23 +918,30 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
       res += theMaterials[i]->recvSelf(commitTag, theChannel, theBroker);
     }
 
-    double Qz = 0.0;
-    double Qy = 0.0;
-    double A  = 0.0;
-    double yLoc, zLoc, Area;
+    QzBar = 0.0;
+    QyBar = 0.0;
+    ABar = 0.0;
 
+    computeCentroid = data(2) ? true : false;
+    
     // Recompute centroid
-    for (i = 0; i < numFibers; i++) {
-      yLoc = -matData[3*i];
+    double yLoc, zLoc, Area;    
+    for (i = 0; computeCentroid && i < numFibers; i++) {
+      yLoc = matData[3*i];
       zLoc = matData[3*i+1];
       Area = matData[3*i+2];
-      A  += Area;
-      Qz += yLoc*Area;
-      Qy += zLoc*Area;
+      ABar  += Area;
+      QzBar += yLoc*Area;
+      QyBar += zLoc*Area;
     }
 
-    yBar = -Qz/A;
-    zBar = Qy/A;
+    if (computeCentroid) {
+      yBar = QzBar/ABar;
+      zBar = QyBar/ABar;
+    } else {
+      yBar = 0.0;
+      zBar = 0.0;
+    }
   }
 
   return res;
@@ -942,7 +959,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
     s << "\nFiberSection3dThermal, tag: " << this->getTag() << endln;
     s << "\tSection code: " << code;
     s << "\tNumber of Fibers: " << numFibers << endln;
-    s << "\tCentroid: (" << -yBar << ", " << zBar << ')' << endln;
+    s << "\tCentroid: (" << yBar << ", " << zBar << ')' << endln;
 
     if (flag == 1) {
       for (int i = 0; i < numFibers; i++) {
@@ -1084,7 +1101,7 @@ FiberSection3dThermal::setResponse(const char **argv, int argc, OPS_Stream &outp
     int numData = numFibers*5;
     for (int j = 0; j < numFibers; j++) {
       output.tag("FiberOutput");
-      output.attr("yLoc", -matData[3*j]);
+      output.attr("yLoc", matData[3*j]);
       output.attr("zLoc", matData[3*j+1]);
       output.attr("area", matData[3*j+2]);
       output.tag("ResponseType","yCoord");
@@ -1177,7 +1194,7 @@ FiberSection3dThermal::setResponse(const char **argv, int argc, OPS_Stream &outp
 
       if (key < numFibers && key >= 0) {
 	output.tag("FiberOutput");
-	output.attr("yLoc",-matData[3*key]);
+	output.attr("yLoc",matData[3*key]);
 	output.attr("zLoc",matData[3*key+1]);
 	output.attr("area",matData[3*key+2]);
 
@@ -1285,7 +1302,6 @@ FiberSection3dThermal::getStressResultantSensitivity(int gradIndex, bool conditi
 
 
   for (int i = 0; i < numFibers; i++) {
-    UniaxialMaterial *theMat = theMaterials[i];
     double y = matData[loc++] - yBar;
     double z = matData[loc++] - zBar;
     double A = matData[loc++];
@@ -1331,16 +1347,13 @@ FiberSection3dThermal::commitSensitivity(const Vector& defSens, int gradIndex, i
   double d2 = defSens(2);
 
   for (int i = 0; i < numFibers; i++) {
-    UniaxialMaterial *theMat = theMaterials[i];
    	double y = matData[loc++] - yBar;
 	double z = matData[loc++] - zBar;
 	loc++;   // skip A data.
 
 	double strainSens = d0 + y*d1 + z*d2;
 
-
-
-	theMat->commitSensitivity(strainSens,gradIndex,numGrads);
+	theMaterials[i]->commitSensitivity(strainSens,gradIndex,numGrads);
   }
 
   return 0;

--- a/SRC/material/section/FiberSection3dThermal.h
+++ b/SRC/material/section/FiberSection3dThermal.h
@@ -47,8 +47,8 @@ class FiberSection3dThermal : public SectionForceDeformation
 {
   public:
     FiberSection3dThermal();
-    FiberSection3dThermal(int tag, int numFibers, Fiber **fibers);
-    FiberSection3dThermal(int tag, int numFibers);
+    FiberSection3dThermal(int tag, int numFibers, Fiber **fibers, bool compCentroid=true);
+    FiberSection3dThermal(int tag, int numFibers, bool compCentroid=true);
     ~FiberSection3dThermal();
 
     const char *getClassType(void) const {return "FiberSection3dThermal";};
@@ -105,7 +105,8 @@ class FiberSection3dThermal : public SectionForceDeformation
     double QzBar, QyBar, ABar;
     double yBar;       // Section centroid
     double zBar;
-
+    bool computeCentroid;
+    
     static ID code;
 
     Vector e;          // trial section deformations
@@ -113,18 +114,16 @@ class FiberSection3dThermal : public SectionForceDeformation
     Vector *s;         // section resisting forces  (axial force, bending moment)
     Matrix *ks;        // section stiffness
 
+    double   sTData[3];               //JZ data for s vector
+    Vector *sT;  // JZ  section resisting forces, caused by the temperature
+    //double  *TemperatureTangent; // JZ  the E of E*A*alpha*DeltaT
+    double *Fiber_T;  //An array storing the TempT of the fibers.
+    double *Fiber_TMax; //An array storing the TempTMax of the fibers.
+    
     // AddingSensitivity:BEGIN //////////////////////////////////////////
     int parameterID;
     Matrix *SHVs;
     // AddingSensitivity:END ///////////////////////////////////////////
-
-
-    double   sTData[3];               //JZ data for s vector
-	Vector *sT;  // JZ  section resisting forces, caused by the temperature
-	//double  *TemperatureTangent; // JZ  the E of E*A*alpha*DeltaT
-    double *Fiber_T;  //An array storing the TempT of the fibers.
-	double *Fiber_TMax; //An array storing the TempTMax of the fibers.
-
 };
 
 #endif

--- a/SRC/material/section/NDFiberSection2d.h
+++ b/SRC/material/section/NDFiberSection2d.h
@@ -46,10 +46,10 @@ class NDFiberSection2d : public SectionForceDeformation
 {
   public:
     NDFiberSection2d(); 
-    NDFiberSection2d(int tag, int numFibers, Fiber **fibers, double a = 1.0);
-    NDFiberSection2d(int tag, int numFibers, double a = 1.0);
+    NDFiberSection2d(int tag, int numFibers, Fiber **fibers, double a = 1.0, bool compCentroid=true);
+    NDFiberSection2d(int tag, int numFibers, double a = 1.0, bool compCentroid=true);
     NDFiberSection2d(int tag, int numFibers, NDMaterial **mats,
-		     SectionIntegration &si, double a = 1.0);
+		     SectionIntegration &si, double a = 1.0, bool compCentroid=true);
     ~NDFiberSection2d();
 
     const char *getClassType(void) const {return "NDFiberSection2d";};
@@ -102,6 +102,7 @@ class NDFiberSection2d : public SectionForceDeformation
     double   sData[3];               // data for s vector 
     
     double QzBar, Abar, yBar;       // Section centroid
+    bool computeCentroid;
     double alpha;      // Shear shape factor
 
     SectionIntegration *sectionIntegr;

--- a/SRC/material/section/NDFiberSection3d.h
+++ b/SRC/material/section/NDFiberSection3d.h
@@ -46,10 +46,10 @@ class NDFiberSection3d : public SectionForceDeformation
 {
   public:
     NDFiberSection3d(); 
-    NDFiberSection3d(int tag, int numFibers, Fiber **fibers, double a = 1.0);
-    NDFiberSection3d(int tag, int numFibers, double a = 1.0);
+    NDFiberSection3d(int tag, int numFibers, Fiber **fibers, double a = 1.0, bool compCentroid=true);
+    NDFiberSection3d(int tag, int numFibers, double a = 1.0, bool compCentroid=true);
     NDFiberSection3d(int tag, int numFibers, NDMaterial **mats,
-		     SectionIntegration &si, double a = 1.0);
+		     SectionIntegration &si, double a = 1.0, bool compCentroid=true);
     ~NDFiberSection3d();
 
     const char *getClassType(void) const {return "NDFiberSection3d";};
@@ -104,6 +104,7 @@ class NDFiberSection3d : public SectionForceDeformation
     double Abar,QyBar, QzBar;
     double yBar;       // Section centroid
     double zBar;       // Section centroid
+    bool computeCentroid;
     double alpha;      // Shear shape factor
 
     SectionIntegration *sectionIntegr;


### PR DESCRIPTION
Default is to compute the centroid (how it's always been)