### PR TITLE
Added better mixed MP command

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -393,6 +393,7 @@ int OPS_Node();
 int OPS_HomogeneousBC();
 int OPS_EqualDOF();
 int OPS_EqualDOF_Mixed();
+int OPS_MixedEqualDOF();
 int OPS_HomogeneousBC_X();
 int OPS_HomogeneousBC_Y();
 int OPS_HomogeneousBC_Z();

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1692,6 +1692,18 @@ static PyObject *Py_ops_equalDOF_Mixed(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject* Py_ops_mixedEqualDOF(PyObject* self, PyObject* args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_MixedEqualDOF() < 0) {
+        opserr << (void*)0;
+        return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_rigidLink(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2356,6 +2368,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("imposedSupportMotion", &Py_ops_imposedMotion);
     addCommand("groundMotion", &Py_ops_groundMotion);
     addCommand("equalDOF_Mixed", &Py_ops_equalDOF_Mixed);
+    addCommand("mixedEqualDOF", &Py_ops_mixedEqualDOF);
     addCommand("rigidLink", &Py_ops_rigidLink);
     addCommand("rigidDiaphragm", &Py_ops_rigidDiaphragm);
     addCommand("ShallowFoundationGen", &Py_ops_ShallowFoundationGen);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1093,6 +1093,14 @@ static int Tcl_ops_equalDOF_Mixed(ClientData clientData, Tcl_Interp *interp, int
     return TCL_OK;
 }
 
+static int Tcl_ops_mixedEqualDOF(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv) {
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_MixedEqualDOF() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_rigidLink(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv) {
     wrapper->resetCommandLine(argc, 1, argv);
 
@@ -1628,6 +1636,7 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"imposedSupportMotion", &Tcl_ops_imposedMotion);
     addCommand(interp,"groundMotion", &Tcl_ops_groundMotion);
     addCommand(interp,"equalDOF_Mixed", &Tcl_ops_equalDOF_Mixed);
+    addCommand(interp,"mixedEqualDOF", &Tcl_ops_mixedEqualDOF);
     addCommand(interp,"rigidLink", &Tcl_ops_rigidLink);
     addCommand(interp,"rigidDiaphragm", &Tcl_ops_rigidDiaphragm);
     addCommand(interp,"ShallowFoundationGen", &Tcl_ops_ShallowFoundationGen);


### PR DESCRIPTION
Added mixedEqualDOF MP constraint command.
The current command to make a mixed MP constraint has rather cumbersome syntax. I am proposing to make a new command with better syntax to replace the equalDOF_Mixed command (while keeping the old command for backwards compatibility)

Current mixed MP syntax:
equalDOF_Mixed $rNode $cNode $numDOF $rDOF1 $cDOF1 $rDOF2 $cDOF2 ... ...
Proposed:
mixedEqualDOF $rNode $cNode $rDOF1 $cDOF1 $rDOF2 $cDOF2 ... ...

The main difference is the elimination of the redundant $numDOF argument, which can simply be calculated with integer division when parsing the command. Additionally, I think the proposed command name is cleaner.