### PR TITLE
Element load output commands

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -282,6 +282,7 @@ int OPS_sensLambda();
 int OPS_sensSectionForce();
 int OPS_sensNodePressure();
 int OPS_getNumElements();
+int OPS_getEleClassTags();
 int OPS_getEleLoadClassTags();
 int OPS_getEleLoadTags();
 int OPS_getEleLoadData();

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -281,6 +281,10 @@ int OPS_sensNodeAccel();
 int OPS_sensLambda();
 int OPS_sensSectionForce();
 int OPS_sensNodePressure();
+int OPS_getNumElements();
+int OPS_getEleLoadClassTags();
+int OPS_getEleLoadTags();
+int OPS_getEleLoadData();
 // Sensitivity:END /////////////////////////////////////////////
 
 /* OpenSeesMiscCommands.cpp */

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -45,6 +45,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <DOF_Group.h>
 #include <Matrix.h>
 #include <LoadPattern.h>
+#include <LoadPatternIter.h>
 #include <FileStream.h>
 #include <ID.h>
 // #include <TaggedObject.h>
@@ -3161,27 +3162,44 @@ int OPS_getEleLoadClassTags()
     if (theDomain == 0) return -1;
 
     int numdata = OPS_GetNumRemainingInputArgs();
-    if (numdata < 1) {
-	opserr << "WARNING want - getEleLoadClassTags patternTag?\n";
-	return -1;
-    }
-
-    int patternTag;
-    numdata = 1;
-    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
-	opserr << "could not read patternTag\n";
-	return -1;
-    }
-
-	LoadPattern *thePattern = theDomain->getLoadPattern(patternTag);
-	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
-	ElementalLoad* theLoad;
 
 	std::vector <int> data;
 
-	while ((theLoad = theEleLoads()) != 0) {
-	  data.push_back(theLoad->getClassTag());
-	}
+    if (numdata < 1) {
+	  LoadPattern *thePattern;
+	  LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
+
+	  while ((thePattern = thePatterns()) != 0) {
+		ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+		ElementalLoad* theLoad;
+
+		while ((theLoad = theEleLoads()) != 0) {
+		  data.push_back(theLoad->getClassTag());
+		}
+
+	  }
+
+	} else if (numdata == 1) {
+
+	  int patternTag;
+	  if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+		opserr << "could not read patternTag\n";
+		return -1;
+	  }
+
+	  LoadPattern *thePattern = theDomain->getLoadPattern(patternTag);
+	  ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad* theLoad;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		data.push_back(theLoad->getClassTag());
+	  }
+
+	} else {
+	opserr << "WARNING want - getEleLoadClassTags <patternTag?>\n";
+	return -1;
+    }
+
 
 	int size = data.size();
 
@@ -3199,27 +3217,43 @@ int OPS_getEleLoadTags()
     if (theDomain == 0) return -1;
 
     int numdata = OPS_GetNumRemainingInputArgs();
-    if (numdata < 1) {
-	opserr << "WARNING want - getEleLoadTags patternTag?\n";
-	return -1;
-    }
-
-    int patternTag;
-    numdata = 1;
-    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
-	opserr << "could not read patternTag\n";
-	return -1;
-    }
-
-	LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
-	ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
-	ElementalLoad* theLoad;
 
 	std::vector <int> data;
 
-	while ((theLoad = theEleLoads()) != 0) {
-	  data.push_back(theLoad->getElementTag());
-	}
+    if (numdata < 1) {
+	  LoadPattern *thePattern;
+	  LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
+
+	  while ((thePattern = thePatterns()) != 0) {
+		ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+		ElementalLoad* theLoad;
+
+		while ((theLoad = theEleLoads()) != 0) {
+		  data.push_back(theLoad->getElementTag());
+		}
+
+	  }
+
+	} else if (numdata == 1) {
+
+	  int patternTag;
+	  if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+		opserr << "could not read patternTag\n";
+		return -1;
+	  }
+
+	  LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	  ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad* theLoad;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		data.push_back(theLoad->getElementTag());
+	  }
+
+	} else {
+	opserr << "WARNING want - getEleLoadTags <patternTag?>\n";
+	return -1;
+    }
 
 	int size = data.size();
 
@@ -3237,34 +3271,56 @@ int OPS_getEleLoadData()
     if (theDomain == 0) return -1;
 
     int numdata = OPS_GetNumRemainingInputArgs();
-    if (numdata < 1) {
-	opserr << "WARNING want - getEleLoadData patternTag?\n";
-	return -1;
-    }
-
-    int patternTag;
-    numdata = 1;
-    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
-	opserr << "could not read patternTag\n";
-	return -1;
-    }
-
-	LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
-	ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
-	ElementalLoad* theLoad;
 
 	std::vector <double> data;
 
-	int typeEL;
+    if (numdata < 1) {
+	  LoadPattern *thePattern;
+	  LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
 
-	while ((theLoad = theEleLoads()) != 0) {
-	  const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+	  int typeEL;
+	  
+	  while ((thePattern = thePatterns()) != 0) {
+		ElementalLoadIter &theEleLoads = thePattern->getElementalLoads();
+		ElementalLoad* theLoad;
 
-	  int eleLoadDataSize = eleLoadData.Size();
-	  for (int i = 0; i < eleLoadDataSize; i++) {
-		data.push_back(eleLoadData(i));
+		while ((theLoad = theEleLoads()) != 0) {
+		  const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+
+		  int eleLoadDataSize = eleLoadData.Size();
+		  for (int i = 0; i < eleLoadDataSize; i++) {
+			data.push_back(eleLoadData(i));
+		  }
+		}
 	  }
-	}
+
+	} else if (numdata == 1) {
+
+	  int patternTag;
+	  if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+		opserr << "could not read patternTag\n";
+		return -1;
+	  }
+
+	  LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	  ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad* theLoad;
+
+	  int typeEL;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+
+		int eleLoadDataSize = eleLoadData.Size();
+		for (int i = 0; i < eleLoadDataSize; i++) {
+		  data.push_back(eleLoadData(i));
+		}
+	  }
+
+	} else {
+	opserr << "WARNING want - getEleLoadData <patternTag?>\n";
+	return -1;
+    }
 
 	int size = data.size();
 

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -3109,6 +3109,52 @@ int OPS_sensNodePressure()
     return 0;
 }
 
+int OPS_getEleClassTags()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+
+	std::vector <int> data;
+
+	// all element tags
+    if (numdata < 1) {
+	  Element *theEle;
+	  ElementIter &theEles = theDomain->getElements();
+
+	  while ((theEle = theEles()) != 0) {
+		data.push_back(theEle->getClassTag());
+	  }
+
+	  // specific element tag
+    } else if (numdata == 1) {
+	  int eleTag;
+
+	  if (OPS_GetIntInput(&numdata, &eleTag) < 0) {
+		opserr << "could not read eleTag\n";
+		return -1;
+	  }
+
+	  Element *theEle = theDomain->getElement(eleTag);
+
+	  data.push_back(theEle->getClassTag());
+
+	} else {
+	  opserr << "WARNING want - getEleClassTags <eleTag?>\n";
+	  return -1;
+    }
+
+	int size = data.size();
+
+	if (OPS_SetIntOutput(&size, data.data(), false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
 int OPS_getEleLoadClassTags()
 {
     Domain* theDomain = OPS_GetDomain();
@@ -3116,7 +3162,7 @@ int OPS_getEleLoadClassTags()
 
     int numdata = OPS_GetNumRemainingInputArgs();
     if (numdata < 1) {
-	opserr << "WARNING want - getEleLoadTags patternTag?\n";
+	opserr << "WARNING want - getEleLoadClassTags patternTag?\n";
 	return -1;
     }
 

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -48,10 +48,6 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <LoadPatternIter.h>
 #include <FileStream.h>
 #include <ID.h>
-// #include <TaggedObject.h>
-// #include <TaggedObjectIter.h>
-// #include <TaggedObjectStorage.h>
-// #include <MapOfTaggedObjects.h>
 #include <ElementalLoad.h>
 #include <ElementalLoadIter.h>
 #include <Element.h>
@@ -3188,6 +3184,10 @@ int OPS_getEleLoadClassTags()
 	  }
 
 	  LoadPattern *thePattern = theDomain->getLoadPattern(patternTag);
+	  if (thePattern == nullptr) {
+		opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadClassTags\n";
+		return -1;
+	  }
 	  ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
 	  ElementalLoad* theLoad;
 
@@ -3243,6 +3243,10 @@ int OPS_getEleLoadTags()
 	  }
 
 	  LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	  if (thePattern == nullptr) {
+		opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadTags\n";
+		return -1;
+	  }
 	  ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
 	  ElementalLoad* theLoad;
 
@@ -3279,7 +3283,7 @@ int OPS_getEleLoadData()
 	  LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
 
 	  int typeEL;
-	  
+
 	  while ((thePattern = thePatterns()) != 0) {
 		ElementalLoadIter &theEleLoads = thePattern->getElementalLoads();
 		ElementalLoad* theLoad;
@@ -3303,6 +3307,10 @@ int OPS_getEleLoadData()
 	  }
 
 	  LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	  if (thePattern == nullptr) {
+		opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadData\n";
+		return -1;
+	  }
 	  ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
 	  ElementalLoad* theLoad;
 

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -47,6 +47,12 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <LoadPattern.h>
 #include <FileStream.h>
 #include <ID.h>
+// #include <TaggedObject.h>
+// #include <TaggedObjectIter.h>
+// #include <TaggedObjectStorage.h>
+// #include <MapOfTaggedObjects.h>
+#include <ElementalLoad.h>
+#include <ElementalLoadIter.h>
 #include <Element.h>
 #include <ElementIter.h>
 #include <map>
@@ -3099,6 +3105,143 @@ int OPS_sensNodePressure()
 	opserr<<"WARNING failed to set output\n";
 	return -1;
     }
+
+    return 0;
+}
+
+int OPS_getEleLoadClassTags()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 1) {
+	opserr << "WARNING want - getEleLoadTags patternTag?\n";
+	return -1;
+    }
+
+    int patternTag;
+    numdata = 1;
+    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+	opserr << "could not read patternTag\n";
+	return -1;
+    }
+
+	LoadPattern *thePattern = theDomain->getLoadPattern(patternTag);
+	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	std::vector <int> data;
+
+	while ((theLoad = theEleLoads()) != 0) {
+	  data.push_back(theLoad->getClassTag());
+	}
+
+	int size = data.size();
+
+	if (OPS_SetIntOutput(&size, data.data(), false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
+int OPS_getEleLoadTags()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 1) {
+	opserr << "WARNING want - getEleLoadTags patternTag?\n";
+	return -1;
+    }
+
+    int patternTag;
+    numdata = 1;
+    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+	opserr << "could not read patternTag\n";
+	return -1;
+    }
+
+	LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	std::vector <int> data;
+
+	while ((theLoad = theEleLoads()) != 0) {
+	  data.push_back(theLoad->getElementTag());
+	}
+
+	int size = data.size();
+
+	if (OPS_SetIntOutput(&size, data.data(), false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
+int OPS_getEleLoadData()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+    if (numdata < 1) {
+	opserr << "WARNING want - getEleLoadData patternTag?\n";
+	return -1;
+    }
+
+    int patternTag;
+    numdata = 1;
+    if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+	opserr << "could not read patternTag\n";
+	return -1;
+    }
+
+	LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	ElementalLoadIter& theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	std::vector <double> data;
+
+	int typeEL;
+
+	while ((theLoad = theEleLoads()) != 0) {
+	  const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+
+	  int eleLoadDataSize = eleLoadData.Size();
+	  for (int i = 0; i < eleLoadDataSize; i++) {
+		data.push_back(eleLoadData(i));
+	  }
+	}
+
+	int size = data.size();
+
+	if (OPS_SetDoubleOutput(&size, data.data(), false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
+int OPS_getNumElements()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+	int nEles = theDomain->getNumElements();
+	int size = 1;
+
+	if (OPS_SetIntOutput(&size, &nEles, false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
 
     return 0;
 }

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1992,6 +1992,54 @@ static PyObject *Py_ops_sensNodePressure(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getNumElements(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getNumElements() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
+static PyObject *Py_ops_getEleLoadClassTags(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getEleLoadClassTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
+static PyObject *Py_ops_getEleLoadTags(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getEleLoadTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
+static PyObject *Py_ops_getEleLoadData(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getEleLoadData() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_randomVariable(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2381,6 +2429,10 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("sensLambda", &Py_ops_sensLambda);
     addCommand("sensSectionForce", &Py_ops_sensSectionForce);
     addCommand("sensNodePressure", &Py_ops_sensNodePressure);
+    addCommand("getNumElements", &Py_ops_getNumElements);
+    addCommand("getEleLoadClassTags", &Py_ops_getEleLoadClassTags);
+    addCommand("getEleLoadTags", &Py_ops_getEleLoadTags);
+    addCommand("getEleLoadData", &Py_ops_getEleLoadData);
     addCommand("randomVariable", &Py_ops_randomVariable);
     addCommand("getRVTags", &Py_ops_getRVTags);
     addCommand("getMean", &Py_ops_getRVMean);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -2004,6 +2004,18 @@ static PyObject *Py_ops_getNumElements(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getEleClassTags(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getEleClassTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_getEleLoadClassTags(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2430,6 +2442,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("sensSectionForce", &Py_ops_sensSectionForce);
     addCommand("sensNodePressure", &Py_ops_sensNodePressure);
     addCommand("getNumElements", &Py_ops_getNumElements);
+    addCommand("getEleClassTags", &Py_ops_getEleClassTags);
     addCommand("getEleLoadClassTags", &Py_ops_getEleLoadClassTags);
     addCommand("getEleLoadTags", &Py_ops_getEleLoadTags);
     addCommand("getEleLoadData", &Py_ops_getEleLoadData);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1308,6 +1308,42 @@ static int Tcl_ops_sensNodePressure(ClientData clientData, Tcl_Interp *interp, i
     return TCL_OK;
 }
 
+static int Tcl_ops_getNumElements(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getNumElements() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
+static int Tcl_ops_getEleLoadClassTags(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getEleLoadClassTags() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
+static int Tcl_ops_getEleLoadTags(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getEleLoadTags() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
+static int Tcl_ops_getEleLoadData(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getEleLoadData() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_randomVariable(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
 {
     wrapper->resetCommandLine(argc, 1, argv);
@@ -1653,6 +1689,10 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"sensLambda", &Tcl_ops_sensLambda);
     addCommand(interp,"sensSectionForce", &Tcl_ops_sensSectionForce);
     addCommand(interp,"sensNodePressure", &Tcl_ops_sensNodePressure);
+    addCommand(interp,"getNumElements", &Tcl_ops_getNumElements);
+    addCommand(interp,"getEleLoadClassTags", &Tcl_ops_getEleLoadClassTags);
+    addCommand(interp,"getEleLoadTags", &Tcl_ops_getEleLoadTags);
+    addCommand(interp,"getEleLoadData", &Tcl_ops_getEleLoadData);
     addCommand(interp,"randomVariable", &Tcl_ops_randomVariable);
     addCommand(interp,"getRVTags", &Tcl_ops_getRVTags);
     addCommand(interp,"getMean", &Tcl_ops_getRVMean);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1317,6 +1317,15 @@ static int Tcl_ops_getNumElements(ClientData clientData, Tcl_Interp *interp, int
     return TCL_OK;
 }
 
+static int Tcl_ops_getEleClassTags(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getEleClassTags() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_getEleLoadClassTags(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
 {
     wrapper->resetCommandLine(argc, 1, argv);
@@ -1690,6 +1699,7 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"sensSectionForce", &Tcl_ops_sensSectionForce);
     addCommand(interp,"sensNodePressure", &Tcl_ops_sensNodePressure);
     addCommand(interp,"getNumElements", &Tcl_ops_getNumElements);
+    addCommand(interp,"getEleClassTags", &Tcl_ops_getEleClassTags);
     addCommand(interp,"getEleLoadClassTags", &Tcl_ops_getEleLoadClassTags);
     addCommand(interp,"getEleLoadTags", &Tcl_ops_getEleLoadTags);
     addCommand(interp,"getEleLoadData", &Tcl_ops_getEleLoadData);

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -8544,11 +8544,16 @@ getEleLoadClassTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Cha
 	int patternTag;
 
 	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
-	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  opserr << "WARNING getEleLoadClassTags -- could not read patternTag\n";
 	  return TCL_ERROR;
 	}
 
 	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+    if (thePattern == nullptr) {
+	  opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadClassTags\n";
+	  return TCL_ERROR;
+	}
+
 	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
 	ElementalLoad* theLoad;
 
@@ -8591,11 +8596,16 @@ getEleLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **a
 	int patternTag;
 
 	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
-	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  opserr << "WARNING getEleLoadTags -- could not read patternTag \n";
 	  return TCL_ERROR;
 	}
 
 	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+    if (thePattern == nullptr) {
+	  opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadTags\n";
+	  return TCL_ERROR;
+	}
+
 	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
 	ElementalLoad* theLoad;
 
@@ -8645,11 +8655,16 @@ getEleLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **a
 	int patternTag;
 
 	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
-	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  opserr << "WARNING getEleLoadData -- could not read patternTag \n";
 	  return TCL_ERROR;
 	}
 
 	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+    if (thePattern == nullptr) {
+	  opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getEleLoadData\n";
+	  return TCL_ERROR;
+	}
+
 	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
 	ElementalLoad* theLoad;
 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -990,6 +990,17 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
     Tcl_CreateCommand(interp, "getParamValue", &getParamValue, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
 
+    Tcl_CreateCommand(interp, "getNumElements", &getNumElements, 
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+    Tcl_CreateCommand(interp, "getEleClassTags", &getEleClassTags, 
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+    Tcl_CreateCommand(interp, "getEleLoadClassTags", &getEleLoadClassTags, 
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+    Tcl_CreateCommand(interp, "getEleLoadTags", &getEleLoadTags, 
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+    Tcl_CreateCommand(interp, "getEleLoadData", &getEleLoadData, 
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+
     Tcl_CreateCommand(interp, "sdfResponse", &sdfResponse, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
 
@@ -8457,6 +8468,211 @@ getNP(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
   Tcl_SetResult(interp, buffer, TCL_VOLATILE);
 
   return TCL_OK;  
+}
+
+// sewi
+int
+getNumElements(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+  char buffer[20];
+
+  sprintf(buffer, "%d ", theDomain.getNumElements());
+  Tcl_AppendResult(interp, buffer, NULL);
+
+  return TCL_OK;
+}
+
+// sewi
+int
+getEleClassTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+
+  if (argc == 1) {
+	Element *theEle;
+	ElementIter &eleIter = theDomain.getElements();
+
+	char buffer[20];
+
+        while ((theEle = eleIter()) != 0) {
+          sprintf(buffer, "%d ", theEle->getClassTag());
+          Tcl_AppendResult(interp, buffer, NULL);
+        }
+  } else if (argc == 2) {
+	int eleTag;
+
+	if (Tcl_GetInt(interp, argv[1], &eleTag) != TCL_OK) {
+	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  return TCL_ERROR;
+	}
+
+	Element *theEle = theDomain.getElement(eleTag);
+
+	char buffer[20];
+
+	sprintf(buffer, "%d ", theEle->getClassTag());
+	Tcl_AppendResult(interp, buffer, NULL);
+
+  } else {
+    opserr << "WARNING want - getEleClassTags <eleTag?>\n" << endln;
+    return TCL_ERROR;
+  }
+
+  return TCL_OK;
+}
+
+int
+getEleLoadClassTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+
+  if (argc == 1) {
+	LoadPattern *thePattern;
+	LoadPatternIter &thePatterns = theDomain.getLoadPatterns();
+
+	char buffer[20];
+
+	while ((thePattern = thePatterns()) != 0) {
+	  ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad *theLoad;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		sprintf(buffer, "%d ", theLoad->getClassTag());
+		Tcl_AppendResult(interp, buffer, NULL);
+	  }
+	}
+
+  } else if (argc == 2) {
+	int patternTag;
+
+	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
+	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  return TCL_ERROR;
+	}
+
+	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	char buffer[20];
+
+	while ((theLoad = theEleLoads()) != 0) {
+	  sprintf(buffer, "%d ", theLoad->getClassTag());
+	  Tcl_AppendResult(interp, buffer, NULL);
+	}
+
+  } else {
+    opserr << "WARNING want - getEleLoadClassTags <patternTag?>\n" << endln;
+    return TCL_ERROR;
+  }
+
+  return TCL_OK;
+}
+
+int
+getEleLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+
+  if (argc == 1) {
+	LoadPattern *thePattern;
+	LoadPatternIter &thePatterns = theDomain.getLoadPatterns();
+
+	char buffer[20];
+
+	while ((thePattern = thePatterns()) != 0) {
+	  ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad *theLoad;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		sprintf(buffer, "%d ", theLoad->getElementTag());
+		Tcl_AppendResult(interp, buffer, NULL);
+	  }
+	}
+
+  } else if (argc == 2) {
+	int patternTag;
+
+	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
+	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  return TCL_ERROR;
+	}
+
+	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	char buffer[20];
+
+	while ((theLoad = theEleLoads()) != 0) {
+	  sprintf(buffer, "%d ", theLoad->getElementTag());
+	  Tcl_AppendResult(interp, buffer, NULL);
+	}
+
+  } else {
+    opserr << "WARNING want - getEleLoadTags <patternTag?>\n" << endln;
+    return TCL_ERROR;
+  }
+
+  return TCL_OK;
+}
+
+int
+getEleLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+
+  if (argc == 1) {
+	LoadPattern *thePattern;
+	LoadPatternIter &thePatterns = theDomain.getLoadPatterns();
+
+	char buffer[40];
+	int typeEL;
+
+	while ((thePattern = thePatterns()) != 0) {
+	  ElementalLoadIter &theEleLoads = thePattern->getElementalLoads();
+	  ElementalLoad *theLoad;
+
+	  while ((theLoad = theEleLoads()) != 0) {
+		const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+
+		int eleLoadDataSize = eleLoadData.Size();
+		opserr << "eleLoadDataSize: "<< eleLoadDataSize << "\n";
+		for (int i = 0; i < eleLoadDataSize; i++) {
+		  sprintf(buffer, "%35.20f ", eleLoadData(i));
+		  Tcl_AppendResult(interp, buffer, NULL);
+		}
+	  }
+	}
+
+  } else if (argc == 2) {
+	int patternTag;
+
+	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
+	  opserr << "WARNING getParamValue -- could not read paramTag \n";
+	  return TCL_ERROR;
+	}
+
+	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+	ElementalLoadIter theEleLoads = thePattern->getElementalLoads();
+	ElementalLoad* theLoad;
+
+	int typeEL;
+	char buffer[40];
+
+	while ((theLoad = theEleLoads()) != 0) {
+		const Vector &eleLoadData = theLoad->getData(typeEL, 1.0);
+
+		int eleLoadDataSize = eleLoadData.Size();
+		for (int i = 0; i < eleLoadDataSize; i++) {
+		  sprintf(buffer, "%35.20f ", eleLoadData(i));
+		  Tcl_AppendResult(interp, buffer, NULL);
+		}
+
+	}
+
+  } else {
+    opserr << "WARNING want - getEleLoadTags <patternTag?>\n" << endln;
+    return TCL_ERROR;
+  }
+
+  return TCL_OK;
 }
 
 int

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -254,6 +254,20 @@ int
 sensitivityIntegrator(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 // AddingSensitivity:END ///////////////////////////////////////////////////
 
+int 
+getNumElements(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
+getEleClassTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
+getEleLoadClassTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
+getEleLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
+getEleLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 
 startTimer(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);


### PR DESCRIPTION
This PR adds a few utility commands which will be helpful for OpenSeesPy plotting module.
For now ops_vis module requires specifying the element load information in the plotting commands which can be different from the actual element load data in the domain. The commands uses unique class tags for elements and element loads specified in `OpenSees/SRC/classTags.h `


The new output commands and examples of usage are:
```
nEles = ops.getNumElements()

# zero or one ele_tag only
ele_classtag = ops.getEleClassTags(1)
ele_classtags = ops.getEleClassTags()

ele_load_classtags = ops.getEleLoadClassTags(1)
ele_load_classtags_all_patterns = ops.getEleLoadClassTags()
# error if pattern_tag does not exist
# ele_load_classtags = ops.getEleLoadClassTags(3)

ele_load_tags = ops.getEleLoadTags(1)
ele_load_tags_all_patterns = ops.getEleLoadTags()

ele_load_data = ops.getEleLoadData(1)
ele_load_data_all_patterns = ops.getEleLoadData()
```

The example output would be:
```
nEles: 2
ele_classtag: 3
ele_classtags: [3, 3]
ele_load_classtags: [3, 12]
ele_load_classtags_all_patterns: [3, 12, 4]
ele_load_tags: [1, 2]
ele_load_tags_all_patterns: [1, 2, 2]
ele_load_data:
[-4.0, 0.0, -3.0, -7.0, 1.1, 1.9, 0.1, 0.9]
ele_load_data_all_patterns:
[-4.0, 0.0, -3.0, -7.0, 1.1, 1.9, 0.1, 0.9, -7.0, 0.0, 0.5]
```

Please review it and consider it for merging.