### PR TITLE
Ubuntu 21.04 Makfefile for python

### DIFF
--- a/MAKES/Makefile.def.UBUNTU.21.04
+++ b/MAKES/Makefile.def.UBUNTU.21.04
@@ -1,0 +1,291 @@
+############################################################################
+#
+#  Program:  OpenSees
+#
+#  Purpose:  A Top-level Makefile to create the libraries needed
+#	     to use the OpenSees framework. Works on Linux version 6.1
+#            and below.
+#
+#  Written: fmk 
+#  Created: 10/99
+#
+#  Send bug reports, comments or suggestions to fmckenna@ce.berkeley.edu
+#
+############################################################################
+
+
+# Instructuction for building OpenSees on Ubuntu 21.04 for Python Interpreter
+
+# 1. Make sure you have the following libraries installed:
+#       make tcl8.6 tcl8.6-dev gcc g++ gfortran python3-dev
+# 2. git clone the OpenSees repo to a local directory:
+#       e.g. ~/projects/opensees to get ~/projects/opensees/OpenSees
+# 3. mkdir lib and bin in the ~/projects/opensees folder
+# 4. Issue the following:
+#   cd OpenSees
+#   cp ./MAKES/Makefile.def.Ubuntu21.04 ./Makefile.def   
+# 5. Carefully check through this file and make edits where indicated for your system.
+# open file and make sure INTERPRETER_LANGUAGE set to PYTHON, then issue:
+#   make
+# 5. Presuming all goes well, now make the OpenSeesPy shared library
+#   make python
+# 6. And if you want TCL:
+# edit Makefile.def, comment out INTERPRETER_LANGUAGE=PYTHON (LINE 62) and UNCOMMENT INTERPRTETER_LNAGUAGE=TCL (LINE 63)
+# make wipe
+# make                       (NOTE: new OpenSees.exe compiled with optimization flags)
+
+
+INTERPRETER_LANGUAGE = PYTHON
+#INTERPRETER_LANGUAGE = TCL
+
+# %---------------------------------%
+# |  SECTION 1: PROGRAM             |
+# %---------------------------------%
+#
+# Specify the location and name of the OpenSees interpreter program
+# that will be created (if this all works!)
+
+OpenSees_PROGRAM = $(HOME)/bin/OpenSees
+
+OPERATING_SYSTEM = LINUX
+GRAPHICS = NONE
+GRAPHIC_FLAG = -D_NOGRAPHICS
+PROGRAMMING_MODE = SEQUENTIAL
+DEBUG_MODE = NO_DEBUG
+RELIABILITY = NO_RELIABILITY
+
+
+# %---------------------------------%
+# |  SECTION 2: PATHS               |
+# %---------------------------------%
+#
+# Note: if vendor supplied BLAS and LAPACK libraries or if you have
+# any of the libraries already leave the directory location blank AND
+# remove the directory from DIRS.
+
+BASE	= /usr/local
+
+# Set the $(HOME) directory of the cloned repo; 
+# make sure to expand ~/ to /home/username/
+
+HOME = /home/username/projects/opensees
+
+FE		    = $(HOME)/OpenSees/SRC
+AMDdir       = $(HOME)/OpenSees/OTHER/AMD
+BLASdir      = $(HOME)/OpenSees/OTHER/BLAS
+CBLASdir     = $(HOME)/OpenSees/OTHER/CBLAS
+LAPACKdir    = $(HOME)/OpenSees/OTHER/LAPACK
+SUPERLUdir   = $(HOME)/OpenSees/OTHER/SuperLU_5.1.1/SRC
+ARPACKdir    = $(HOME)/OpenSees/OTHER/ARPACK
+UMFPACKdir   = $(HOME)/OpenSees/OTHER/UMFPACK
+METISdir     = $(HOME)/OpenSees/OTHER/METIS
+CSPARSEdir   = $(HOME)/OpenSees/OTHER/CSPARSE
+
+
+DIRS        = $(BLASdir) $(CBLASdir) $(LAPACKdir) $(AMDdir) $(CSPARSEdir) \
+	$(SUPERLUdir) $(ARPACKdir) $(UMFPACKdir) $(SRCdir) $(METISdir)
+
+# %-------------------------------------------------------%
+# | SECTION 3: LIBRARIES                                  |
+# |                                                       |
+# | The following section defines the libraries that will |
+# | be created and/or linked with when the libraries are  | 
+# | being created or linked with.                         |
+# %-------------------------------------------------------%
+#
+# Note: if vendor supplied BLAS and LAPACK libraries leave the
+# libraries blank. You have to get your own copy of the tcl/tk 
+# library!! 
+#
+# Note: For libraries that will be created (any in DIRS above)
+# make sure the directory exsists where you want the library to go!
+
+FE_LIBRARY      = $(HOME)/lib/libOpenSees.a
+NDARRAY_LIBRARY = $(HOME)/lib/libndarray.a # BJ_UCD jeremic@ucdavis.edu
+MATMOD_LIBRARY  = $(HOME)/lib/libmatmod.a  # BJ_UCD jeremic@ucdavis.edu
+BJMISC_LIBRARY  = $(HOME)/lib/libBJmisc.a  # BJ_UCD jeremic@ucdavis.edu
+LAPACK_LIBRARY  = $(HOME)/lib/libLapack.a
+BLAS_LIBRARY    = $(HOME)/lib/libBlas.a
+SUPERLU_LIBRARY = $(HOME)/lib/libSuperLU.a
+CBLAS_LIBRARY   = $(HOME)/lib/libCBlas.a
+ARPACK_LIBRARY  = $(HOME)/lib/libArpack.a
+AMD_LIBRARY     = $(HOME)/lib/libAMD.a
+UMFPACK_LIBRARY = $(HOME)/lib/libUmfpack.a
+METIS_LIBRARY   = $(HOME)/lib/libMetis.a
+CSPARSE_LIBRARY = $(HOME)/lib/libCSparse.a
+
+# Use whereis to find the TCL library if not in this default install position
+TCL_LIBRARY = /usr/lib/x86_64-linux-gnu/libtcl8.6.so
+
+BLITZ_LIBRARY = $(HOME)/blitz/lib/libblitz.a
+GRAPHIC_LIBRARY     = 
+
+# WATCH OUT .. These libraries are removed when 'make wipe' is invoked.
+WIPE_LIBS	= $(FE_LIBRARY) \
+		$(LAPACK_LIBRARY) \
+		$(BLAS_LIBRARY) \
+		$(CBLAS_LIBRARY) \
+		$(SUPERLU_LIBRARY) \
+		$(ARPACK_LIBRARY) \
+		$(UMFPACK_LIBRARY) \
+		$(CSPARSE_LIBRARY) \
+        $(METIS_LIBRARY) \
+        $(AMD_LIBRARY)
+
+# %---------------------------------------------------------%
+# | SECTION 4: COMPILERS                                    |
+# |                                                         |
+# | The following macros specify compilers, linker/loaders, |
+# | the archiver, and their options.  You need to make sure |
+# | these are correct for your system.                      |
+# %---------------------------------------------------------%
+
+# Compilers
+CC++	= /usr/bin/g++
+CC      = /usr/bin/gcc
+FC	    = /usr/bin/gfortran
+
+AR		    = ar 
+ARFLAGS		= cqls
+RANLIB		= ranlib
+RANLIBFLAGS =
+
+# Compiler Flags
+#
+# NOTES:
+#   C++ FLAGS TAKE need _UNIX or _WIN32 for preprocessor dircetives
+#        - the _WIN32 for the Windows95/98 or NT operating system.
+#   C FLAGS used -DUSE_VENDOR_BLAS (needed in SuperLU) if UNIX in C++ FLAGS
+#
+#   FFLAGS need the -fallow-argument-mismatch for gfortran > 10.0 to 
+#   build ARpack due to a change in the compiler standard.
+#
+#   LINKER path: Ananconda or other installs can add other linkers.
+#   Use echo $PATH to confirm the GNU linker ld at /usr/bin/ will be first
+#   in the path. If not (anaconda often places itself first), change the path order:
+#   export PATH=$PATH:/usr/bin
+#   this will only last for the shell duration and duplicates do not matter.
+
+# modified as optimizaton currently causing problems with Steeln01 code
+
+ifeq ($(INTERPRETER_LANGUAGE), PYTHON)
+
+C++FLAGS         = -Wall -D_LINUX -D_UNIX  -D_TCL85  \
+	$(GRAPHIC_FLAG) $(RELIABILITY_FLAG) $(DEBUG_FLAG) \
+	$(PROGRAMMING_FLAG) -fPIC -ffloat-store 
+CFLAGS          = -Wall -fPIC
+FFLAGS          = -Wall -fPIC -fallow-argument-mismatch
+
+# Linker
+LINKER          = $(CC++)
+LINKFLAGS       = -g -fPIC 
+
+else
+
+C++FLAGS         = -Wall -D_LINUX -D_UNIX  -D_TCL85  \
+	$(GRAPHIC_FLAG) $(RELIABILITY_FLAG) $(DEBUG_FLAG) \
+	$(PROGRAMMING_FLAG) -O3 -ffloat-store 
+CFLAGS          = -Wall -O2
+FFLAGS          = -Wall -O -fallow-argument-mismatch
+
+# Linker
+LINKER          = $(CC++)
+LINKFLAGS       = -rdynamic 
+
+endif
+
+
+# Misc
+MAKE	    = make
+CD          = cd
+ECHO        = echo
+RM          = rm
+RMFLAGS     = -f
+SHELL       = /bin/sh
+
+# %---------------------------------------------------------%
+# | SECTION 5: COMPILATION                                  |
+# |                                                         |
+# | The following macros specify the macros used in         |
+# | to compile the source code into object code.            |
+# %---------------------------------------------------------%
+
+.SUFFIXES:
+.SUFFIXES:	.C .c .f .f90 .cpp .o .cpp
+
+#
+# %------------------%
+# | Default command. |
+# %------------------%
+#
+.DEFAULT:
+	@$(ECHO) "Unknown target $@, try:  make help"
+#
+# %-------------------------------------------%
+# |  Command to build .o files from .f files. |
+# %-------------------------------------------%
+#
+
+.cpp.o:
+	@$(ECHO) Making $@ from $<
+	$(CC++) $(C++FLAGS) $(INCLUDES) -c $< -o $@
+
+.C.o:
+	@$(ECHO) Making $@ from $<
+	$(CC++) $(C++FLAGS) $(INCLUDES) -c $< -o $@
+.c.o:
+	@$(ECHO) Making $@ from $<
+	$(CC) $(CFLAGS) -c $< -o $@
+.f.o:      
+	@$(ECHO) Making $@ from $<
+	$(FC) $(FFLAGS) -c $< -o $@
+
+# %---------------------------------------------------------%
+# | SECTION 6: OTHER LIBRARIES                              |
+# |                                                         |
+# | The following macros specify other libraries that must  |
+# | be linked with when creating executables. These are     |
+# | platform specific and typically order does matter!!     |
+# %---------------------------------------------------------%
+
+MACHINE_LINKLIBS  = -L$(BASE)/lib \
+                    -L$(HOME)/lib \
+                    -L/usr/local/lib
+                    
+
+MACHINE_NUMERICAL_LIBS  = -lm \
+		$(ARPACK_LIBRARY) \
+		$(SUPERLU_LIBRARY) \
+		$(UMFPACK_LIBRARY) $(CSPARSE_LIBRARY) \
+	        $(LAPACK_LIBRARY) $(BLAS_LIBRARY) $(CBLAS_LIBRARY) \
+		$(AMD_LIBRARY) $(GRAPHIC_LIBRARY)\
+		-ldl -lgfortran 
+
+MACHINE_SPECIFIC_LIBS = 
+
+
+
+# %---------------------------------------------------------%
+# | SECTION 7: INCLUDE FILES                                |
+# |                                                         |
+# | The following macros specify include files needed for   |
+# | compilation.                                            |
+# %---------------------------------------------------------%
+MACHINE_INCLUDES        = -I/usr/include \
+			  -I$(BASE)/include \
+			  -I/usr/include/cxx \
+			  -I$(HOME)/include -I$(HOME)/blitz
+
+# this file contains all the OpenSees/SRC includes
+include $(FE)/Makefile.incl
+
+#TCL_INCLUDES = -I/usr/includes/tcl-private/generic
+TCL_INCLUDES = -I/usr/include/tcl8.6
+
+# Point to either system python or venv python
+#PYTHON_INCLUDES = -I/home/username/anaconda3/include/python3.8
+PYTHON_INCLUDES = -I/usr/include/python3.9
+
+INCLUDES = $(TCL_INCLUDES) $(FE_INCLUDES) $(MACHINE_INCLUDES) $(PYTHON_INCLUDES)
+
+


### PR DESCRIPTION
After quite a few issues on a new 21.04 machine; hopefully this working makefile will assist others.

Key points:
- relative directories to repo location
- gfortran >10.0 flag `-fallow-argument-mismatch` for building ARpack successfully
- Instructions for $PATH order so linker can find all libraries 
- Linker flag `-fPIC`
- Linklibs add `-L/usr/local/lib`
- `PYTHON_INCLUDES` for system or venv