### PR TITLE
Improve output of elements with 1 gauss point

### DIFF
--- a/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
+++ b/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
@@ -1701,7 +1701,7 @@ FourNodeTetrahedron::setResponse(const char **argv, int argc, OPS_Stream &output
 
   if (strcmp(argv[0],"force") == 0 || strcmp(argv[0],"forces") == 0)
   {
-    for (int i=1; i<=3; i++) 
+    for (int i=1; i<=4; i++) 
     {
       sprintf(outputData,"P1_%d",i);
       output.tag("ResponseType",outputData);

--- a/SRC/element/truss/CorotTruss.cpp
+++ b/SRC/element/truss/CorotTruss.cpp
@@ -1098,41 +1098,35 @@ CorotTruss::setResponse(const char **argv, int argc, OPS_Stream &output)
             output.tag("ResponseType", "U");
             theResponse = new ElementResponse(this, 3, 0.0);
 
-            // a material quantity
-    }
-    else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
-        output.tag("GaussPointOutput");
-        output.attr("number", 1);
-        output.attr("eta", 0.0);
-
+    // a material quantity
+    } else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
         if (argc > 1) {
             // we need at least one more argument otherwise 
             // there is no need to forward this call to the material
+            // by default assume the old call style for backward compatibility "material result"
+            int offset = 1;
+            bool is_valid = true;
+            // in case the user specifies the gauss point id... "material 1 result"
             if (argc > 2) {
-                // if we have 2 or more extra arguments, the first one 
-                // could be an integer. In this case we check to see if it is the section id
-                // (only 1 in this case)
                 int sectionNum = atoi(argv[1]);
-                if (sectionNum == 0) {
-                    // if it is not a number we forward the call to the section as usual
-                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                if (sectionNum == 1) {
+                    // this is the only supported gauss id
+                    offset = 2;
                 }
-                else {
-                    // it is a number. Now we have to make sure it is within the allowed range
-                    // for this element (in this case it can only be 1)
-                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-                    // uses this call to understand how many fibers we have in a section
-                    if (sectionNum == 1) {
-                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
-                    }
+                else if (sectionNum > 1) {
+                    // this is a number, but not within the valid range
+                    is_valid = false;
                 }
+                // if it is 0, then it is not a number, forward it as usual...
             }
-            else {
-                // otherwise forward it as usual
-                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            if (is_valid) {
+                output.tag("GaussPointOutput");
+                output.attr("number", 1);
+                output.attr("eta", 0.0);
+                theResponse = theMaterial->setResponse(&argv[offset], argc - offset, output);
+                output.endTag();
             }
         }
-        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/CorotTruss2.cpp
+++ b/SRC/element/truss/CorotTruss2.cpp
@@ -936,38 +936,33 @@ CorotTruss2::setResponse(const char **argv, int argc, OPS_Stream &output)
             // a material quantity
     }
     else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
-        output.tag("GaussPointOutput");
-        output.attr("number", 1);
-        output.attr("eta", 0.0);
-
         if (argc > 1) {
             // we need at least one more argument otherwise 
             // there is no need to forward this call to the material
+            // by default assume the old call style for backward compatibility "material result"
+            int offset = 1;
+            bool is_valid = true;
+            // in case the user specifies the gauss point id... "material 1 result"
             if (argc > 2) {
-                // if we have 2 or more extra arguments, the first one 
-                // could be an integer. In this case we check to see if it is the section id
-                // (only 1 in this case)
                 int sectionNum = atoi(argv[1]);
-                if (sectionNum == 0) {
-                    // if it is not a number we forward the call to the section as usual
-                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                if (sectionNum == 1) {
+                    // this is the only supported gauss id
+                    offset = 2;
                 }
-                else {
-                    // it is a number. Now we have to make sure it is within the allowed range
-                    // for this element (in this case it can only be 1)
-                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-                    // uses this call to understand how many fibers we have in a section
-                    if (sectionNum == 1) {
-                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
-                    }
+                else if (sectionNum > 1) {
+                    // this is a number, but not within the valid range
+                    is_valid = false;
                 }
+                // if it is 0, then it is not a number, forward it as usual...
             }
-            else {
-                // otherwise forward it as usual
-                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            if (is_valid) {
+                output.tag("GaussPointOutput");
+                output.attr("number", 1);
+                output.attr("eta", 0.0);
+                theResponse = theMaterial->setResponse(&argv[offset], argc - offset, output);
+                output.endTag();
             }
         }
-        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/CorotTrussSection.cpp
+++ b/SRC/element/truss/CorotTrussSection.cpp
@@ -964,38 +964,33 @@ CorotTrussSection::setResponse(const char **argv, int argc, OPS_Stream &output)
     // a section quantity
     }
     else if (strcmp(argv[0], "section") == 0) {
-        output.tag("GaussPointOutput");
-        output.attr("number", 1);
-        output.attr("eta", 0.0);
-
         if (argc > 1) {
             // we need at least one more argument otherwise 
-            // there is no need to forward this call to the section
+            // there is no need to forward this call to the material
+            // by default assume the old call style for backward compatibility "material result"
+            int offset = 1;
+            bool is_valid = true;
+            // in case the user specifies the gauss point id... "section 1 result"
             if (argc > 2) {
-                // if we have 2 or more extra arguments, the first one 
-                // could be an integer. In this case we check to see if it is the section id
-                // (only 1 in this case)
                 int sectionNum = atoi(argv[1]);
-                if (sectionNum == 0) {
-                    // if it is not a number we forward the call to the section as usual
-                    theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+                if (sectionNum == 1) {
+                    // this is the only supported gauss id
+                    offset = 2;
                 }
-                else {
-                    // it is a number. Now we have to make sure it is within the allowed range
-                    // for this element (in this case it can only be 1)
-                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-                    // uses this call to understand how many fibers we have in a section
-                    if (sectionNum == 1) {
-                        theResponse = theSection->setResponse(&argv[2], argc - 2, output);
-                    }
+                else if (sectionNum > 1) {
+                    // this is a number, but not within the valid range
+                    is_valid = false;
                 }
+                // if it is 0, then it is not a number, forward it as usual...
             }
-            else {
-                // otherwise forward it as usual
-                theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+            if (is_valid) {
+                output.tag("GaussPointOutput");
+                output.attr("number", 1);
+                output.attr("eta", 0.0);
+                theResponse = theSection->setResponse(&argv[offset], argc - offset, output);
+                output.endTag();
             }
         }
-        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/N4BiaxialTruss.cpp
+++ b/SRC/element/truss/N4BiaxialTruss.cpp
@@ -1276,59 +1276,38 @@ N4BiaxialTruss::setResponse(const char **argv, int argc, OPS_Stream &output)
 
 		// a material quantity
 	} else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
-		output.tag("GaussPointOutput");
-		output.attr("number", 1);
-		output.attr("eta", 0.0);
-
 		if (argc > 1) {
 			// we need at least one more argument otherwise 
 			// there is no need to forward this call to the material
+			// by default assume the old call style for backward compatibility "material result"
+			int offset = 1;
+			bool is_valid = true;
+			// in case the user specifies the gauss point id... "material 1 result"
 			if (argc > 2) {
-				// if we have 2 or more extra arguments, the first one 
-				// could be an integer. In this case we check to see if it is the section id
-				// (only 1 in this case)
 				int sectionNum = atoi(argv[1]);
-				if (sectionNum == 0) {
-					// if it is not a number we forward the call to the section as usual
-					CompositeResponse* theCResponse = new CompositeResponse();
-					Response* theResponse1 = theMaterial_1->setResponse(&argv[1], argc - 1, output);
-					Response* theResponse2 = theMaterial_2->setResponse(&argv[1], argc - 1, output);
-
-					theCResponse->addResponse(theResponse1);
-					theCResponse->addResponse(theResponse2);
-
-					theResponse = theCResponse;
+				if (sectionNum == 1) {
+					// this is the only supported gauss id
+					offset = 2;
 				}
-				else {
-					// it is a number. Now we have to make sure it is within the allowed range
-					// for this element (in this case it can only be 1)
-					// If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-					// uses this call to understand how many fibers we have in a section
-					if (sectionNum == 1) {
-						CompositeResponse* theCResponse = new CompositeResponse();
-						Response* theResponse1 = theMaterial_1->setResponse(&argv[2], argc - 2, output);
-						Response* theResponse2 = theMaterial_2->setResponse(&argv[2], argc - 2, output);
-
-						theCResponse->addResponse(theResponse1);
-						theCResponse->addResponse(theResponse2);
-
-						theResponse = theCResponse;
-					}
+				else if (sectionNum > 1) {
+					// this is a number, but not within the valid range
+					is_valid = false;
 				}
+				// if it is 0, then it is not a number, forward it as usual...
 			}
-			else {
-				// otherwise forward it as usual
+			if (is_valid) {
+				output.tag("GaussPointOutput");
+				output.attr("number", 1);
+				output.attr("eta", 0.0);
 				CompositeResponse* theCResponse = new CompositeResponse();
-				Response* theResponse1 = theMaterial_1->setResponse(&argv[1], argc - 1, output);
-				Response* theResponse2 = theMaterial_2->setResponse(&argv[1], argc - 1, output);
-
+				Response* theResponse1 = theMaterial_1->setResponse(&argv[offset], argc - offset, output);
+				Response* theResponse2 = theMaterial_2->setResponse(&argv[offset], argc - offset, output);
 				theCResponse->addResponse(theResponse1);
 				theCResponse->addResponse(theResponse2);
-
 				theResponse = theCResponse;
+				output.endTag();
 			}
 		}
-		output.endTag();
 	}
 
 	output.endTag();

--- a/SRC/element/truss/Truss.cpp
+++ b/SRC/element/truss/Truss.cpp
@@ -1195,38 +1195,33 @@ Truss::setResponse(const char **argv, int argc, OPS_Stream &output)
 	    
     // a material quantity
     } else if (strcmp(argv[0],"material") == 0 || strcmp(argv[0],"-material") == 0) {
-        output.tag("GaussPointOutput");
-        output.attr("number", 1);
-        output.attr("eta", 0.0);
-
         if (argc > 1) {
             // we need at least one more argument otherwise 
-			// there is no need to forward this call to the material
+            // there is no need to forward this call to the material
+            // by default assume the old call style for backward compatibility "material result"
+            int offset = 1;
+            bool is_valid = true;
+            // in case the user specifies the gauss point id... "material 1 result"
             if (argc > 2) {
-                // if we have 2 or more extra arguments, the first one 
-                // could be an integer. In this case we check to see if it is the section id
-                // (only 1 in this case)
                 int sectionNum = atoi(argv[1]);
-                if (sectionNum == 0) {
-                    // if it is not a number we forward the call to the section as usual
-                    theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+                if (sectionNum == 1) {
+                    // this is the only supported gauss id
+                    offset = 2;
                 }
-                else {
-                    // it is a number. Now we have to make sure it is within the allowed range
-                    // for this element (in this case it can only be 1)
-                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-                    // uses this call to understand how many fibers we have in a section
-                    if (sectionNum == 1) {
-                        theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
-                    }
+                else if (sectionNum > 1) {
+                    // this is a number, but not within the valid range
+                    is_valid = false;
                 }
+                // if it is 0, then it is not a number, forward it as usual...
             }
-            else {
-                // otherwise forward it as usual
-                theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+            if (is_valid) {
+                output.tag("GaussPointOutput");
+                output.attr("number", 1);
+                output.attr("eta", 0.0);
+                theResponse = theMaterial->setResponse(&argv[offset], argc - offset, output);
+                output.endTag();
             }
         }
-        output.endTag();
     }
 
     output.endTag();

--- a/SRC/element/truss/Truss2.cpp
+++ b/SRC/element/truss/Truss2.cpp
@@ -1196,38 +1196,33 @@ Response*
 			// a material quantity
 	}
 	else if (strcmp(argv[0], "material") == 0 || strcmp(argv[0], "-material") == 0) {
-		output.tag("GaussPointOutput");
-		output.attr("number", 1);
-		output.attr("eta", 0.0);
-
 		if (argc > 1) {
 			// we need at least one more argument otherwise 
 			// there is no need to forward this call to the material
+			// by default assume the old call style for backward compatibility "material result"
+			int offset = 1;
+			bool is_valid = true;
+			// in case the user specifies the gauss point id... "material 1 result"
 			if (argc > 2) {
-				// if we have 2 or more extra arguments, the first one 
-				// could be an integer. In this case we check to see if it is the section id
-				// (only 1 in this case)
 				int sectionNum = atoi(argv[1]);
-				if (sectionNum == 0) {
-					// if it is not a number we forward the call to the section as usual
-					theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+				if (sectionNum == 1) {
+					// this is the only supported gauss id
+					offset = 2;
 				}
-				else {
-					// it is a number. Now we have to make sure it is within the allowed range
-					// for this element (in this case it can only be 1)
-					// If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-					// uses this call to understand how many fibers we have in a section
-					if (sectionNum == 1) {
-						theResponse = theMaterial->setResponse(&argv[2], argc - 2, output);
-					}
+				else if (sectionNum > 1) {
+					// this is a number, but not within the valid range
+					is_valid = false;
 				}
+				// if it is 0, then it is not a number, forward it as usual...
 			}
-			else {
-				// otherwise forward it as usual
-				theResponse = theMaterial->setResponse(&argv[1], argc - 1, output);
+			if (is_valid) {
+				output.tag("GaussPointOutput");
+				output.attr("number", 1);
+				output.attr("eta", 0.0);
+				theResponse = theMaterial->setResponse(&argv[offset], argc - offset, output);
+				output.endTag();
 			}
 		}
-		output.endTag();
 	}
 
 	output.endTag();

--- a/SRC/element/truss/TrussSection.cpp
+++ b/SRC/element/truss/TrussSection.cpp
@@ -1125,38 +1125,33 @@ TrussSection::setResponse(const char **argv, int argc, OPS_Stream &output)
 
     // a section quantity
     } else if (strcmp(argv[0], "section") == 0) {
-        output.tag("GaussPointOutput");
-        output.attr("number", 1);
-        output.attr("eta", 0.0);
-        
         if (argc > 1) {
             // we need at least one more argument otherwise 
-            // there is no need to forward this call to the section
+            // there is no need to forward this call to the material
+            // by default assume the old call style for backward compatibility "material result"
+            int offset = 1;
+            bool is_valid = true;
+            // in case the user specifies the gauss point id... "section 1 result"
             if (argc > 2) {
-                // if we have 2 or more extra arguments, the first one 
-                // could be an integer. In this case we check to see if it is the section id
-                // (only 1 in this case)
                 int sectionNum = atoi(argv[1]);
-                if (sectionNum == 0) {
-                    // if it is not a number we forward the call to the section as usual
-                    theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+                if (sectionNum == 1) {
+                    // this is the only supported gauss id
+                    offset = 2;
                 }
-                else {
-                    // it is a number. Now we have to make sure it is within the allowed range
-                    // for this element (in this case it can only be 1)
-                    // If it is > 1, then we MUST return NULL, because the MPCO recorder iteratively
-                    // uses this call to understand how many fibers we have in a section
-                    if (sectionNum == 1) {
-                        theResponse = theSection->setResponse(&argv[2], argc - 2, output);
-                    }
+                else if (sectionNum > 1) {
+                    // this is a number, but not within the valid range
+                    is_valid = false;
                 }
+                // if it is 0, then it is not a number, forward it as usual...
             }
-            else {
-                // otherwise forward it as usual
-                theResponse = theSection->setResponse(&argv[1], argc - 1, output);
+            if (is_valid) {
+                output.tag("GaussPointOutput");
+                output.attr("number", 1);
+                output.attr("eta", 0.0);
+                theResponse = theSection->setResponse(&argv[offset], argc - offset, output);
+                output.endTag();
             }
         }
-        output.endTag();
     }
 
     output.endTag();


### PR DESCRIPTION
Dear Dr. @fmckenna and Prof. @mhscott ,
This PR fixes some bugs in the setResponse method of some elements:

- The Tetrahedron creates the "ResponseType" XML tag inside a for-loop of 3 iterations instead of 4 (number of nodes)
- The other truss elements instead open the "GaussPointOutput" tag even if a result is not supported.