### PR TITLE
Constraints utility commands

### DIFF
--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -6653,19 +6653,22 @@ fixedNodes(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
     SP_Constraint* theSP;
     SP_ConstraintIter& spIter = theDomain.getDomainAndLoadPatternSPs();
 
-    char buffer[20];
-
+    // get unique constrained nodes with set
+    set<int> tags;
     int tag;
-    int count = 0;
-    int lastTag;
     while ((theSP = spIter()) != 0) {
         tag = theSP->getNodeTag();
-        if (count == 0 || tag != lastTag) {
-            sprintf(buffer, "%d ", tag);
-            Tcl_AppendResult(interp, buffer, NULL);
-        }
-        count += 1;
-        lastTag = tag;
+        tags.insert(tag);
+    }
+    // assign set to vector and sort
+    vector<int> tagv;
+    tagv.assign(tags.begin(), tags.end());
+    sort(tagv.begin(), tagv.end());
+    // loop through unique, sorted tags, adding to output
+    char buffer[20];
+    for (int tag : tagv) {
+        sprintf(buffer, "%d ", tag);
+        Tcl_AppendResult(interp, buffer, NULL);
     }
 
     return TCL_OK;
@@ -6689,7 +6692,7 @@ fixedDOFs(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
     SP_ConstraintIter& spIter = theDomain.getDomainAndLoadPatternSPs();
 
     int tag;
-    static Vector fixed(6);
+    Vector fixed(6);
     while ((theSP = spIter()) != 0) {
         tag = theSP->getNodeTag();
         if (tag == fNode) {
@@ -6750,7 +6753,6 @@ constrainedNodes(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char**
 int
 constrainedDOFs(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
 {
-
     if (argc < 2) {
         opserr << "WARNING want - constrainedDOFs cNode? <rNode?>\n";
         return TCL_ERROR;

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -205,6 +205,24 @@ getNodeTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv
 int 
 getEleTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
+int
+fixedNodes(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+fixedDOFs(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+constrainedNodes(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+constrainedDOFs(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+retainedNodes(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
+int
+retainedDOFs(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+
 int 
 nodeDOFs(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 


### PR DESCRIPTION
Six commands added:
fixedNodes, fixedDOFs, constrainedNodes, constrainedDOFs, retainedNodes, retainedDOFs.
These are especially useful for trouble-shooting SP/MP conflicts.
Syntax:
fixedNodes; # all nodes with fixities
fixedDOFs $fNode; # all fixed dofs at fixed node
constrainedNodes <$rNode>; # all constrained nodes, optionally from specific node
constrainedDOFs $cNode <$rNode> <$rDOF>; # all constrained dofs at a node, optionally from specific node/dof
retainedNodes <$cNode>; # all retained nodes, optionally to specific node
retainedDOFs $rNode <$cNode> <$cDOF>; # all retained DOFs, optionally to specific node/dof

Example Tcl script to check for MP/SP conflicts:
foreach nodeTag [fixedNodes] {
    set fDOFs [fixedDOFs $nodeTag]
    set cDOFs [constrainedDOFs $nodeTag]
    foreach dof $fDOFs {
        if {$dof in $cDOFs} {
            puts "Node $nodeTag is fixed and constrained at dof $dof"
        }
    }
}

Additionally, it can be used to get all the fixed nodes in a certain direction (for reaction recorders):
foreach nodeTag [fixedNodes] {
    foreach dof [fixedDOFs $nodeTag] {
        switch $dof {
            1 {lappend xNodes $nodeTag}
            2 {lappend yNodes $nodeTag}
            3 {lappend zNodes $nodeTag}
        }
    }
}