### PR TITLE
Fix overlapping class tag and invalid Visual Studio Filters

### DIFF
--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -230,13 +230,14 @@
 #define MAT_TAG_PySimple3                    214
 #define MAT_TAG_PlateBearingConnectionThermal 215
 #define MAT_TAG_ASD_SMA_3K                    216
-#define MAT_TAG_SteelFractureDI			217 // galvisf
 
 #define MAT_TAG_Masonry 217
 #define MAT_TAG_Masonryt 218
 #define MAT_TAG_Trilinwp 219
 #define MAT_TAG_Trilinwp2 220
 #define MAT_TAG_Trilinwpd 221
+
+#define MAT_TAG_SteelFractureDI			222 // galvisf
 
 #define MAT_TAG_FedeasMaterial    1000
 #define MAT_TAG_FedeasBond1       1001

--- a/Win64/proj/material/material.vcxproj.filters
+++ b/Win64/proj/material/material.vcxproj.filters
@@ -1371,6 +1371,8 @@
       <Filter>section</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelFractureDI.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\Masonry.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>


### PR DESCRIPTION
Dear @fmckenna and @mhscott, in a recently merged PR (#634) there were 2 issues:

1. The material tag **MAT_TAG_SteelFractureDI** was set at the same value (217) of a pre-existing tag (**MAT_TAG_Masonry**)
2. 2 lines were missing in the **Visual Studio filters file** for the material project, messing up all the filters in visual studio