### PR TITLE
CYPE Software: Several corrections related to OpenSeesSP

### DIFF
--- a/SRC/domain/domain/partitioned/PartitionedDomain.cpp
+++ b/SRC/domain/domain/partitioned/PartitionedDomain.cpp
@@ -1346,6 +1346,10 @@ PartitionedDomain::revertToStart(void)
         return res;
       }
     }
+
+#ifdef _PARALLEL_PROCESSING
+    this->barrierCheck(result);
+#endif
   }
 
   return 0;

--- a/SRC/domain/subdomain/ActorSubdomain.cpp
+++ b/SRC/domain/subdomain/ActorSubdomain.cpp
@@ -665,7 +665,9 @@ opserr << "ActorSubdomain::addSP_AXIS :: DONE\n";
 	  case ShadowActorSubdomain_revertToStart:
 	    this->revertToStart();
 	    this->sendID(msgData);
-
+		#ifdef _PARALLEL_PROCESSING
+		this->barrierCheck(0);
+		#endif
 	    break;	    	    
 
 	  case ShadowActorSubdomain_addRecorder:

--- a/SRC/domain/subdomain/ShadowSubdomain.cpp
+++ b/SRC/domain/subdomain/ShadowSubdomain.cpp
@@ -1093,6 +1093,15 @@ ShadowSubdomain::revertToStart(void)
 {
   msgData(0) = ShadowActorSubdomain_revertToStart;
   this->sendID(msgData);
+
+#ifdef _PARALLEL_PROCESSING
+  // CYPE Software: revertToStart() invokes update on ActorSubdomain which asks for barrierCheck.
+  {
+      int res = this->barrierCheckIN();
+      this->barrierCheckOUT(res);
+  }
+#endif
+
   if (this->recvID(msgData) != 0) {
     opserr << "ShadowSubdomain::revertToStart ERROR ERROR\n";
   }

--- a/SRC/element/shell/ShellNLDKGT.cpp
+++ b/SRC/element/shell/ShellNLDKGT.cpp
@@ -114,7 +114,7 @@ double ShellNLDKGT::wg[4] ;
 //null constructor
 ShellNLDKGT::ShellNLDKGT( ) :                              
 Element( 0, ELE_TAG_ShellNLDKGT ),
-connectedExternalNodes(3), CstrainGauss(32),TstrainGauss(32),load(0), Ki(0)
+connectedExternalNodes(3), CstrainGauss(32),TstrainGauss(32),load(0), Ki(0), nodePointers(), xl(), g1(), g2(), g3()
 { 
   for (int i = 0 ;  i < 4; i++ ) 
     materialPointers[i] = 0;
@@ -150,8 +150,8 @@ ShellNLDKGT::ShellNLDKGT(  int tag,
                          int node2,
    	                     int node3,
 	                     SectionForceDeformation &theMaterial ) :
-Element( tag, ELE_TAG_ShellDKGT ),
-connectedExternalNodes(3), CstrainGauss(32),TstrainGauss(32),load(0), Ki(0)
+Element( tag, ELE_TAG_ShellNLDKGT),
+connectedExternalNodes(3), CstrainGauss(32),TstrainGauss(32),load(0), Ki(0), nodePointers(), xl(), g1(), g2(), g3()
 {
   int i;
   connectedExternalNodes(0) = node1 ;           

--- a/SRC/handler/BinaryFileStream.cpp
+++ b/SRC/handler/BinaryFileStream.cpp
@@ -875,7 +875,7 @@ BinaryFileStream::setOrder(const ID &orderData)
       count++;
     }
     
-    opserr << printMapping;
+    //opserr << printMapping;
   }
 
   return 0;

--- a/SRC/material/nD/PlateFiberMaterial.cpp
+++ b/SRC/material/nD/PlateFiberMaterial.cpp
@@ -79,6 +79,7 @@ void* OPS_PlateFiberMaterial()
 //null constructor
 PlateFiberMaterial::PlateFiberMaterial() : 
 NDMaterial(0, ND_TAG_PlateFiberMaterial), 
+theMaterial(0),
 strain(5) 
 { 
     Tstrain22 = 0.0;

--- a/SRC/material/nD/PlateFiberMaterial.cpp
+++ b/SRC/material/nD/PlateFiberMaterial.cpp
@@ -81,7 +81,8 @@ PlateFiberMaterial::PlateFiberMaterial() :
 NDMaterial(0, ND_TAG_PlateFiberMaterial), 
 strain(5) 
 { 
-
+    Tstrain22 = 0.0;
+    Cstrain22 = 0.0;
 }
 
 

--- a/SRC/material/uniaxial/ENTMaterial.cpp
+++ b/SRC/material/uniaxial/ENTMaterial.cpp
@@ -68,14 +68,14 @@ void* OPS_ENTMaterial()
 
 ENTMaterial::ENTMaterial(int tag, double e, double A, double B)
   :UniaxialMaterial(tag,MAT_TAG_ENTMaterial),
-   E(e), trialStrain(0.0), parameterID(0),a(A), b(B)
+   E(e), commitStrain(0.0), trialStrain(0.0), parameterID(0),a(A), b(B)
 {
 
 }
 
 ENTMaterial::ENTMaterial()
 :UniaxialMaterial(0,MAT_TAG_ENTMaterial),
- E(0.0), trialStrain(0.0), parameterID(0)
+ E(0.0), commitStrain(0.0), trialStrain(0.0), parameterID(0), a(0.0), b(1.0)
 {
 
 }
@@ -124,20 +124,24 @@ ENTMaterial::getTangent(void)
 
 int 
 ENTMaterial::commitState(void)
-{
+{   
+    commitStrain = trialStrain;
     return 0;
 }
 
 int 
 ENTMaterial::revertToLastCommit(void)
 {
+    trialStrain = commitStrain;
     return 0;
 }
 
 int 
 ENTMaterial::revertToStart(void)
 {
-  return 0;
+    commitStrain = 0.;
+    trialStrain = 0.;
+    return 0;
 }
 
 UniaxialMaterial *
@@ -153,9 +157,14 @@ int
 ENTMaterial::sendSelf(int cTag, Channel &theChannel)
 {
   int res = 0;
-  static Vector data(2);
+
+  static Vector data(5);
   data(0) = this->getTag();
   data(1) = E;
+  data(2) = a;
+  data(3) = b;
+  data(4) = commitStrain;
+
   res = theChannel.sendVector(this->getDbTag(), cTag, data);
   if (res < 0) 
     opserr << "ENTMaterial::sendSelf() - failed to send data\n";
@@ -168,17 +177,24 @@ ENTMaterial::recvSelf(int cTag, Channel &theChannel,
 			       FEM_ObjectBroker &theBroker)
 {
   int res = 0;
-  static Vector data(2);
+  static Vector data(5);
   res = theChannel.recvVector(this->getDbTag(), cTag, data);
   
   if (res < 0) {
       opserr << "ENTMaterial::recvSelf() - failed to receive data\n";
-      E = 0; 
-      this->setTag(0);      
+      E = 0;
+      a = 0;
+      b = 0;
+      commitStrain = 0;
+      this->setTag(0);
   }
   else {
     this->setTag((int)data(0));
     E = data(1);
+    a = data(2);
+    b = data(3);
+    commitStrain = data(4);
+    trialStrain = commitStrain;
   }
     
   return res;

--- a/SRC/material/uniaxial/ENTMaterial.h
+++ b/SRC/material/uniaxial/ENTMaterial.h
@@ -84,6 +84,7 @@ class ENTMaterial : public UniaxialMaterial
     
   private:
     double E;
+    double commitStrain;
     double trialStrain;
 
     // AddingSensitivity:BEGIN //////////////////////////////////////////


### PR DESCRIPTION
This pr contains the first batch of corrections related to OpenSeesSP. Mainly they're variable initializations in default constructors and parameters that weren't send through the MPI channel.

The most complex is the one related to revertToStart() method invoked by the reset command in the tcl script. This caused the processes to stuck because one of them was paused waiting on a barrier check. This has been only tested on OpenSeesSP so I made use of the _PARALLEL_PROCESSING macro.

