### PR TITLE
Correct PartitionedDomain::partition 

### DIFF
--- a/SRC/domain/domain/partitioned/PartitionedDomain.cpp
+++ b/SRC/domain/domain/partitioned/PartitionedDomain.cpp
@@ -1498,7 +1498,7 @@ PartitionedDomain::partition(int numPartitions, bool usingMain, int mainPartitio
   Graph &theEleGraph = this->getElementGraph();
 
   // now we call partition on the domainPartitioner which does the partitioning
-  DomainPartitioner *thePartitioner = 0;//this->getPartitioner();
+  DomainPartitioner *thePartitioner = this->getPartitioner();
   if (thePartitioner != 0) {
     thePartitioner->setPartitionedDomain(*this);
     result =  thePartitioner->partition(numPartitions, usingMain, mainPartitionID, specialElementTag);


### PR DESCRIPTION
Correcting erroneous commenting of `getPartitioner`. This issue was brought up in follow up discussion from #467, and fixed, among other unmerged commits, in #522. This was also the cause of one issue I faced when compiling OpenSeesSP on a new HPC machine (#545).  