### PR TITLE
Commit strain commands for material/section model builders

### DIFF
--- a/SRC/modelbuilder/tcl/TclPlaneStressMaterialTester.cpp
+++ b/SRC/modelbuilder/tcl/TclPlaneStressMaterialTester.cpp
@@ -60,6 +60,11 @@ int  TclPlaneStressMaterialTester_setStrainPlaneStressMaterial(ClientData client
 							       int argc,   
 							       TCL_Char **argv);
 
+int  TclPlaneStressMaterialTester_commitStrainPlaneStressMaterial(ClientData clientData,
+    Tcl_Interp* interp,
+    int argc,
+    TCL_Char** argv);
+
 int  TclPlaneStressMaterialTester_getStressPlaneStressMaterial(ClientData clientData,
 							       Tcl_Interp *interp,
 							       int argc,
@@ -91,6 +96,9 @@ TclPlaneStressMaterialTester::TclPlaneStressMaterialTester(Domain &theDomain,
   Tcl_CreateCommand(interp, "setStrain", TclPlaneStressMaterialTester_setStrainPlaneStressMaterial,
 		    (ClientData)NULL, NULL);
 
+  Tcl_CreateCommand(interp, "commitStrain", TclPlaneStressMaterialTester_commitStrainPlaneStressMaterial,
+      (ClientData)NULL, NULL);
+
   Tcl_CreateCommand(interp, "getStress", TclPlaneStressMaterialTester_getStressPlaneStressMaterial,
 		    (ClientData)NULL, NULL);
 
@@ -109,6 +117,7 @@ TclPlaneStressMaterialTester::~TclPlaneStressMaterialTester()
   opserr << "REMOVING COMMANDS";
   Tcl_DeleteCommand(theInterp, "setMaterial");
   Tcl_DeleteCommand(theInterp, "setStrain");
+  Tcl_DeleteCommand(theInterp, "commitStrain");
   Tcl_DeleteCommand(theInterp, "getStress");
   Tcl_DeleteCommand(theInterp, "getTangent");
 }
@@ -161,7 +170,6 @@ TclPlaneStressMaterialTester_setPlaneStressMaterial(ClientData clientData, Tcl_I
   return TCL_OK;
 }
 
-
 int  
 TclPlaneStressMaterialTester_setStrainPlaneStressMaterial(ClientData clientData, Tcl_Interp *interp,
 						    int argc,   TCL_Char **argv)
@@ -205,7 +213,16 @@ TclPlaneStressMaterialTester_setStrainPlaneStressMaterial(ClientData clientData,
   return TCL_OK;
 }
 
-
+int
+TclPlaneStressMaterialTester_commitStrainPlaneStressMaterial(ClientData clientData, Tcl_Interp* interp,
+    int argc, TCL_Char** argv)
+{
+    if (theMaterial != 0) {
+        theMaterial->commitState();
+        count = 1;
+    }
+    return TCL_OK;
+}
 
 int  TclPlaneStressMaterialTester_getStressPlaneStressMaterial(ClientData clientData, Tcl_Interp *interp,
 							 int argc,   TCL_Char **argv)

--- a/SRC/modelbuilder/tcl/TclPlaneStressMaterialTester.cpp
+++ b/SRC/modelbuilder/tcl/TclPlaneStressMaterialTester.cpp
@@ -114,7 +114,6 @@ TclPlaneStressMaterialTester::~TclPlaneStressMaterialTester()
 {
 
   theTclBuilder =0;
-  opserr << "REMOVING COMMANDS";
   Tcl_DeleteCommand(theInterp, "setMaterial");
   Tcl_DeleteCommand(theInterp, "setStrain");
   Tcl_DeleteCommand(theInterp, "commitStrain");

--- a/SRC/modelbuilder/tcl/TclSectionTester.cpp
+++ b/SRC/modelbuilder/tcl/TclSectionTester.cpp
@@ -56,6 +56,9 @@ int  TclSectionTester_setSection(ClientData clientData, Tcl_Interp *interp,
 int  TclSectionTester_setStrainSection(ClientData clientData, Tcl_Interp *interp,
 				       int argc,   TCL_Char **argv);
 
+int  TclSectionTester_commitStrainSection(ClientData clientData, Tcl_Interp* interp,
+    int argc, TCL_Char** argv);
+
 int  TclSectionTester_getStressSection(ClientData clientData, Tcl_Interp *interp,
 				       int argc,   TCL_Char **argv);
 
@@ -83,6 +86,9 @@ TclSectionTester::TclSectionTester(Domain &theDomain, Tcl_Interp *interp, int cT
   
   Tcl_CreateCommand(interp, "strainSectionTest", TclSectionTester_setStrainSection,
 		    (ClientData)NULL, NULL);
+
+  Tcl_CreateCommand(interp, "commitSectionTest", TclSectionTester_commitStrainSection,
+      (ClientData)NULL, NULL);
   
   Tcl_CreateCommand(interp, "stressSectionTest", TclSectionTester_getStressSection,
 		    (ClientData)NULL, NULL);
@@ -104,6 +110,7 @@ TclSectionTester::~TclSectionTester()
 
   Tcl_DeleteCommand(theInterp, "sectionTest");
   Tcl_DeleteCommand(theInterp, "strainSectionTest");
+  Tcl_DeleteCommand(theInterp, "commitSectionTest");
   Tcl_DeleteCommand(theInterp, "stressSectionTest");
   Tcl_DeleteCommand(theInterp, "tangSectionTest");
   Tcl_DeleteCommand(theInterp, "responseSectionTest");
@@ -197,6 +204,16 @@ TclSectionTester_setStrainSection(ClientData clientData, Tcl_Interp *interp,
   return TCL_OK;
 }
 
+int
+TclSectionTester_commitStrainSection(ClientData clientData, Tcl_Interp* interp,
+    int argc, TCL_Char** argv)
+{
+    if (theTestingSection != 0) {
+        theTestingSection->commitState();
+        count = 1;
+    }
+    return TCL_OK;
+}
 
 int  TclSectionTester_getStressSection(ClientData clientData, Tcl_Interp *interp,
 				       int argc,   TCL_Char **argv)

--- a/SRC/modelbuilder/tcl/TclUniaxialMaterialTester.cpp
+++ b/SRC/modelbuilder/tcl/TclUniaxialMaterialTester.cpp
@@ -59,6 +59,11 @@ int  TclUniaxialMaterialTester_setStrainUniaxialMaterial(ClientData clientData,
 							 int argc,   
 							 TCL_Char **argv);
 
+int  TclUniaxialMaterialTester_commitStrainUniaxialMaterial(ClientData clientData,
+    Tcl_Interp* interp,
+    int argc,
+    TCL_Char** argv);
+
 int  TclUniaxialMaterialTester_getStressUniaxialMaterial(ClientData clientData,
 							 Tcl_Interp *interp,
 							 int argc,   
@@ -86,6 +91,9 @@ TclUniaxialMaterialTester::TclUniaxialMaterialTester(Domain &theDomain, Tcl_Inte
   Tcl_CreateCommand(interp, "strainUniaxialTest", TclUniaxialMaterialTester_setStrainUniaxialMaterial,
 		    (ClientData)NULL, NULL);
 
+  Tcl_CreateCommand(interp, "commitUniaxialTest", TclUniaxialMaterialTester_commitStrainUniaxialMaterial,
+      (ClientData)NULL, NULL);
+
   Tcl_CreateCommand(interp, "stressUniaxialTest", TclUniaxialMaterialTester_getStressUniaxialMaterial,
 		    (ClientData)NULL, NULL);
 
@@ -104,10 +112,10 @@ TclUniaxialMaterialTester::~TclUniaxialMaterialTester()
 
   Tcl_DeleteCommand(theInterp, "uniaxialTest");
   Tcl_DeleteCommand(theInterp, "strainUniaxialTest");
+  Tcl_DeleteCommand(theInterp, "commitUniaxialTest");
   Tcl_DeleteCommand(theInterp, "stressUniaxialTest");
   Tcl_DeleteCommand(theInterp, "tangUniaxialTest");
 }
-
 
 //
 // THE FUNCTIONS INVOKED BY THE INTERPRETER
@@ -156,7 +164,6 @@ TclUniaxialMaterialTester_setUniaxialMaterial(ClientData clientData, Tcl_Interp 
   return TCL_OK;
 }
 
-
 int  
 TclUniaxialMaterialTester_setStrainUniaxialMaterial(ClientData clientData, Tcl_Interp *interp,
 						    int argc,   TCL_Char **argv)
@@ -202,7 +209,16 @@ TclUniaxialMaterialTester_setStrainUniaxialMaterial(ClientData clientData, Tcl_I
   return TCL_OK;
 }
 
-
+int
+TclUniaxialMaterialTester_commitStrainUniaxialMaterial(ClientData clientData, Tcl_Interp* interp,
+    int argc, TCL_Char** argv)
+{
+    if (theTestingUniaxialMaterial != 0) {
+        theTestingUniaxialMaterial->commitState();
+        count = 1;
+    }
+    return TCL_OK;
+}
 
 int  TclUniaxialMaterialTester_getStressUniaxialMaterial(ClientData clientData, Tcl_Interp *interp,
 							 int argc,   TCL_Char **argv)


### PR DESCRIPTION
This is so that you don't have to call the "setStrain" function multiple times to commit the state (e.g. you are looking for some tolerance on the response, for example).