### PR TITLE
Added ndm and ndf utility commands

### DIFF
--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -811,6 +811,11 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
     Tcl_CreateObjCommand(interp, "source", &OPS_SourceCmd,
 			 (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL); 
 
+    Tcl_CreateCommand(interp, "ndm", &ndm,
+        (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
+    Tcl_CreateCommand(interp, "ndf", &ndf,
+        (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
+
     Tcl_CreateCommand(interp, "wipe", &wipeModel,
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL); 
 
@@ -6681,6 +6686,73 @@ updateElementDomain(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Cha
     }
 
 	return 0;
+}
+
+int
+ndm(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+{
+    int ndm;
+
+    if (argc > 1) {
+        int tag;
+        if (Tcl_GetInt(interp, argv[1], &tag) != TCL_OK) {
+            opserr << "WARNING ndm nodeTag? \n";
+            return TCL_ERROR;
+        }
+        Node* theNode = theDomain.getNode(tag);
+        if (theNode == 0) {
+            opserr << "WARNING nodeTag " << tag << " does not exist \n";
+            return TCL_ERROR;
+        }
+        const Vector& coords = theNode->getCrds();
+        ndm = coords.Size();
+    } else {
+        if (theBuilder == 0) {
+            return TCL_OK;
+        }
+        else {
+            ndm = OPS_GetNDM();
+        }
+    }
+
+    char buffer[20];
+    sprintf(buffer, "%d", ndm);
+    Tcl_AppendResult(interp, buffer, NULL);
+
+    return TCL_OK;
+}
+
+int
+ndf(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+{
+    int ndf;
+
+    if (argc > 1) {
+        int tag;
+        if (Tcl_GetInt(interp, argv[1], &tag) != TCL_OK) {
+            opserr << "WARNING ndf nodeTag? \n";
+            return TCL_ERROR;
+        }
+        Node* theNode = theDomain.getNode(tag);
+        if (theNode == 0) {
+            opserr << "WARNING nodeTag " << tag << " does not exist \n";
+            return TCL_ERROR;
+        }
+        ndf = theNode->getNumberDOF();
+    } else {
+        if (theBuilder == 0) {
+            return TCL_OK;
+        }
+        else {
+            ndf = OPS_GetNDF();
+        }
+    }
+
+    char buffer[20];
+    sprintf(buffer, "%d", ndf);
+    Tcl_AppendResult(interp, buffer, NULL);
+
+    return TCL_OK;
 }
 
 int 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -811,9 +811,9 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
     Tcl_CreateObjCommand(interp, "source", &OPS_SourceCmd,
 			 (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL); 
 
-    Tcl_CreateCommand(interp, "ndm", &ndm,
+    Tcl_CreateCommand(interp, "getNDM", &getNDM,
         (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
-    Tcl_CreateCommand(interp, "ndf", &ndf,
+    Tcl_CreateCommand(interp, "getNDF", &getNDF,
         (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
 
     Tcl_CreateCommand(interp, "wipe", &wipeModel,
@@ -6689,7 +6689,7 @@ updateElementDomain(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Cha
 }
 
 int
-ndm(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+getNDM(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
 {
     int ndm;
 
@@ -6723,7 +6723,7 @@ ndm(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
 }
 
 int
-ndf(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+getNDF(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
 {
     int ndf;
 

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -48,10 +48,10 @@ int
 OPS_SourceCmd(ClientData clientData, Tcl_Interp *interp, int argc, Tcl_Obj * const *argv);
 
 int
-ndm(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+getNDM(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
 
 int
-ndf(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+getNDF(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
 
 int 
 wipeModel(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -47,6 +47,12 @@ OPS_SetObjCmd(ClientData clientData, Tcl_Interp *interp, int argc, Tcl_Obj * con
 int
 OPS_SourceCmd(ClientData clientData, Tcl_Interp *interp, int argc, Tcl_Obj * const *argv);
 
+int
+ndm(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+ndf(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
 int 
 wipeModel(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 


### PR DESCRIPTION
Utility commands for getting the input ndm and input ndf, as well as the nodal ndm and ndf. Syntax:
getNDM<$nodeTag>
getNDF<$nodeTag>
If the nodeTag argument is provided, it will return the nodal dimensions/degrees of freedom, or throw an error if the node does not exist.
If the nodeTag argument is not provided, it will return the input ndm/ndf, or the blank string if the model builder is undefined.