### PR TITLE
Added nodeDist, utility distance calculator

### DIFF
--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -169,6 +169,9 @@ nodeCoord(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 int 
 setNodeCoord(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
+int
+nodeDist(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
 int 
 updateElementDomain(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 


### PR DESCRIPTION
Computes the distance between two nodes, or optionally the signed distance in a specific dimension.
Syntax:
nodeDist $iNode $jNode <$dim>
e.g.
node 1 0 0
node 2 3 4
nodeDist 1 2 -> 5
nodeDist 1 2 1 -> 3
nodeDist 1 2 2 -> 4
nodeDist 2 1 1 -> -3
nodeDist 2 1 2 -> -4

This function, while not providing any information that you couldn't get with nodeCoord, is a convenience in cases where the length of an element is needed (e.g. defining plastic hinge length as proportion of element length)