### PR TITLE
Node bounds fix

### DIFF
--- a/SRC/domain/domain/Domain.cpp
+++ b/SRC/domain/domain/Domain.cpp
@@ -98,7 +98,7 @@ Domain::Domain()
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false),  nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0), 
- theRegions(0), numRegions(0), commitTag(0), initBounds(true),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true), resetBounds(false),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -154,7 +154,7 @@ Domain::Domain(int numNodes, int numElements, int numSPs, int numMPs,
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false), nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0),
- theRegions(0), numRegions(0), commitTag(0), initBounds(true),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true), resetBounds(false),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -215,7 +215,7 @@ Domain::Domain(TaggedObjectStorage &theNodesStorage,
  theSPs(&theSPsStorage),
  theMPs(&theMPsStorage), 
  theLoadPatterns(&theLoadPatternsStorage),
- theRegions(0), numRegions(0), commitTag(0), initBounds(true),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true), resetBounds(false),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -274,7 +274,7 @@ Domain::Domain(TaggedObjectStorage &theStorage)
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false), nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0), 
- theRegions(0), numRegions(0), commitTag(0),initBounds(true),
+ theRegions(0), numRegions(0), commitTag(0),initBounds(true), resetBounds(false),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -1079,58 +1079,7 @@ Domain::removeNode(int tag)
   this->domainChange();
 
   // adjust node bounds 
-  initBounds = true;
-  theBounds(0) = 0;
-  theBounds(1) = 0;
-  theBounds(2) = 0;
-  theBounds(3) = 0;
-  theBounds(4) = 0;
-  theBounds(5) = 0;
-  if (theNodes->getNumComponents() != 0) {
-      initBounds = false;
-      Node* nodePtr;
-      NodeIter& theNodeIter = this->getNodes();
-      // initialize with first node
-      nodePtr = theNodeIter();
-      const Vector& crds = nodePtr->getCrds();
-      int dim = crds.Size();
-      double x, y, z;
-      if (dim >= 1) {
-          x = crds(0);
-          theBounds(0) = x;
-          theBounds(3) = x;
-      }
-      if (dim >= 2) {
-          y = crds(1);
-          theBounds(1) = y;
-          theBounds(4) = y;
-      }
-      if (dim == 3) {
-          z = crds(2);
-          theBounds(2) = z;
-          theBounds(5) = z;
-      }
-      // adjust for other nodes
-      while ((nodePtr = theNodeIter()) != 0) {
-          const Vector& crds = nodePtr->getCrds();
-          dim = crds.Size();
-          if (dim >= 1) {
-              x = crds(0);
-              if (x < theBounds(0)) theBounds(0) = x;
-              if (x > theBounds(3)) theBounds(3) = x;
-          }
-          if (dim >= 2) {
-              y = crds(1);
-              if (y < theBounds(1)) theBounds(1) = y;
-              if (y > theBounds(4)) theBounds(4) = y;
-          }
-          if (dim == 3) {
-              z = crds(2);
-              if (z < theBounds(2)) theBounds(2) = z;
-              if (z > theBounds(5)) theBounds(5) = z;
-          }
-      }
-  }
+  resetBounds = true;
   
   // perform a downward cast to a Node (safe as only Node added to
   // this container and return the result of the cast
@@ -1672,6 +1621,63 @@ Domain::getNumParameters(void) const
 const Vector &
 Domain::getPhysicalBounds(void)
 {
+    // reset bounds if nodes were deleted
+    if (resetBounds) {
+        initBounds = true;
+        theBounds(0) = 0;
+        theBounds(1) = 0;
+        theBounds(2) = 0;
+        theBounds(3) = 0;
+        theBounds(4) = 0;
+        theBounds(5) = 0;
+        if (theNodes->getNumComponents() != 0) {
+            initBounds = false;
+            Node* nodePtr;
+            NodeIter& theNodeIter = this->getNodes();
+            // initialize with first node
+            nodePtr = theNodeIter();
+            const Vector& crds = nodePtr->getCrds();
+            int dim = crds.Size();
+            double x, y, z;
+            if (dim >= 1) {
+                x = crds(0);
+                theBounds(0) = x;
+                theBounds(3) = x;
+            }
+            if (dim >= 2) {
+                y = crds(1);
+                theBounds(1) = y;
+                theBounds(4) = y;
+            }
+            if (dim == 3) {
+                z = crds(2);
+                theBounds(2) = z;
+                theBounds(5) = z;
+            }
+            // adjust for other nodes
+            while ((nodePtr = theNodeIter()) != 0) {
+                const Vector& crds = nodePtr->getCrds();
+                dim = crds.Size();
+                if (dim >= 1) {
+                    x = crds(0);
+                    if (x < theBounds(0)) theBounds(0) = x;
+                    if (x > theBounds(3)) theBounds(3) = x;
+                }
+                if (dim >= 2) {
+                    y = crds(1);
+                    if (y < theBounds(1)) theBounds(1) = y;
+                    if (y > theBounds(4)) theBounds(4) = y;
+                }
+                if (dim == 3) {
+                    z = crds(2);
+                    if (z < theBounds(2)) theBounds(2) = z;
+                    if (z > theBounds(5)) theBounds(5) = z;
+                }
+            }
+        }
+        resetBounds = false;
+    }
+    
     return theBounds;
 }
 

--- a/SRC/domain/domain/Domain.cpp
+++ b/SRC/domain/domain/Domain.cpp
@@ -1077,11 +1077,67 @@ Domain::removeNode(int tag)
 
   // mark the domain has having changed 
   this->domainChange();
+
+  // adjust node bounds 
+  initBounds = true;
+  theBounds(0) = 0;
+  theBounds(1) = 0;
+  theBounds(2) = 0;
+  theBounds(3) = 0;
+  theBounds(4) = 0;
+  theBounds(5) = 0;
+  if (theNodes->getNumComponents() != 0) {
+      initBounds = false;
+      Node* nodePtr;
+      NodeIter& theNodeIter = this->getNodes();
+      // initialize with first node
+      nodePtr = theNodeIter();
+      const Vector& crds = nodePtr->getCrds();
+      int dim = crds.Size();
+      double x, y, z;
+      if (dim >= 1) {
+          x = crds(0);
+          theBounds(0) = x;
+          theBounds(3) = x;
+      }
+      if (dim >= 2) {
+          y = crds(1);
+          theBounds(1) = y;
+          theBounds(4) = y;
+      }
+      if (dim == 3) {
+          z = crds(2);
+          theBounds(2) = z;
+          theBounds(5) = z;
+      }
+      // adjust for other nodes
+      while ((nodePtr = theNodeIter()) != 0) {
+          const Vector& crds = nodePtr->getCrds();
+          dim = crds.Size();
+          if (dim >= 1) {
+              x = crds(0);
+              if (x < theBounds(0)) theBounds(0) = x;
+              if (x > theBounds(3)) theBounds(3) = x;
+          }
+          if (dim >= 2) {
+              y = crds(1);
+              if (y < theBounds(1)) theBounds(1) = y;
+              if (y > theBounds(4)) theBounds(4) = y;
+          }
+          if (dim == 3) {
+              z = crds(2);
+              if (z < theBounds(2)) theBounds(2) = z;
+              if (z > theBounds(5)) theBounds(5) = z;
+          }
+      }
+  }
   
   // perform a downward cast to a Node (safe as only Node added to
   // this container and return the result of the cast
   Node *result = (Node *)mc;
   // result->setDomain(0);
+  
+
   return result;
 }
 

--- a/SRC/domain/domain/Domain.cpp
+++ b/SRC/domain/domain/Domain.cpp
@@ -98,7 +98,7 @@ Domain::Domain()
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false),  nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0), 
- theRegions(0), numRegions(0), commitTag(0),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -154,7 +154,7 @@ Domain::Domain(int numNodes, int numElements, int numSPs, int numMPs,
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false), nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0),
- theRegions(0), numRegions(0), commitTag(0),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -215,7 +215,7 @@ Domain::Domain(TaggedObjectStorage &theNodesStorage,
  theSPs(&theSPsStorage),
  theMPs(&theMPsStorage), 
  theLoadPatterns(&theLoadPatternsStorage),
- theRegions(0), numRegions(0), commitTag(0),
+ theRegions(0), numRegions(0), commitTag(0), initBounds(true),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -274,7 +274,7 @@ Domain::Domain(TaggedObjectStorage &theStorage)
  dbEle(0), dbNod(0), dbSPs(0), dbPCs(0), dbMPs(0), dbLPs(0), dbParam(0),
  eleGraphBuiltFlag(false), nodeGraphBuiltFlag(false), theNodeGraph(0), 
  theElementGraph(0), 
- theRegions(0), numRegions(0), commitTag(0),
+ theRegions(0), numRegions(0), commitTag(0),initBounds(true),
  theBounds(6), theEigenvalues(0), theEigenvalueSetTime(0), 
  theModalProperties(0),
  theModalDampingFactors(0), inclModalMatrix(false),
@@ -488,27 +488,46 @@ Domain::addNode(Node * node)
   if (result == true) {
       node->setDomain(this);
       this->domainChange();
-      
+
       // see if the physical bounds are changed
       // note this assumes 0,0,0,0,0,0 as startup min,max values
-      const Vector &crds = node->getCrds();
+      const Vector& crds = node->getCrds();
       int dim = crds.Size();
-      if (dim >= 1) {
-	  double x = crds(0);
-	  if (x < theBounds(0)) theBounds(0) = x;
-	  if (x > theBounds(3)) theBounds(3) = x;
-      } 
-      if (dim >= 2) {
-	  double y = crds(1);
-	  if (y < theBounds(1)) theBounds(1) = y;
-	  if (y > theBounds(4)) theBounds(4) = y;	  
-      } 
-      if (dim == 3) {
-	  double z = crds(2);
-	  if (z < theBounds(2)) theBounds(2) = z;
-	  if (z > theBounds(5)) theBounds(5) = z;	  
+      if (initBounds) {
+          if (dim >= 1) {
+              double x = crds(0);
+              theBounds(0) = x;
+              theBounds(3) = x;
+          }
+          if (dim >= 2) {
+              double y = crds(1);
+              theBounds(1) = y;
+              theBounds(4) = y;
+          }
+          if (dim == 3) {
+              double z = crds(2);
+              theBounds(2) = z;
+              theBounds(5) = z;
+          }
+          initBounds = false;
       }
-      
+      else {
+          if (dim >= 1) {
+              double x = crds(0);
+              if (x < theBounds(0)) theBounds(0) = x;
+              if (x > theBounds(3)) theBounds(3) = x;
+          }
+          if (dim >= 2) {
+              double y = crds(1);
+              if (y < theBounds(1)) theBounds(1) = y;
+              if (y > theBounds(4)) theBounds(4) = y;
+          }
+          if (dim == 3) {
+              double z = crds(2);
+              if (z < theBounds(2)) theBounds(2) = z;
+              if (z > theBounds(5)) theBounds(5) = z;
+          }
+      }
   } else
     opserr << "Domain::addNode - node with tag " << nodTag << "could not be added to container\n";
 
@@ -987,12 +1006,13 @@ Domain::clearAll(void) {
   this->setModalDampingFactors(0);
 
   // set the bounds around the origin
+  initBounds = true;
   theBounds(0) = 0;
   theBounds(1) = 0;
   theBounds(2) = 0;
   theBounds(3) = 0;
-  theBounds(4) = 0;    
-  theBounds(5) = 0;        
+  theBounds(4) = 0;
+  theBounds(5) = 0;
   
   currentGeoTag = 0;
   lastGeoSendTag = -1;

--- a/SRC/domain/domain/Domain.h
+++ b/SRC/domain/domain/Domain.h
@@ -290,6 +290,7 @@ class Domain
     
     Vector theBounds;
     bool initBounds; // added to fix bug when all nodes are positive or negative - ambaker1
+    bool resetBounds; // added to optimize bound resetting for when nodes are removed.
     
     Vector *theEigenvalues;
     double theEigenvalueSetTime;

--- a/SRC/domain/domain/Domain.h
+++ b/SRC/domain/domain/Domain.h
@@ -289,6 +289,7 @@ class Domain
     int commitTag;
     
     Vector theBounds;
+    bool initBounds; // added to fix bug when all nodes are positive or negative - ambaker1
     
     Vector *theEigenvalues;
     double theEigenvalueSetTime;


### PR DESCRIPTION
This fixes a few bugs with the nodeBounds command.
1.) The node bounds were initialized with 0,0,0 and not the first node. In cases where a model is entirely in a positive or negative region (i.e. all X values are > 0), the zero coordinate is still included in the bounds.
2.) Node bounds were not updated after nodes were removed.

Test code (Tcl):
```
model BasicBuilder -ndm 3
puts [nodeBounds]
node 1 1 1 1
puts [nodeBounds]
node 2 2 2 2
puts [nodeBounds]
remove node 1
puts [nodeBounds]
remove node 2
puts [nodeBounds]
node 3 3 3 3
puts [nodeBounds]
```

Output (version 3.2.2):
```
0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  1.000000e+00  1.000000e+00  1.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  3.000000e+00  3.000000e+00  3.000000e+00
```

Output (this PR):
```
0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
1.000000e+00  1.000000e+00  1.000000e+00  1.000000e+00  1.000000e+00  1.000000e+00
1.000000e+00  1.000000e+00  1.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00
2.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00  2.000000e+00
0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
3.000000e+00  3.000000e+00  3.000000e+00  3.000000e+00  3.000000e+00  3.000000e+00
```

For reference, the output to the nodeBounds command corresponds to xMin, yMin, zMin, xMax, yMax, and zMax.

One of the benefits to this PR is that OpenSees display procedures will now properly center all models, even if all the coordinates are positive. 

