### PR TITLE
Add an new element InertiaTruss to OpenSees

### DIFF
--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -138,7 +138,6 @@
 //#include "FiberSection.h"
 #include "FiberSection2d.h"
 #include "FiberSection3d.h"
-#include "FiberSectionAsym3d.h" //Xinlong Du
 #include "ElasticPlateSection.h"
 #include "ElasticMembranePlateSection.h"
 #include "MembranePlateFiberSection.h"
@@ -191,9 +190,6 @@
 #include "UWmaterials/ManzariDafaliasPlaneStrainRO.h"
 #include "UWmaterials/PM4Sand.h"
 #include "UWmaterials/PM4Silt.h"
-#include "J2CyclicBoundingSurface.h"
-#include "J2CyclicBoundingSurface3D.h"
-#include "J2CyclicBoundingSurfacePlaneStrain.h"
 #include "UWmaterials/InitialStateAnalysisWrapper.h"
 #include "stressDensityModel/stressDensity.h"
 #include "InitStressNDMaterial.h"
@@ -216,6 +212,7 @@
 #include "truss/TrussSection.h"
 #include "truss/CorotTruss.h"
 #include "truss/CorotTrussSection.h"
+#include "truss/InertiaTruss.h"
 #include "zeroLength/ZeroLength.h"
 #include "zeroLength/ZeroLengthSection.h"
 #include "zeroLength/ZeroLengthContact2D.h"
@@ -263,8 +260,6 @@
 
 #include "dispBeamColumn/DispBeamColumn2d.h"
 #include "dispBeamColumn/DispBeamColumn3d.h"
-#include "dispBeamColumn/DispBeamColumnAsym3d.h"    //Xinlong Du
-#include "mixedBeamColumn/MixedBeamColumnAsym3d.h"  //Xinlong Du
 #include "shell/ShellMITC4.h"
 #include "shell/ShellMITC9.h"
 #include "shell/ShellDKGQ.h"   //Added by Lisha Wang, Xinzheng Lu, Linlin Xie, Song Cen & Quan Gu
@@ -661,6 +656,9 @@ FEM_ObjectBrokerAllClasses::getNewElement(int classTag)
     case ELE_TAG_CorotTrussSection:  
       return new CorotTrussSection(); 	     
       
+	case ELE_TAG_InertiaTruss:
+		return new InertiaTruss();
+
     case ELE_TAG_ZeroLength:  
       return new ZeroLength(); 	     
       
@@ -719,12 +717,6 @@ FEM_ObjectBrokerAllClasses::getNewElement(int classTag)
       
     case ELE_TAG_DispBeamColumn3d:  
       return new DispBeamColumn3d(); 
-
-	case ELE_TAG_DispBeamColumnAsym3d:
-		return new DispBeamColumnAsym3d();    //Xinlong Du
-
-	case ELE_TAG_MixedBeamColumnAsym3d:
-		return new MixedBeamColumnAsym3d();   //Xinlong Du
       
     case ELE_TAG_EnhancedQuad:
       return new EnhancedQuad();
@@ -1379,9 +1371,6 @@ FEM_ObjectBrokerAllClasses::getNewSection(int classTag)
 	case SEC_TAG_FiberSection3d:
 		return new FiberSection3d();
 
-	case SEC_TAG_FiberSectionAsym3d:
-		return new FiberSectionAsym3d(); //Xinlong Du
-
 	case SEC_TAG_ElasticPlateSection:
 		return new ElasticPlateSection();
 
@@ -1521,15 +1510,6 @@ FEM_ObjectBrokerAllClasses::getNewNDMaterial(int classTag)
 
   case ND_TAG_PM4Silt:
 	return new PM4Silt();
-
-  case ND_TAG_J2CyclicBoundingSurface:
-	  return new J2CyclicBoundingSurface();
-
-  case ND_TAG_J2CyclicBoundingSurface3D:
-	  return new J2CyclicBoundingSurface3D();
-  
-  case ND_TAG_J2CyclicBoundingSurfacePlaneStrain:
-	  return new J2CyclicBoundingSurfacePlaneStrain();
 
   case ND_TAG_InitialStateAnalysisWrapper:
       return new InitialStateAnalysisWrapper(); 

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -292,7 +292,6 @@
 #define SEC_TAG_NDFiberSection2d		         900
 #define SEC_TAG_FiberSection3d		        10
 #define SEC_TAG_FiberSectionWarping3d		        1010
-#define SEC_TAG_FiberSectionAsym3d		        1011
 #define SEC_TAG_NDFiberSection3d		         1000
 #define SEC_TAG_FiberSectionGJ		        11
 #define SEC_TAG_BeamFiberSection	        12
@@ -459,7 +458,7 @@
 #define ND_TAG_PM4Sand                        14021
 // PM4Silt material - L.Chen
 #define ND_TAG_PM4Silt                        14022
-// J2CyclicBoundingSurface material - P. Arduino,  D.Turello
+// J2CyclicBoundingSurface material - D.Turello
 #define ND_TAG_J2CyclicBoundingSurface            14023
 #define ND_TAG_J2CyclicBoundingSurface3D          14024
 #define ND_TAG_J2CyclicBoundingSurfacePlaneStrain 14025
@@ -623,9 +622,7 @@
 #define ELE_TAG_DispBeamColumnNL2d        621
 #define ELE_TAG_TimoshenkoBeamColumn2d  63
 #define ELE_TAG_DispBeamColumn3d        64
-#define ELE_TAG_DispBeamColumnNL3d        640
 #define ELE_TAG_DispBeamColumnWarping3d        641
-#define ELE_TAG_DispBeamColumnAsym3d           642
 #define ELE_TAG_HingedBeam2d            65
 #define ELE_TAG_HingedBeam3d            66
 #define ELE_TAG_TwoPointHingedBeam2d    67
@@ -644,7 +641,6 @@
 #define ELE_TAG_ForceBeamColumnCBDI3d   78
 #define ELE_TAG_MixedBeamColumn2d 30766
 #define ELE_TAG_MixedBeamColumn3d 30765
-#define ELE_TAG_MixedBeamColumnAsym3d 30767
 #define ELE_TAG_DispBeamColumn2dInt     79
 #define ELE_TAG_InternalSpring          80
 #define ELE_TAG_SimpleJoint2D           81
@@ -780,6 +776,7 @@
 #define ELE_TAG_BeamColumn2DwLHNMYS_Damage 211
 #define ELE_TAG_MVLEM_3D	          212 // Kristijan Kolozvari
 #define ELE_TAG_SFI_MVLEM_3D	          213 // Kristijan Kolozvari
+#define ELE_TAG_InertiaTruss              214	//Added by Xiaodong Ji, Yuhao Cheng, Yue Yu
 #define ELE_TAG_ExternalElement           99990
 
 

--- a/SRC/element/TclElementCommands.cpp
+++ b/SRC/element/TclElementCommands.cpp
@@ -150,6 +150,7 @@ extern void *OPS_ElastomericBearingBoucWenMod3d(void);
 extern void *OPS_PFEMElement2DBubble(const ID &info);
 extern void *OPS_PFEMElement2Dmini(const ID &info);
 extern void *OPS_PFEMElement2D();
+extern void* OPS_InertiaTrussElement(void);     //Added by Xiaodong Ji, Yuhao Cheng, Yue Yu
 #ifdef _HAVE_LHNMYS
 extern void* OPS_BeamColumn2DwLHNMYS(void);
 extern void* OPS_BeamColumn2DwLHNMYS_Damage(void);
@@ -185,9 +186,6 @@ extern void *OPS_RJWatsonEQS3d(void);
 extern void *OPS_RockingBC(void);
 
 extern void* OPS_LehighJoint2d(void);
-
-extern void* OPS_DispBeamColumnAsym3dTcl();  //Xinlong Du
-extern void* OPS_MixedBeamColumnAsym3dTcl(); //Xinlong Du
 
 extern int TclModelBuilder_addFeapTruss(ClientData clientData, Tcl_Interp *interp,  int argc,
 					TCL_Char **argv, Domain*, TclModelBuilder *, int argStart);
@@ -1433,35 +1431,16 @@ TclModelBuilderElementCommand(ClientData clientData, Tcl_Interp *interp,
       return TCL_ERROR;
     }
   }
+  else if ((strcmp(argv[1], "InertiaTruss") == 0)) { 	
 
-  //Xinlong Du
-  else if ((strcmp(argv[1], "dispBeamColumnAsym") == 0) || (strcmp(argv[1], "dispBeamAsym")) == 0) {
-  Element* theEle = 0;
-  if (OPS_GetNDM() == 3)
-      theEle = (Element*)OPS_DispBeamColumnAsym3dTcl();
+  void* theEle = OPS_InertiaTrussElement();
   if (theEle != 0)
-      theElement = theEle;
+      theElement = (Element*)theEle;
   else {
-      opserr << "TclElementCommand -- unable to create element of type : " << argv[1] << endln;
+      opserr << "tclelementcommand -- unable to create element of type : " << argv[1] << endln;
       return TCL_ERROR;
   }
-
   }
-
-  else if ((strcmp(argv[1], "mixedBeamColumnAsym") == 0) || (strcmp(argv[1], "mixedBeamAsym") == 0)) {
-  Element* theEle = 0;
-  if (OPS_GetNDM() == 3)
-      theEle = (Element*)OPS_MixedBeamColumnAsym3dTcl();
-  if (theEle != 0)
-      theElement = theEle;
-  else {
-      opserr << "TclElementCommand -- unable to create element of type : " << argv[1] << endln;
-      return TCL_ERROR;
-  }
-
-  }
-  //Xinlong Du
-  
   // if one of the above worked
   if (theElement != 0) {
     if (theTclDomain->addElement(theElement) == false) {

--- a/SRC/element/truss/InertiaTruss.cpp
+++ b/SRC/element/truss/InertiaTruss.cpp
@@ -1,0 +1,1002 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+************************************************************************
+** 
+** 
+**************************************************************************************************************
+** InertiaTruss Element                                                                                     **
+** First published in: Ji X, Cheng Y, Molina Hutt C.                                                        **
+** Seismic response of a tuned viscous mass damper (TVMD) coupled wall system. Eng Struct 2020;225:111252.  **
+** https://doi.org/10.1016/j.engstruct.2020.111252.                                                         **
+** *********************************************************************************************************** 
+*/
+
+// Description: This file contains the implementation for the InertiaTruss class.
+// Not Ready for sensitivity analysis yet
+// modified from truss.cpp    author: Frank McKenna
+
+#include <InertiaTruss.h>
+#include <Information.h>
+#include <Parameter.h>
+
+#include <Domain.h>
+#include <Node.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <UniaxialMaterial.h>
+#include <Renderer.h>
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ElementResponse.h>
+
+//#include <fstream>
+
+// initialise the class wide variables
+Matrix InertiaTruss::trussM2(2,2);
+Matrix InertiaTruss::trussM4(4,4);
+Matrix InertiaTruss::trussM6(6,6);
+Matrix InertiaTruss::trussM12(12,12);
+Vector InertiaTruss::trussV2(2);
+Vector InertiaTruss::trussV4(4);
+Vector InertiaTruss::trussV6(6);
+Vector InertiaTruss::trussV12(12);
+#include <elementAPI.h>
+
+#define OPS_Export
+
+static int numMyTruss = 0;
+
+// constructor:
+//  responsible for allocating the necessary space needed by each object
+//  and storing the tags of the inertiatruss end nodes.
+
+
+OPS_Export void *
+OPS_InertiaTrussElement()
+{
+  // print out a message about who wrote this element & any copyright info wanted
+  if (numMyTruss == 0) {
+    opserr << " \n";
+	opserr << "                          InertiaTruss element v1.0\n";
+	opserr << "                    by Xiaodong Ji, Yuhao Cheng, Yue Yu\n";
+	opserr << "                           Tsinghua University\n";
+	opserr << "Please contact jixd@mail.tsinghua.edu.cn, yuhao_cheng@126.com if anything goes wrong\n";
+	opserr << " \n";
+	numMyTruss++;
+
+  }
+	
+  Element *theElement = 0;
+
+  int numRemainingArgs = OPS_GetNumRemainingInputArgs();
+
+  if (numRemainingArgs < 4) {
+    opserr << "Invalid Args want: element InertiaTruss $tag $iNode $jNode $mr\n";
+    return 0;	
+  }
+
+  int iData[3];
+  double mr = 0.0;
+  int ndm = OPS_GetNDM();
+
+  int numData = 3;
+  if (OPS_GetIntInput(&numData, iData) != 0) {
+    opserr << "WARNING invalid integer (tag, iNode, jNode) in element InertiaTruss " << endln;
+    return 0;
+  }
+
+  numData = 1;
+  if (OPS_GetDoubleInput(&numData, &mr) != 0) {
+    opserr << "WARNING: Invalid mr: element InertiaTruss " << iData[0] << 
+      " $iNode $jNode $mr\n";
+    return 0;	
+  }
+
+  // now create the InertiaTruss
+  theElement = new InertiaTruss(iData[0], ndm, iData[1], iData[2], mr);
+
+  if (theElement == 0) {
+    opserr << "WARNING: out of memory: element InertiaTruss " << iData[0] << 
+      " $iNode $jNode $mr\n";
+  }
+
+  return theElement;
+}
+
+InertiaTruss::InertiaTruss(int tag, int dim,
+	int Nd1, int Nd2,
+	double mr)
+ :Element(tag,ELE_TAG_InertiaTruss),
+  connectedExternalNodes(2),
+  dimension(dim), numDOF(0),
+  theLoad(0), theMatrix(0), theVector(0),
+  L(0.0),  mass(mr), initialDisp(0)
+{
+  
+    // ensure the connectedExternalNode ID is of correct size & set values
+    if (connectedExternalNodes.Size() != 2) {
+      opserr << "FATAL InertiaTruss::InertiaTruss - " <<  tag << "failed to create an ID of size 2\n";
+      exit(-1);
+    }
+
+    connectedExternalNodes(0) = Nd1;
+    connectedExternalNodes(1) = Nd2;        
+
+    // set node pointers to NULL
+    for (int i=0; i<2; i++)
+      theNodes[i] = 0;
+
+    cosX[0] = 0.0;
+    cosX[1] = 0.0;
+    cosX[2] = 0.0;
+
+// AddingSensitivity:BEGIN /////////////////////////////////////
+	parameterID = 0;
+	theLoadSens = 0;
+// AddingSensitivity:END //////////////////////////////////////
+}
+
+// constructor:
+//   invoked by a FEM_ObjectBroker - blank object that recvSelf needs
+//   to be invoked upon
+InertiaTruss::InertiaTruss()
+:Element(0,ELE_TAG_InertiaTruss),     
+ connectedExternalNodes(2),
+ dimension(0), numDOF(0),
+ theLoad(0), theMatrix(0), theVector(0),
+ L(0.0), mass(0.0)
+{
+    // ensure the connectedExternalNode ID is of correct size 
+  if (connectedExternalNodes.Size() != 2) {
+      opserr << "FATAL InertiaTruss::InertiaTruss - failed to create an ID of size 2\n";
+      exit(-1);
+  }
+  for (int i=0; i<2; i++)
+    theNodes[i] = 0;
+
+  cosX[0] = 0.0;
+  cosX[1] = 0.0;
+  cosX[2] = 0.0;
+
+// AddingSensitivity:BEGIN /////////////////////////////////////
+	parameterID = 0;
+	theLoadSens = 0;
+// AddingSensitivity:END //////////////////////////////////////
+}
+
+//  destructor
+//     delete must be invoked on any objects created by the object
+//     and on the matertial object.
+InertiaTruss::~InertiaTruss()
+{
+    // invoke the destructor on any objects created by the object
+    // that the object still holds a pointer to
+    if (theLoad != 0)
+	delete theLoad;
+    if (theLoadSens != 0)
+	delete theLoadSens;
+    if (initialDisp != 0)
+      delete [] initialDisp;
+}
+
+
+int
+InertiaTruss::getNumExternalNodes(void) const
+{
+    return 2;
+}
+
+const ID &
+InertiaTruss::getExternalNodes(void) 
+{
+    return connectedExternalNodes;
+}
+
+Node **
+InertiaTruss::getNodePtrs(void) 
+{
+  return theNodes;
+}
+
+int
+InertiaTruss::getNumDOF(void) 
+{
+    return numDOF;
+}
+
+
+// method: setDomain()
+//    to set a link to the enclosing Domain and to set the node pointers.
+//    also determines the number of dof associated
+//    with the truss element, we set matrix and vector pointers,
+//    allocate space for t matrix, determine the length
+//    and set the transformation matrix.
+void
+InertiaTruss::setDomain(Domain *theDomain)
+{
+    // check Domain is not null - invoked when object removed from a domain
+    if (theDomain == 0) {
+	theNodes[0] = 0;
+	theNodes[1] = 0;
+	L = 0;
+	return;
+    }
+
+    // first set the node pointers
+    int Nd1 = connectedExternalNodes(0);
+    int Nd2 = connectedExternalNodes(1);
+    theNodes[0] = theDomain->getNode(Nd1);
+    theNodes[1] = theDomain->getNode(Nd2);	
+    
+    // if can't find both - send a warning message
+    if ((theNodes[0] == 0) || (theNodes[1] == 0)) {
+      if (theNodes[0] == 0)
+	opserr <<"InertiaTruss::setDomain() - truss" << this->getTag() << " node " << Nd1 <<
+	  "does not exist in the model\n";
+      else
+	opserr <<"InertiaTruss::setDomain() - truss" << this->getTag() << " node " << Nd2 <<
+	  "does not exist in the model\n";
+
+      // fill this in so don't segment fault later
+      numDOF = 2;    
+      theMatrix = &trussM2;
+      theVector = &trussV2;	
+      return;
+    }
+
+    // now determine the number of dof and the dimesnion    
+    int dofNd1 = theNodes[0]->getNumberDOF();
+    int dofNd2 = theNodes[1]->getNumberDOF();	
+
+    // if differing dof at the ends - print a warning message
+    if (dofNd1 != dofNd2) {
+      opserr <<"WARNING InertiaTruss::setDomain(): nodes " << Nd1 << " and " << Nd2 <<
+	"have differing dof at ends for truss " << this->getTag() << endln;
+
+      // fill this in so don't segment fault later
+      numDOF = 2;    
+      theMatrix = &trussM2;
+      theVector = &trussV2;	
+	
+      return;
+    }	
+
+    // call the base class method
+    this->DomainComponent::setDomain(theDomain);
+
+    // now set the number of dof for element and set matrix and vector pointer
+    if (dimension == 1 && dofNd1 == 1) {
+	numDOF = 2;    
+	theMatrix = &trussM2;
+	theVector = &trussV2;
+    }
+    else if (dimension == 2 && dofNd1 == 2) {
+	numDOF = 4;
+	theMatrix = &trussM4;
+	theVector = &trussV4;	
+    }
+    else if (dimension == 2 && dofNd1 == 3) {
+	numDOF = 6;	
+	theMatrix = &trussM6;
+	theVector = &trussV6;		
+    }
+    else if (dimension == 3 && dofNd1 == 3) {
+	numDOF = 6;	
+	theMatrix = &trussM6;
+	theVector = &trussV6;			
+    }
+    else if (dimension == 3 && dofNd1 == 6) {
+	numDOF = 12;	    
+	theMatrix = &trussM12;
+	theVector = &trussV12;			
+    }
+    else {
+      opserr <<"WARNING InertiaTruss::setDomain cannot handle " << dimension << " dofs at nodes in " << 
+	dofNd1  << " problem\n";
+
+      numDOF = 2;    
+      theMatrix = &trussM2;
+      theVector = &trussV2;	
+      return;
+    }
+
+    // create the load vector
+    if (theLoad == 0)
+      theLoad = new Vector(numDOF);
+    else if (theLoad->Size() != numDOF) {
+      delete theLoad;
+      theLoad = new Vector(numDOF);
+    }
+
+    if (theLoad == 0) {
+      opserr << "InertiaTruss::setDomain - truss " << this->getTag() << 
+	"out of memory creating vector of size" << numDOF << endln;
+      exit(-1);
+      return;
+    }          
+    
+    // now determine the length, cosines and fill in the transformation
+    // NOTE t = -t(every one else uses for residual calc)
+    const Vector &end1Crd = theNodes[0]->getCrds();
+    const Vector &end2Crd = theNodes[1]->getCrds();	
+    const Vector &end1Disp = theNodes[0]->getDisp();
+    const Vector &end2Disp = theNodes[1]->getDisp();
+
+    if (dimension == 1) {
+      double dx = end2Crd(0)-end1Crd(0);
+
+      if (initialDisp == 0) {
+	double iDisp = end2Disp(0)-end1Disp(0);
+
+	if (iDisp != 0) {
+	  initialDisp = new double[1];
+	  initialDisp[0] = iDisp;
+	  dx += iDisp;
+	}
+      }
+      L = sqrt(dx*dx);
+      
+      if (L == 0.0) {
+	opserr <<"WARNING InertiaTruss::setDomain() - truss " << this->getTag() << " has zero length\n";
+	return;
+      }
+      
+      cosX[0] = 1.0;
+    }
+    else if (dimension == 2) {
+      double dx = end2Crd(0)-end1Crd(0);
+      double dy = end2Crd(1)-end1Crd(1);	
+    
+      if (initialDisp == 0) {
+	double iDispX = end2Disp(0)-end1Disp(0);
+	double iDispY = end2Disp(1)-end1Disp(1);
+	if (iDispX != 0 || iDispY != 0) {
+	  initialDisp = new double[2];
+	  initialDisp[0] = iDispX;
+	  initialDisp[1] = iDispY;
+	  dx += iDispX;
+	  dy += iDispY;
+	}
+      }
+      
+      L = sqrt(dx*dx + dy*dy);
+      
+      if (L == 0.0) {
+	opserr <<"WARNING InertiaTruss::setDomain() - truss " << this->getTag() << " has zero length\n";
+	return;
+      }
+	
+      cosX[0] = dx/L;
+      cosX[1] = dy/L;
+    }
+    else {
+
+      double dx = end2Crd(0)-end1Crd(0);
+      double dy = end2Crd(1)-end1Crd(1);	
+      double dz = end2Crd(2)-end1Crd(2);		
+
+      if (initialDisp == 0) {
+	double iDispX = end2Disp(0)-end1Disp(0);
+	double iDispY = end2Disp(1)-end1Disp(1);      
+	double iDispZ = end2Disp(2)-end1Disp(2);      
+	if (iDispX != 0 || iDispY != 0 || iDispZ != 0) {
+	  initialDisp = new double[3];
+	  initialDisp[0] = iDispX;
+	  initialDisp[1] = iDispY;
+	  initialDisp[2] = iDispZ;
+	  dx += iDispX;
+	  dy += iDispY;
+	  dz += iDispZ;
+	}
+      }
+      
+      L = sqrt(dx*dx + dy*dy + dz*dz);
+      
+      if (L == 0.0) {
+	opserr <<"WARNING InertiaTruss::setDomain() - inertiatruss " << this->getTag() << " has zero length\n";
+	return;
+      }
+	
+	cosX[0] = dx/L;
+	cosX[1] = dy/L;
+	cosX[2] = dz/L;
+    }
+}   	 
+
+
+int
+InertiaTruss::commitState()
+{
+  int retVal = 0;
+  // call element commitState to do any base class stuff
+  if ((retVal = this->Element::commitState()) != 0) {
+    opserr << "InertiaTruss::commitState () - failed in base class";
+  }    
+  return retVal;
+}
+
+int
+InertiaTruss::revertToLastCommit()
+{
+	return 0;
+}
+
+int
+InertiaTruss::revertToStart()
+{
+	return 0;
+}
+
+int
+InertiaTruss::update(void)
+{
+	double strain = this->computeCurrentStrain();
+	double rate = this->computeCurrentStrainRate();
+	return 0;
+}
+
+
+const Matrix &
+InertiaTruss::getTangentStiff(void)
+{
+
+    // come back later and redo this if too slow
+    Matrix &stiff = *theMatrix;
+
+    int numDOF2 = numDOF/2;
+    double temp;
+    double EAoverL = 0.0000000001;
+    for (int i = 0; i < dimension; i++) {
+      for (int j = 0; j < dimension; j++) {
+	temp = cosX[i]*cosX[j]*EAoverL;
+	stiff(i,j) = temp;
+	stiff(i+numDOF2,j) = -temp;
+	stiff(i,j+numDOF2) = -temp;
+	stiff(i+numDOF2,j+numDOF2) = temp;
+      }
+    }
+
+    return stiff;
+}
+
+
+const Matrix &
+InertiaTruss::getInitialStiff(void)
+{
+    // come back later and redo this if too slow
+    Matrix &stiff = *theMatrix;
+
+    int numDOF2 = numDOF/2;
+    double temp;
+    double EAoverL = 0.0000000001;
+    for (int i = 0; i < dimension; i++) {
+      for (int j = 0; j < dimension; j++) {
+	temp = cosX[i]*cosX[j]*EAoverL;
+	stiff(i,j) = temp;
+	stiff(i+numDOF2,j) = -temp;
+	stiff(i,j+numDOF2) = -temp;
+	stiff(i+numDOF2,j+numDOF2) = temp;
+      }
+    }
+
+    return *theMatrix;
+}
+
+
+
+const Matrix &
+InertiaTruss::getMass(void)
+{
+  // zero the matrix
+  Matrix &Mmass = *theMatrix;
+  Mmass.Zero();
+  
+  // check for quick return
+  if (L == 0.0 || mass == 0.0) { // - problem in setDomain() no further warnings
+    return Mmass;
+  }
+  
+
+	  // inertia mass matrix
+	  double m = mass;
+	  int numDOF2 = numDOF / 2;
+	  double temp;
+	  for (int i = 0; i < dimension; i++) {
+		  for (int j = 0; j < dimension; j++) {
+			  temp = cosX[i] * cosX[j] * m;
+			  Mmass(i, j) = temp;
+			  Mmass(i + numDOF2, j) = -temp;
+			  Mmass(i, j + numDOF2) = -temp;
+			  Mmass(i + numDOF2, j + numDOF2) = temp;
+
+	  }
+  }
+  
+      return Mmass;
+}
+  
+void 
+InertiaTruss::zeroLoad(void)
+{
+  theLoad->Zero();
+}
+
+int 
+InertiaTruss::addLoad(ElementalLoad *theLoad, double loadFactor)
+
+{  
+  opserr <<"InertiaTruss::addLoad - load type unknown for InertiaTruss with tag: " << this->getTag() << endln; 
+  return -1;
+}
+
+int 
+InertiaTruss::addInertiaLoadToUnbalance(const Vector &accel)
+{
+  // check for a quick return
+  if (L == 0.0 || mass == 0.0) 
+    return 0;
+  
+  // get R * accel from the nodes
+  const Vector &Raccel1 = theNodes[0]->getRV(accel);
+  const Vector &Raccel2 = theNodes[1]->getRV(accel);    
+  
+  int nodalDOF = numDOF/2;
+  
+#ifdef _G3DEBUG    
+  if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
+    opserr <<"InertiaTruss::addInertiaLoadToUnbalance " <<
+      "matrix and vector sizes are incompatable\n";
+    return -1;
+  }
+#endif
+  
+  // want to add ( - fact * M R * accel ) to unbalance
+  
+    double m = mass;
+	opserr << m;
+	Matrix &addinertiamass = *theMatrix;
+	double temp;
+	for (int i = 0; i < dimension; i++) {
+		for (int j = 0; j < dimension; j++) {
+			temp = cosX[i] * cosX[j] * m;
+			addinertiamass(i, j) = temp;
+			addinertiamass(i + nodalDOF, j) = -temp;
+			addinertiamass(i, j + nodalDOF) = -temp;
+			addinertiamass(i + nodalDOF, j + nodalDOF) = temp;
+		}
+	}
+	for (int k = 0; k < dimension; k++) {
+		for (int l = 0; l < dimension; l++) {
+			(*theLoad)(k) -= addinertiamass(k, l)*Raccel1(l) + addinertiamass(k, l + nodalDOF)*Raccel2(l);
+			(*theLoad)(k + nodalDOF) -= addinertiamass(k + nodalDOF, l)*Raccel1(l) + addinertiamass(k + nodalDOF, l + nodalDOF)*Raccel2(l);
+		}
+	}
+  
+  return 0;
+}
+
+
+int 
+InertiaTruss::addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool somethingRandomInMotions)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	return -1;
+}
+
+const Vector &
+InertiaTruss::getResistingForce()
+{	
+    if (L == 0.0) { // - problem in setDomain() no further warnings
+	theVector->Zero();
+	return *theVector;
+    }
+    
+    // R = Ku - Pext
+    // Ku = F * transformation
+    int numDOF2 = numDOF/2;
+    double temp;
+    for (int i = 0; i < dimension; i++) {
+      (*theVector)(i) = 0;
+      (*theVector)(i+numDOF2) = 0;
+    }
+    
+    return *theVector;
+}
+
+
+const Vector &
+InertiaTruss::getResistingForceIncInertia()
+{	
+  this->getResistingForce();
+  
+  // subtract external load
+  (*theVector) -= *theLoad;
+  
+  // now include the mass portion
+  if (L != 0.0 && mass != 0.0) {
+    
+    // add inertia forces from element mass
+    const Vector &accel1 = theNodes[0]->getTrialAccel();
+    const Vector &accel2 = theNodes[1]->getTrialAccel();	
+    
+    int numDOF2 = numDOF/2;
+    
+    
+      // inertia mass matrix
+	  double m = mass;
+	  Matrix &getinertiaforce = *theMatrix;
+	  double temp;
+	  for (int i = 0; i < dimension; i++) {
+		  for (int j = 0; j < dimension; j++) {
+			  temp = cosX[i] * cosX[j] * m;
+			  getinertiaforce(i, j) = temp;
+			  getinertiaforce(i + numDOF2, j) = -temp;
+			  getinertiaforce(i, j + numDOF2) = -temp;
+			  getinertiaforce(i + numDOF2, j + numDOF2) = temp;
+		  }
+	  }
+	  for (int k = 0; k < dimension; k++) {
+		  for (int l = 0; l < dimension; l++) {
+			  (*theVector)(k) += getinertiaforce(k, l)*accel1(l) + getinertiaforce(k, l + numDOF2)*accel2(l);
+			  (*theVector)(k + numDOF2) += getinertiaforce(k + numDOF2, l)*accel1(l) + getinertiaforce(k + numDOF2, l + numDOF2)*accel2(l);
+		  }
+	  }  
+  }
+  
+  return *theVector;
+}
+
+int
+InertiaTruss::sendSelf(int commitTag, Channel &theChannel)
+{
+  int res;
+
+  // note: we don't check for dataTag == 0 for Element
+  // objects as that is taken care of in a commit by the Domain
+  // object - don't want to have to do the check if sending data
+  int dataTag = this->getDbTag();
+  // truss packs it's data into a Vector and sends this to theChannel
+  // along with it's dbTag and the commitTag passed in the arguments
+
+  static Vector data(12);
+  data(0) = this->getTag();
+  data(1) = dimension;
+  data(2) = numDOF;
+  data(3) = mass; 
+  if (initialDisp != 0) {
+    for (int i=0; i<dimension; i++) {
+      data[4+i] = initialDisp[i];
+    }
+  }
+
+  res = theChannel.sendVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr <<"WARNING InertiaTruss::sendSelf() - " << this->getTag() << " failed to send Vector\n";
+    return -1;
+  }	      
+
+  // inertiatruss then sends the tags of it's two end nodes
+  res = theChannel.sendID(dataTag, commitTag, connectedExternalNodes);
+  if (res < 0) {
+    opserr <<"WARNING InertiaTruss::sendSelf() - " << this->getTag() << " failed to send Vector\n";
+    return -2;
+  }
+
+  return 0;
+}
+
+int
+InertiaTruss::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
+{
+  int res;
+  int dataTag = this->getDbTag();
+
+  // inertiatruss creates a Vector, receives the Vector and then sets the 
+  // internal data with the data in the Vector
+
+  static Vector data(12);
+  res = theChannel.recvVector(dataTag, commitTag, data);
+  if (res < 0) {
+    opserr <<"WARNING InertiaTruss::recvSelf() - failed to receive Vector\n";
+    return -1;
+  }	      
+
+  this->setTag((int)data(0));
+  dimension = (int)data(1);
+  numDOF = (int)data(2);
+  mass = data(3);
+
+
+  initialDisp = new double[dimension];
+  for (int i=0; i<dimension; i++)
+    initialDisp[i] = 0.0;
+
+  int initial = 0;
+  for (int i=0; i<dimension; i++) {
+    if (data(4+i) != 0.0) {
+      initial = 1;
+    }
+  }
+  
+  if (initial != 0) {
+    for (int i=0; i<dimension; i++) {
+      initialDisp[i] = data(4+i);
+    }    
+  }
+  
+  // inertiatruss now receives the tags of it's two external nodes
+  res = theChannel.recvID(dataTag, commitTag, connectedExternalNodes);
+  if (res < 0) {
+    opserr <<"WARNING InertiaTruss::recvSelf() - " << this->getTag() << " failed to receive ID\n";
+    return -2;
+  }
+  return 0;
+}
+
+int
+InertiaTruss::displaySelf(Renderer &theViewer, int displayMode, float fact, 
+		   const char **displayModes, int numModes)
+{
+  int res = 0;
+  if (L == 0.0)
+    return res;
+  
+  static Vector v1(3);
+  static Vector v2(3);
+  static Vector relativeaccel(dimension);
+  float d1 = 0.0;
+  float d2 = 0.0;
+  
+  theNodes[0]->getDisplayCrds(v1, fact);
+  theNodes[1]->getDisplayCrds(v2, fact);
+
+  if (displayMode > 0) {
+    res += theViewer.drawLine(v1, v2, d1, d1, this->getTag(), 0);
+  }
+  
+  for (int i=0; i<numModes; i++) {
+    
+    const char *mode = displayModes[i];
+    if (strcmp(mode, "axialForce") == 0) {
+      double force = 0;    	  
+      d1 = force; 
+      d2 = force;
+
+      res +=theViewer.drawLine(v1, v2, d1, d1, this->getTag(), i);
+      
+    } else if (strcmp(mode, "material") == 0) {
+      d1 = theMaterial->getTag();
+      d2 = theMaterial->getTag();
+
+      res += theViewer.drawLine(v1, v2, d1, d1, this->getTag(), i);
+      
+    } else if (strcmp(mode, "materialStress") == 0) {
+      d1 = theMaterial->getStress();
+      d2 = theMaterial->getStress();
+
+      res += theViewer.drawLine(v1, v2, d1, d1, this->getTag(), i);
+      
+      } else if (strcmp(mode, "materialStrain") == 0) {
+      
+      d1 = theMaterial->getStrain();
+      d2 = theMaterial->getStrain();
+
+      res += theViewer.drawLine(v1, v2, d1, d1, this->getTag(), i);
+    }
+  }    
+  return res;
+}
+
+
+
+void
+InertiaTruss::Print(OPS_Stream &s, int flag)
+{
+    //double force=0;
+    
+	if (flag == OPS_PRINT_CURRENTSTATE) {
+		s << "Element: " << this->getTag();
+		s << " type: InertiaTruss  iNode: " << connectedExternalNodes(0);
+		s << " jNode: " << connectedExternalNodes(1);
+        s << " mr: " << mass;//mass of inertia
+        
+		if (initialDisp != 0) {
+			s << " initialDisplacements: ";
+			for (int i = 0; i < dimension; i++)
+				s << initialDisp[i] << " ";
+		}
+		s << endln;
+	}
+    if (flag == 1) {
+        s << "Nothing to be printed." << endln;
+    }
+    
+	if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		s << "\t\t\t{";
+		s << "\"name\": " << this->getTag() << ", ";
+		s << "\"type\": \"InertiaTruss\", ";
+		s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
+		s << "\"mr\": " << mass << ", ";
+	}
+}
+
+double
+InertiaTruss::computeCurrentStrain(void) const
+{
+    // NOTE method will not be called if L == 0
+
+    // determine the strain
+    const Vector &disp1 = theNodes[0]->getTrialDisp();
+    const Vector &disp2 = theNodes[1]->getTrialDisp();	
+
+    double dLength = 0.0;
+    if (initialDisp == 0)
+      for (int i = 0; i < dimension; i++)
+	dLength += (disp2(i)-disp1(i))*cosX[i];
+    else
+      for (int i = 0; i < dimension; i++)
+	dLength += (disp2(i)-disp1(i)-initialDisp[i])*cosX[i];
+  
+    // this method should never be called with L == 0
+    return dLength/L;
+}
+
+double
+InertiaTruss::computeCurrentStrainRate(void) const
+{
+    // NOTE method will not be called if L == 0
+    // determine the strain
+    const Vector &vel1 = theNodes[0]->getTrialVel();
+    const Vector &vel2 = theNodes[1]->getTrialVel();	
+
+    double dLength = 0.0;
+    for (int i = 0; i < dimension; i++)
+      dLength += (vel2(i)-vel1(i))*cosX[i];
+
+    // this method should never be called with L == 0
+    return dLength/L;
+}
+
+Response*
+InertiaTruss::setResponse(const char **argv, int argc, OPS_Stream &output)
+{
+
+    Response *theResponse = 0;
+
+    output.tag("ElementOutput");
+    output.attr("eleType","InertiaTruss");
+    output.attr("eleTag",this->getTag());
+    output.attr("node1",connectedExternalNodes[0]);
+    output.attr("node2",connectedExternalNodes[1]);
+
+    // we compare argv[0] for known response types for the InertiaTruss
+    if ((strcmp(argv[0], "force") == 0) || (strcmp(argv[0], "forces") == 0)
+        || (strcmp(argv[0], "axialForce") == 0) ){
+            output.tag("ResponseType", "F");
+            theResponse = new ElementResponse(this, 2, Vector(3));
+
+    } else if ((strcmp(argv[0],"relativeAcceleration") == 0) || 
+	       (strcmp(argv[0],"acceleration") == 0) || 
+	       (strcmp(argv[0],"accel") == 0) || 
+	       (strcmp(argv[0],"relAccel") == 0)) {
+            output.tag("ResponseType", "acceleration");
+            theResponse =  new ElementResponse(this, 1, Vector(3));
+
+    } 
+    output.endTag();
+    return theResponse;
+}
+
+int 
+InertiaTruss::getResponse(int responseID, Information &eleInfo)
+{
+    static Vector fVec(3);
+    static Vector fVec2(3);
+    static Matrix kVec(1, 1);
+    double strain;
+    const Vector& acc1 = theNodes[0]->getAccel();
+    const Vector& acc2 = theNodes[1]->getAccel();
+    Vector& toret = acc1 - acc2;
+    fVec2(0) = toret(0);
+    fVec2(1) = toret(1);
+    fVec2(2) = toret(2);
+    switch (responseID) {
+    case 1:
+        return eleInfo.setVector(fVec2);
+    case 2:
+        fVec(0) = fVec2(0) * mass;
+        fVec(1) = fVec2(1) * mass;
+        fVec(2) = fVec2(2) * mass;
+        return eleInfo.setVector(fVec);   
+    default:
+        return 0;
+    }
+}
+
+// AddingSensitivity:BEGIN ///////////////////////////////////
+// InertiaTruss::addInertiaLoadSensitivityToUnbalance not ready for sensitivity analysis yet
+int
+InertiaTruss::setParameter(const char **argv, int argc, Parameter &param)
+{ 
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	return -1;
+}
+
+int
+InertiaTruss::updateParameter (int parameterID, Information &info)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	return -1;
+}
+
+int
+InertiaTruss::activateParameter(int passedParameterID)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	return -1;
+}
+
+
+const Matrix &
+InertiaTruss::getKiSensitivity(int gradNumber)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	Matrix &Error = *theMatrix;
+	Error.Zero();
+	return Error;
+}
+
+const Matrix &
+InertiaTruss::getMassSensitivity(int gradNumber)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	Matrix &Mmass = *theMatrix;
+	Mmass.Zero();
+
+	return Mmass;
+}
+
+const Vector &
+InertiaTruss::getResistingForceSensitivity(int gradNumber)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	theVector->Zero();
+
+	return *theVector;
+}
+
+int
+InertiaTruss::commitSensitivity(int gradNumber, int numGrads)
+{
+	opserr << "InertiaTruss::addInertiaLoadSensitivityToUnbalance " <<
+		"not ready for sensitivity analysis yet\n";
+	return -1;
+}
+
+// AddingSensitivity:END /////////////////////////////////////////////

--- a/SRC/element/truss/InertiaTruss.h
+++ b/SRC/element/truss/InertiaTruss.h
@@ -1,0 +1,152 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+#ifndef InertiaTruss_h
+#define InertiaTruss_h
+
+
+// Description: This file contains the class definition for InertiaTruss. A InertiaTruss object
+// provides the abstraction of the small deformation bar element. Each truss
+// object is assocaited with a material object. This InertiaTruss element will work
+// in 1d, 2d or 3d problems.
+// Not ready for sensitivity analysis yet
+// modified from truss.cpp    author: Frank McKenna
+/*
+**************************************************************************************************************
+** InertiaTruss Element                                                                                     **
+** First published in : Ji X, Cheng Y, Molina Hutt C.                                                       **
+** Seismic response of a tuned viscous mass damper(TVMD) coupled wall system.Eng Struct 2020; 225:111252.   **
+** https ://doi.org/10.1016/j.engstruct.2020.111252.                                                        **
+**************************************************************************************************************
+*/
+
+
+#include <Element.h>
+#include <Matrix.h>
+#include <Vector.h>
+class Node;
+class Channel;
+class UniaxialMaterial;
+
+class InertiaTruss : public Element
+{
+  public:
+    InertiaTruss(int tag, int dimension,
+	  int Nd1, int Nd2, 
+	  double mr);
+    
+    InertiaTruss();    
+    ~InertiaTruss();
+
+    const char *getClassType(void) const {return "InertiaTruss";};
+
+    // public methods to obtain inforrmation about dof & connectivity    
+    int getNumExternalNodes(void) const;
+    const ID &getExternalNodes(void);
+    Node **getNodePtrs(void);
+
+    int getNumDOF(void);	
+    void setDomain(Domain *theDomain);
+
+    // public methods to set the state of the element    
+    int commitState(void);
+    int revertToLastCommit(void);        
+    int revertToStart(void);        
+    int update(void);
+    
+    // public methods to obtain stiffness, mass, damping and residual information    
+    const Matrix &getKi(void);
+    const Matrix &getTangentStiff(void);
+    const Matrix &getInitialStiff(void); 
+    const Matrix &getMass(void);    
+
+    void zeroLoad(void);	
+    int addLoad(ElementalLoad *theLoad, double loadFactor);
+    int addInertiaLoadToUnbalance(const Vector &accel);
+
+    const Vector &getResistingForce(void);
+    const Vector &getResistingForceIncInertia(void);            
+
+    // public methods for element output
+    int sendSelf(int commitTag, Channel &theChannel);
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
+    int displaySelf(Renderer &, int mode, float fact, const char **displayModes=0, int numModes=0);
+    void Print(OPS_Stream &s, int flag =0);    
+
+    Response *setResponse(const char **argv, int argc, OPS_Stream &s);
+    int getResponse(int responseID, Information &eleInformation);
+
+
+    // **************************************
+    // Not ready for sensitivity analysis yet
+    // AddingSensitivity:BEGIN //////////////////////////////////////////
+    int		   addInertiaLoadSensitivityToUnbalance(const Vector &accel, bool tag);
+    int setParameter(const char **argv, int argc, Parameter &param);
+    int updateParameter(int parameterID, Information &info);
+    int activateParameter(int parameterID);
+    const Vector & getResistingForceSensitivity(int gradNumber);
+    const Matrix & getKiSensitivity(int gradNumber);
+    const Matrix & getMassSensitivity(int gradNumber);
+    int            commitSensitivity(int gradNumber, int numGrads);
+    // AddingSensitivity:END ///////////////////////////////////////////
+
+  protected:
+    
+  private:
+    double computeCurrentStrain(void) const;
+    double computeCurrentStrainRate(void) const;
+    
+    // private attributes - a copy for each object of the class
+    UniaxialMaterial *theMaterial;  // pointer to a material
+    ID  connectedExternalNodes;     // contains the tags of the end nodes
+    int dimension;                  // inertiatruss in 2 or 3d domain
+    int numDOF;	                    // number of dof for truss
+
+    Vector *theLoad;    // pointer to the load vector P
+    Matrix *theMatrix;  // pointer to objects matrix (a class wide Matrix)
+    Vector *theVector;  // pointer to objects vector (a class wide Vector)
+
+    double L;               // length of Inertiatruss based on undeformed configuration
+    double mass;             // inertial mass
+
+
+    double cosX[3];  // direction cosines
+
+    Node *theNodes[2];
+    double *initialDisp;
+
+	
+// AddingSensitivity:BEGIN //////////////////////////////////////////
+    int parameterID;
+    Vector *theLoadSens;
+// AddingSensitivity:END ///////////////////////////////////////////
+
+    // static data - single copy for all objects of the class	
+    static Matrix trussM2;   // class wide matrix for 2*2
+    static Matrix trussM4;   // class wide matrix for 4*4
+    static Matrix trussM6;   // class wide matrix for 6*6
+    static Matrix trussM12;  // class wide matrix for 12*12
+    static Vector trussV2;   // class wide Vector for size 2
+    static Vector trussV4;   // class wide Vector for size 4
+    static Vector trussV6;   // class wide Vector for size 6
+    static Vector trussV12;  // class wide Vector for size 12
+};
+
+#endif

--- a/SRC/interpreter/OpenSeesElementCommands.cpp
+++ b/SRC/interpreter/OpenSeesElementCommands.cpp
@@ -134,6 +134,7 @@ void* OPS_ElastomericBearingBoucWenMod3d();
 void* OPS_VS3D4WuadWithSensitivity();
 void* OPS_PFEMElement2DBubble(const ID& info);
 void* OPS_PFEMElement3DBubble(const ID& info);
+void* OPS_InertiaTrussElement();
 //void* OPS_TaylorHood2D();
 void* OPS_PFEMElement2DCompressible(const ID& info);
 void* OPS_PFEMElement2Dmini(const ID& info);
@@ -150,12 +151,9 @@ void* OPS_ForceBeamColumn2dThermal();
 void* OPS_DispBeamColumn2d(const ID& info);
 void* OPS_DispBeamColumnNL2d(const ID& info);
 void* OPS_DispBeamColumn3d();
-void* OPS_DispBeamColumnNL3d();
 void* OPS_DispBeamColumnWarping3d();
-void* OPS_DispBeamColumnAsym3d();
 void* OPS_MixedBeamColumn2d();
 void* OPS_MixedBeamColumn3d();
-void* OPS_MixedBeamColumnAsym3d();
 void* OPS_ForceBeamColumnCBDI2d();
 void* OPS_ForceBeamColumnCSBDI2d();
 void* OPS_ForceBeamColumnCBDI3d();
@@ -335,7 +333,7 @@ namespace {
 	    ID info;
 	    return OPS_DispBeamColumnNL2d(info);
 	} else {
-	    return OPS_DispBeamColumnNL3d();
+	    return OPS_DispBeamColumn3d();
 	}
     }
 
@@ -667,8 +665,7 @@ namespace {
 	functionMap.insert(std::make_pair("SurfaceLoad", &OPS_SurfaceLoad));
 	functionMap.insert(std::make_pair("elasticBeamColumn", &OPS_ElasticBeam));
 	functionMap.insert(std::make_pair("elasticBeamColumnWarping", &OPS_ElasticBeamWarping3d));
-	functionMap.insert(std::make_pair("dispBeamColumnWarping", &OPS_DispBeamColumnWarping3d));	
-	functionMap.insert(std::make_pair("dispBeamColumnAsym", &OPS_DispBeamColumnAsym3d));
+	functionMap.insert(std::make_pair("dispBeamColumnWarping", &OPS_DispBeamColumnWarping3d));		
 	functionMap.insert(std::make_pair("forceBeamColumn", &OPS_ForceBeamColumn));
 	functionMap.insert(std::make_pair("nonlinearBeamColumn", &OPS_NonlinearBeamColumn));
 	functionMap.insert(std::make_pair("dispBeamColumn", &OPS_DispBeamColumn));
@@ -677,7 +674,6 @@ namespace {
 	functionMap.insert(std::make_pair("forceBeamColumnCBDI", &OPS_ForceBeamColumnCBDI));
 	functionMap.insert(std::make_pair("forceBeamColumnCSBDI", &OPS_ForceBeamColumnCSBDI));
 	functionMap.insert(std::make_pair("mixedBeamColumn", &OPS_MixedBeamColumn));
-	functionMap.insert(std::make_pair("mixedBeamColumnAsym", &OPS_MixedBeamColumnAsym3d));
 	functionMap.insert(std::make_pair("zeroLength", &OPS_ZeroLength));
 	functionMap.insert(std::make_pair("zeroLengthSection", &OPS_ZeroLengthSection));
 	functionMap.insert(std::make_pair("zeroLengthND", &OPS_ZeroLengthND));
@@ -685,7 +681,7 @@ namespace {
 	functionMap.insert(std::make_pair("CatenaryCable", &OPS_CatenaryCableElement));
 	functionMap.insert(std::make_pair("gradientInelasticBeamColumn", &OPS_GradientInelasticBeamColumn));
 	functionMap.insert(std::make_pair("RockingBC", &OPS_RockingBC));
-
+	functionMap.insert(std::make_pair("InertiaTruss", &OPS_InertiaTrussElement));
 	return 0;
     }
 }

--- a/SRC/recorder/GmshRecorder.cpp
+++ b/SRC/recorder/GmshRecorder.cpp
@@ -1431,4 +1431,5 @@ GmshRecorder::setGMSHType()
     gmshtypes[ELE_TAG_ShellANDeS] = GMSH_TRIANGLE;
     gmshtypes[ELE_TAG_ShellDKGT] = GMSH_TRIANGLE;
     gmshtypes[ELE_TAG_ShellNLDKGT] = GMSH_TRIANGLE;
+    gmshtypes[ELE_TAG_InertiaTruss] = GMSH_LINE;
 }

--- a/SRC/recorder/MPCORecorder.cpp
+++ b/SRC/recorder/MPCORecorder.cpp
@@ -3639,6 +3639,7 @@ namespace mpco {
 					elem_class_tag == ELE_TAG_CorotTruss ||
 					elem_class_tag == ELE_TAG_CorotTruss2 ||
 					elem_class_tag == ELE_TAG_CorotTrussSection ||
+					elem_class_tag == ELE_TAG_InertiaTruss ||
 					// ./zeroLength
 					elem_class_tag == ELE_TAG_ZeroLength ||
 					elem_class_tag == ELE_TAG_ZeroLengthSection ||

--- a/SRC/recorder/PVDRecorder.cpp
+++ b/SRC/recorder/PVDRecorder.cpp
@@ -552,27 +552,27 @@ PVDRecorder::savePart0(int nodendf)
     // node displacement
     if(nodedata.disp) {
 	// all displacement
-    // this->indent();
-	// theFile<<"<DataArray type="<<quota<<"Float32"<<quota;
-	// theFile<<" Name="<<quota<<"AllDisplacement"<<quota;
-	// theFile<<" NumberOfComponents="<<quota<<nodendf<<quota;
-	// theFile<<" format="<<quota<<"ascii"<<quota<<">\n";
-	// this->incrLevel();
-	// for(int i=0; i<(int)nodes.size(); i++) {
-	//     const Vector& vel = nodes[i]->getTrialDisp();
-	//     this->indent();
-	//     for(int j=0; j<nodendf; j++) {
-	// 	if(j < vel.Size()) {
-	// 	    theFile<<vel(j)<<' ';
-	// 	} else {
-	// 	    theFile<<0.0<<' ';
-	// 	}
-	//     }
-	//     theFile<<std::endl;
-	// }
-	// this->decrLevel();
-	// this->indent();
-	// theFile<<"</DataArray>\n";
+    this->indent();
+	theFile<<"<DataArray type="<<quota<<"Float32"<<quota;
+	theFile<<" Name="<<quota<<"AllDisplacement"<<quota;
+	theFile<<" NumberOfComponents="<<quota<<nodendf<<quota;
+	theFile<<" format="<<quota<<"ascii"<<quota<<">\n";
+	this->incrLevel();
+	for(int i=0; i<(int)nodes.size(); i++) {
+	    const Vector& vel = nodes[i]->getTrialDisp();
+	    this->indent();
+	    for(int j=0; j<nodendf; j++) {
+		if(j < vel.Size()) {
+		    theFile<<vel(j)<<' ';
+		} else {
+		    theFile<<0.0<<' ';
+		}
+	    }
+	    theFile<<std::endl;
+	}
+	this->decrLevel();
+	this->indent();
+	theFile<<"</DataArray>\n";
 
     // displacement
     this->indent();
@@ -972,7 +972,7 @@ PVDRecorder::savePartParticle(int pno, int bgtag, int nodendf)
     this->incrLevel();
     for(int i=0; i<(int)particles.size(); i++) {
 	this->indent();
-	theFile<<particles[i]->getTag()<<std::endl;
+	theFile<<i<<std::endl;
     }
     this->decrLevel();
     this->indent();
@@ -1449,27 +1449,27 @@ PVDRecorder::savePart(int partno, int ctag, int nodendf)
     // node displacement
     if(nodedata.disp) {
 	// all displacement
-    // this->indent();
-	// theFile<<"<DataArray type="<<quota<<"Float32"<<quota;
-	// theFile<<" Name="<<quota<<"AllDisplacement"<<quota;
-	// theFile<<" NumberOfComponents="<<quota<<nodendf<<quota;
-	// theFile<<" format="<<quota<<"ascii"<<quota<<">\n";
-	// this->incrLevel();
-	// for(int i=0; i<ndtags.Size(); i++) {
-	//     const Vector& vel = nodes[i]->getTrialDisp();
-	//     this->indent();
-	//     for(int j=0; j<nodendf; j++) {
-	// 	if(j < vel.Size()) {
-	// 	    theFile<<vel(j)<<' ';
-	// 	} else {
-	// 	    theFile<<0.0<<' ';
-	// 	}
-	//     }
-	//     theFile<<std::endl;
-	// }
-	// this->decrLevel();
-	// this->indent();
-	// theFile<<"</DataArray>\n";
+    this->indent();
+	theFile<<"<DataArray type="<<quota<<"Float32"<<quota;
+	theFile<<" Name="<<quota<<"AllDisplacement"<<quota;
+	theFile<<" NumberOfComponents="<<quota<<nodendf<<quota;
+	theFile<<" format="<<quota<<"ascii"<<quota<<">\n";
+	this->incrLevel();
+	for(int i=0; i<ndtags.Size(); i++) {
+	    const Vector& vel = nodes[i]->getTrialDisp();
+	    this->indent();
+	    for(int j=0; j<nodendf; j++) {
+		if(j < vel.Size()) {
+		    theFile<<vel(j)<<' ';
+		} else {
+		    theFile<<0.0<<' ';
+		}
+	    }
+	    theFile<<std::endl;
+	}
+	this->decrLevel();
+	this->indent();
+	theFile<<"</DataArray>\n";
 
     // displacement
     this->indent();
@@ -1977,6 +1977,7 @@ PVDRecorder::setVTKType()
     vtktypes[ELE_TAG_ShellDKGT] = VTK_TRIANGLE;
     vtktypes[ELE_TAG_ShellNLDKGT] = VTK_TRIANGLE;
     vtktypes[ELE_TAG_PFEMContact2D] = VTK_TRIANGLE;
+    vtktypes[ELE_TAG_InertiaTruss] = VTK_LINE;
 }
 
 void

--- a/SRC/recorder/VTK_Recorder.cpp
+++ b/SRC/recorder/VTK_Recorder.cpp
@@ -1172,6 +1172,7 @@ VTK_Recorder::setVTKType()
     vtktypes[ELE_TAG_ShellANDeS] = VTK_TRIANGLE;
     vtktypes[ELE_TAG_ShellDKGT] = VTK_TRIANGLE;
     vtktypes[ELE_TAG_ShellNLDKGT] = VTK_TRIANGLE;
+    vtktypes[ELE_TAG_InertiaTruss] = VTK_LINE;
 }
 
 


### PR DESCRIPTION
The new element InertiaTruss is developed to simulate the behavior of inerter devices. Inerter is a two-terminal element which can generate inertial force proportional to the relative acceleration between its two ends. This new easy-to-use element was developed based on Truss element, and it was verified by comparison with Matlab simulation results and experimental test data. Use of this new element in simulating the interter-based dampers can be found in the paper (Ji X, Cheng Y, Molina Hutt C. Seismic response of a tuned viscous mass damper (TVMD) coupled wall system. Engineering Structures 2020; 225: 111252).