### PR TITLE
OpenSees display "lineWidth" option

### DIFF
--- a/SRC/renderer/OpenGLRenderer.h
+++ b/SRC/renderer/OpenGLRenderer.h
@@ -65,10 +65,9 @@ class OpenGLRenderer : public Renderer
     virtual int drawPoint(const Vector &, const Vector &rgb1, int tag = 0, int mode=0, int width = 1);    
 
     virtual int drawLine(const Vector &, const Vector &, 
-			 float V1, float V2, int tag = 0, int mode = 0, int width = 1, int style = 1);
+			 float V1, float V2, int tag = 0, int mode = 0);
     virtual int drawLine(const Vector &end1, const Vector &end2, 
-			 const Vector &rgb1, const Vector &rgb2,
-			 int tag = 0, int mode = 0, int width = 1, int style = 1);
+			 const Vector &rgb1, const Vector &rgb2, int tag = 0, int mode = 0);
    
     virtual int drawPolygon(const Matrix &points, const Vector &values, int tag = 0, int mode = 0);
     virtual int drawPolygon(const Matrix &points, const Matrix &rgbValues, int tag = 0, int mode = 0);
@@ -90,6 +89,7 @@ class OpenGLRenderer : public Renderer
 
     virtual int setProjectionMode(const char *mode); // parallel or perspective
     virtual int setFillMode(const char *mode);    // wire or  fill
+    virtual int setLineWidth(int width);    // width in pixels
     
     virtual int setPRP(float u, float v, float n); // eye location if 
 	                         // perspective, dirn to +ViewPlane if parallel
@@ -130,6 +130,7 @@ class OpenGLRenderer : public Renderer
     Vector portWindow;  // mapping to window - port window coords [-1,-1] to [1,1]
 
     int fillMode;        // flag indicating fill mode
+    int lineWidth; // line width for drawing lines
 
     float viewData[16];
     float projData[16];

--- a/SRC/renderer/OpenGlRenderer.cpp
+++ b/SRC/renderer/OpenGlRenderer.cpp
@@ -77,7 +77,7 @@ OpenGLRenderer::OpenGLRenderer(const char *_title, int _xLoc, int _yLoc,
   count(-1), theOutputFileName(0), 
   theDevice(0),
   vrp(3), vuv(3), vpn(3), cop(3), ViewMat(4,4), 
-  projectionMode(0), vpWindow(4), ProjMat(4,4),
+  projectionMode(0), lineWidth(1), vpWindow(4), ProjMat(4,4),
   portWindow(4)
 {
 
@@ -121,7 +121,7 @@ OpenGLRenderer::OpenGLRenderer(const char *_title, int _xLoc, int _yLoc,
   count(-1), theOutputFileName(0), 
   theDevice(0),
   vrp(3), vuv(3), vpn(3), cop(3), ViewMat(4,4), 
-  projectionMode(0), vpWindow(4), ProjMat(4,4),
+  projectionMode(0), lineWidth(1), vpWindow(4), ProjMat(4,4),
   portWindow(4)
 {
   // set the WindowDevices title, height, wdth, xLoc and yLoc
@@ -480,14 +480,13 @@ OpenGLRenderer::drawPoint(const Vector &pos1, const Vector &rgb, int tag, int mo
 
 int 
 OpenGLRenderer::drawLine(const Vector &pos1, const Vector &pos2, 
-			 float V1, float V2, int tag, int mode, int width, int style)
+			 float V1, float V2, int tag, int mode)
 {
     // open gl does a divide by zero error if points are the same - so check
     if (pos1(0) == pos2(0) && pos1(1) == pos2(1) && pos1(2) == pos2(2))
       return 0;
 
-    width = 2; // S. Mazzoni
-    glLineWidth(width);
+    glLineWidth(lineWidth);
 
     glBegin(GL_LINES);
     float r, g, b;
@@ -520,15 +519,13 @@ OpenGLRenderer::drawLine(const Vector &pos1, const Vector &pos2,
 
 int 
 OpenGLRenderer::drawLine(const Vector &end1, const Vector &end2, 
-			 const Vector &rgb1, const Vector &rgb2,
-			 int tag, int mode, int width, int style)
+			 const Vector &rgb1, const Vector &rgb2, int tag, int mode)
 {
     // open gl does a divide by zero error if points are the same
     if (end1(0) == end2(0) && end1(1) == end2(1) && end1(2) == end2(2))
       return 0;
 
-    width = 2; // S. Mazzoni
-    glLineWidth(width);
+    glLineWidth(lineWidth);
 
     glBegin(GL_LINES);
     float r, g, b;
@@ -751,6 +748,13 @@ OpenGLRenderer::setFillMode(const char *newMode)
     fillMode = FILL_MODE;
 
   return 0;
+}
+
+int
+OpenGLRenderer::setLineWidth(int width)
+{
+    lineWidth = width;
+    return 0;
 }
 
 // eye location

--- a/SRC/renderer/Renderer.h
+++ b/SRC/renderer/Renderer.h
@@ -67,14 +67,10 @@ class Renderer
     virtual int drawPoint(const Vector &, float V1, int tag = 0, int mode = 0, int width = 1) =0;
     virtual int drawPoint(const Vector &, const Vector &rgb1, int tag = 0, int mode = 0, int width = 1) =0;
 
-    virtual int drawLine(const Vector &, const Vector &, float V1, float V2, int tag = 0, int mode = 0,
-			 int width = 1, int style = 1) =0;
-			 
-    
+    virtual int drawLine(const Vector &, const Vector &, 
+        float V1, float V2, int tag = 0, int mode = 0) =0;
     virtual int drawLine(const Vector &end1, const Vector &end2, 
-			 const Vector &rgb1, const Vector &rgb2,
-			 int tag = 0, int mode = 0,
-			 int width = 1, int style = 1) =0;
+			 const Vector &rgb1, const Vector &rgb2,int tag = 0, int mode = 0) =0;
     
     virtual int drawCube(const Matrix &points, const Vector &values, int tag = 0, int mode = 0);
 
@@ -106,6 +102,7 @@ class Renderer
 
     virtual int setProjectionMode(const char *mode) =0; //parallel or perspective
     virtual int setFillMode(const char *mode) =0;    // wire or fill
+    virtual int setLineWidth(int width) = 0;    // line width
     
     virtual int setPRP(float u, float v, float n) =0; // eye location if 
 	                       // perspective, dirn to +ViewPlane if parallel

--- a/SRC/tcl/TclFeViewer.cpp
+++ b/SRC/tcl/TclFeViewer.cpp
@@ -886,8 +886,8 @@ TclFeViewer_displayModel(ClientData clientData, Tcl_Interp *interp, int argc,
       return TCL_OK;    
   
   // check number of args  
-  if (argc < 3 && argc > 5) {
-      opserr << "WARNING args incorrect - display eleMode <nodeMode> fact\n";
+  if (argc < 3 || argc > 5) {
+      opserr << "WARNING args incorrect - display eleMode <nodeMode> displayFact <lineWidth>\n";
       return TCL_ERROR;
   }    
 
@@ -906,31 +906,31 @@ TclFeViewer_displayModel(ClientData clientData, Tcl_Interp *interp, int argc,
       theTclFeViewer->displayModel(displayMode, -1, float(displayFact));
       return TCL_OK;    
   } else {
-      int eleFlag, nodeFlag;
+      int eleMode, nodeMode;
       double displayFact;
-      if (Tcl_GetInt(interp, argv[1], &eleFlag) != TCL_OK) {
-	  opserr << "WARNING invalid displayMode - display eleFlag nodeFlag displayFact\n";
+      if (Tcl_GetInt(interp, argv[1], &eleMode) != TCL_OK) {
+	  opserr << "WARNING invalid eleMode - display eleMode nodeMode displayFact\n";
 	  return TCL_ERROR;
 	      }
-      if (Tcl_GetInt(interp, argv[2], &nodeFlag) != TCL_OK) {
-	  opserr << "WARNING invalid displayMode - display eleFlag nodeFlahg displayFact\n";
+      if (Tcl_GetInt(interp, argv[2], &nodeMode) != TCL_OK) {
+	  opserr << "WARNING invalid nodeMode - display eleMode nodeMode displayFact\n";
 	  return TCL_ERROR;
 	      }      
       if (Tcl_GetDouble(interp, argv[3], &displayFact) != TCL_OK) {
-	  opserr << "WARNING invalid displayMode - display eleFlag nodeFlahg displayFact\n";
+	  opserr << "WARNING invalid displayFact - display eleMode nodeMode displayFact\n";
 	  return TCL_ERROR;
       }  
       // line width
       if (argc == 5) {
           int lineWidth;
           if (Tcl_GetInt(interp, argv[4], &lineWidth) != TCL_OK) {
-              opserr << "WARNING invalid displayMode - display eleFlag nodeFlahg displayFact lineWidth\n";
+              opserr << "WARNING invalid lineWidth - display eleMode nodeMode displayFact lineWidth\n";
               return TCL_ERROR;
           }
-          theTclFeViewer->displayModel(eleFlag, nodeFlag, float(displayFact), lineWidth);
+          theTclFeViewer->displayModel(eleMode, nodeMode, float(displayFact), lineWidth);
           return TCL_OK;
       }
-      theTclFeViewer->displayModel(eleFlag, nodeFlag, float(displayFact));
+      theTclFeViewer->displayModel(eleMode, nodeMode, float(displayFact));
       return TCL_OK;
   }
 #endif

--- a/SRC/tcl/TclFeViewer.cpp
+++ b/SRC/tcl/TclFeViewer.cpp
@@ -91,7 +91,10 @@ TclFeViewer_setProjectionMode(ClientData clientData, Tcl_Interp *interp, int arg
 			      TCL_Char **argv);		   			 
 int
 TclFeViewer_setFillMode(ClientData clientData, Tcl_Interp *interp, int argc, 
-			TCL_Char **argv);		   			 			      
+			TCL_Char **argv);		
+int
+TclFeViewer_setLineWidth(ClientData clientData, Tcl_Interp* interp, int argc,
+    TCL_Char** argv);
 int
 TclFeViewer_setPRP(ClientData clientData, Tcl_Interp *interp, int argc, 
 		   TCL_Char **argv);		   
@@ -172,6 +175,9 @@ TclFeViewer::TclFeViewer(const char *title, int xLoc, int yLoc, int width, int h
   
   Tcl_CreateCommand(interp, "fill", TclFeViewer_setFillMode,
 		    (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);      
+
+  Tcl_CreateCommand(interp, "lineWidth", TclFeViewer_setLineWidth,
+            (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
   
   Tcl_CreateCommand(interp, "prp", TclFeViewer_setPRP,
 		    (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
@@ -240,6 +246,9 @@ TclFeViewer::TclFeViewer(const char *title, int xLoc, int yLoc, int width, int h
   
   Tcl_CreateCommand(interp, "fill", TclFeViewer_setFillMode,
 		    (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);      
+
+  Tcl_CreateCommand(interp, "lineWidth", TclFeViewer_setLineWidth,
+            (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
   
   Tcl_CreateCommand(interp, "prp", TclFeViewer_setPRP,
 		    (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
@@ -477,6 +486,17 @@ TclFeViewer::setFillMode(const char *mode)
   return theRenderer->setFillMode(mode);
 #endif
 }                
+
+int
+TclFeViewer::setLineWidth(int width)
+{
+#ifdef _NOGRAPHICS
+    // if no graphics .. just return 0
+    return 0;
+#else
+    return theRenderer->setLineWidth(width);
+#endif
+}
 
 int
 TclFeViewer::setPRP(float uLoc, float vLoc , float nLoc)
@@ -787,6 +807,38 @@ TclFeViewer_setFillMode(ClientData clientData, Tcl_Interp *interp, int argc,
   // set the mode
   theTclFeViewer->setFillMode(argv[1]);    
   return TCL_OK;  
+#endif
+}
+
+int
+TclFeViewer_setLineWidth(ClientData clientData, Tcl_Interp* interp, int argc,
+    TCL_Char** argv)
+{
+#ifdef _NOGRAPHICS
+    // if no graphics .. just return 0
+    return TCL_OK;
+#else
+
+    // check destructor has not been called
+    if (theTclFeViewer == 0)
+        return TCL_OK;
+
+    // ensure corrcet num arguments
+    if (argc < 2) {
+        opserr << "WARNING args incorrect - lineWidth width \n";
+        return TCL_ERROR;
+    }
+
+    // get int input
+    int width;
+    if (Tcl_GetInt(interp, argv[1], &width) != TCL_OK) {
+        opserr << "WARNING invalid line width - lineWidth width\n";
+        return TCL_ERROR;
+    }
+
+    // set the width
+    theTclFeViewer->setLineWidth(width);
+    return TCL_OK;
 #endif
 }
 

--- a/SRC/tcl/TclFeViewer.h
+++ b/SRC/tcl/TclFeViewer.h
@@ -77,7 +77,6 @@ class TclFeViewer : public Recorder
 
     int setProjectionMode(const char *); // "parallel" for parallel projection (default), "perspective" for perspective.
     int setFillMode(const char *);    // "wire" for wire-frame (default), "fill" to fill polygons
-    int setLineWidth(int);    // line width in pixels for renderer. default 1
     
     int setPRP(float, float, float); // eye location, global coords
 
@@ -86,7 +85,7 @@ class TclFeViewer : public Recorder
 
 
     // methods invoked on the FE_Viewer
-    int displayModel(int eleFlag, int nodeFlag, float displayFact);
+    int displayModel(int eleFlag, int nodeFlag, float displayFact, int lineWidth = 1); // default line width set here.
     int clearImage(void);
     int saveImage(const char *fileName);
     int saveImage(const char *imageName, const char *fileName);

--- a/SRC/tcl/TclFeViewer.h
+++ b/SRC/tcl/TclFeViewer.h
@@ -75,8 +75,9 @@ class TclFeViewer : public Recorder
     int setPlaneDist(float, float); // location of
                                // near, view & far clipping planes
 
-    int setProjectionMode(const char *); // 
-    int setFillMode(const char *);    // 1 = wire, otherwise fill
+    int setProjectionMode(const char *); // "parallel" for parallel projection (default), "perspective" for perspective.
+    int setFillMode(const char *);    // "wire" for wire-frame (default), "fill" to fill polygons
+    int setLineWidth(int);    // line width in pixels for renderer. default 1
     
     int setPRP(float, float, float); // eye location, global coords
 


### PR DESCRIPTION
This PR returns the default line width back to 1, which was overridden to be 2 in the latest release (#580), and provides a command that allows the user to change the line width on the scripting side.

Command: lineWidth $width
$width: Width of lines in pixels (integer). Default 1