### PR TITLE
Fixes clash of Vec type defined in RockingBC.h:64 with definition in …

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -1077,6 +1077,13 @@ SECTION_LIBS = $(FE)/material/section/SectionForceDeformation.o \
 
 SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o 
 
+PETSC_SOE_OBJ = 
+ifeq ($(HAVEPETSC), YES)
+	PETSC_SOE_OBJ = $(FE)/system_of_eqn/linearSOE/petsc/PetscSOE.o \
+		$(FE)/system_of_eqn/linearSOE/petsc/PetscSolver.o \
+		$(FE)/system_of_eqn/linearSOE/petsc/PetscSparseSeqSolver.o 
+endif
+
 ifeq ($(PROGRAMMING_MODE), THREADS)
 SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/ThreadedSuperLU.o
 endif
@@ -1088,7 +1095,8 @@ SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSOE.o \
-	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSolver.o
+	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSolver.o \
+	$(PETSC_SOE_OBJ)
 endif
 
 ifeq ($(PROGRAMMING_MODE), PARALLEL_INTERPRETERS)
@@ -1100,6 +1108,8 @@ SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSOE.o \
 	$(FE)/system_of_eqn/linearSOE/mumps/MumpsSolver.o
 endif
+
+
 
 CUDA_CLASSES = 
 

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -2287,8 +2287,7 @@ FEM_ObjectBrokerAllClasses::getNewLinearSOE(int classTagSOE)
 
 #ifdef _PETSC
     case LinSOE_TAGS_PetscSOE:
-        thePetscSolver = new PetscSolver();
-        theSOE = new PetscSOE(*thePetscSolver);
+        theSOE = new PetscSOE(*( new PetscSolver()));
 	  return theSOE;
 #endif
 

--- a/SRC/domain/pattern/drm/H5DRM.cpp
+++ b/SRC/domain/pattern/drm/H5DRM.cpp
@@ -1078,17 +1078,11 @@ bool H5DRM::drm_differentiate_displacements(double t)
         bool nanfound = false;
         for (int i = 0; i < 3; ++i)
         {
-<<<<<<< HEAD
-	  if ( isnan(d1[i])  ||
-               isnan(a1[i])  ||
-               isnan(d2[i])  ||
-               isnan(a2[i]) )
-=======
+
             if ( isnan(d1[i])  ||
                  isnan(a1[i])  ||
                  isnan(d2[i])  ||
                  isnan(a2[i]) )
->>>>>>> 732044f5b1846fa0047e4516e0717dc0d22bffc3
             {
                 nanfound = true;
             }
@@ -1150,283 +1144,283 @@ bool H5DRM::drm_integrate_velocity(double next_integration_time)
     exit(-1);
     return false;
 
-    FILE * fptr = 0;
-    if (DEBUG_DRM_INTEGRATION)
-    {
-        char debugfilename[100];
-        sprintf(debugfilename, "drmintegration.%d.txt", myrank);
-        fptr = fopen(debugfilename, "w");
-    }
+//     FILE * fptr = 0;
+//     if (DEBUG_DRM_INTEGRATION)
+//     {
+//         char debugfilename[100];
+//         sprintf(debugfilename, "drmintegration.%d.txt", myrank);
+//         fptr = fopen(debugfilename, "w");
+//     }
 
 
-    if (Nodes.Size() == 0)
-        return false;
+//     if (Nodes.Size() == 0)
+//         return false;
 
-    if (next_integration_time < tstart || next_integration_time > tend)
-    {
-        DRMDisplacements.Zero();
-        DRMAccelerations.Zero();
-        return false;
-    }
+//     if (next_integration_time < tstart || next_integration_time > tend)
+//     {
+//         DRMDisplacements.Zero();
+//         DRMAccelerations.Zero();
+//         return false;
+//     }
 
-    int dir = 1;
-    double t1 = last_integration_time;
-    double t2 = next_integration_time;
-    if (t1 > t2)
-    {
-        // Integrating backwards
-        t1 = next_integration_time;
-        t2 = last_integration_time;
-        dir = -1;
-    }
-    hsize_t i1 = (hsize_t) (t1 - tstart) / dt;
-    hsize_t i2 = (hsize_t) (t2 - tstart) / dt + 1;
-    hsize_t Nt = i2 - i1;
+//     int dir = 1;
+//     double t1 = last_integration_time;
+//     double t2 = next_integration_time;
+//     if (t1 > t2)
+//     {
+//         // Integrating backwards
+//         t1 = next_integration_time;
+//         t2 = last_integration_time;
+//         dir = -1;
+//     }
+//     hsize_t i1 = (hsize_t) (t1 - tstart) / dt;
+//     hsize_t i2 = (hsize_t) (t2 - tstart) / dt + 1;
+//     hsize_t Nt = i2 - i1;
 
-    hsize_t motions_dims[2];
-    id_velocity_dataspace = H5Dget_space(id_velocity);
+//     hsize_t motions_dims[2];
+//     id_velocity_dataspace = H5Dget_space(id_velocity);
 
-    hsize_t imax_t = motions_dims[1] - 1;
-
-
-    i1 = i1 < 0 ? 0 : i1 ;
-    i1 = i1 > imax_t ? imax_t : i1;
-    i2 = i2 < 0 ? 0 : i2 ;
-    i2 = i2 > imax_t ? imax_t : i2;
-    Nt = i1 == i2 ? 1 : Nt;
-
-    for (int n = 0; n < Nodes.Size(); ++n)
-    {
-        int nodeTag = Nodes(n);
-        int station_id = nodetag2station_id[nodeTag];
-        int data_pos = station_id2data_pos[station_id];
-        int local_pos = nodetag2local_pos[nodeTag];
-
-        double v[3][Nt];
-
-        hsize_t start[2]  = {(hsize_t) data_pos , (hsize_t)i1};
-        hsize_t stride[2] = {1                  , 1};
-        hsize_t count[2]  = {1                  , 1};
-        hsize_t block[2]  = {3                  , (hsize_t) Nt};
-
-        //Selection in dataspace
-        H5Sselect_hyperslab(
-            id_velocity_dataspace,
-            H5S_SELECT_SET, start, stride, count, block );
-
-        //Selection in memspace
-        hsize_t rank_two_array = 2;
-        hsize_t one_node_data_dims[2] = {3, Nt};
-        hsize_t one_node_data_maxdims[2] = {3, Nt};
-        hid_t memspace  = H5Screate_simple(rank_two_array, one_node_data_dims, one_node_data_maxdims);       // create dataspace of memory
+//     hsize_t imax_t = motions_dims[1] - 1;
 
 
-        hsize_t mem_start[2] = {0 , 0};
-        H5Sselect_hyperslab(
-            memspace,
-            H5S_SELECT_SET, mem_start, stride, count, block );
+//     i1 = i1 < 0 ? 0 : i1 ;
+//     i1 = i1 > imax_t ? imax_t : i1;
+//     i2 = i2 < 0 ? 0 : i2 ;
+//     i2 = i2 > imax_t ? imax_t : i2;
+//     Nt = i1 == i2 ? 1 : Nt;
 
-        //Read data
-        herr_t errorflag = H5Dread( id_velocity, H5T_NATIVE_DOUBLE, memspace,
-                                    id_velocity_dataspace, id_xfer_plist,  v );
+//     for (int n = 0; n < Nodes.Size(); ++n)
+//     {
+//         int nodeTag = Nodes(n);
+//         int station_id = nodetag2station_id[nodeTag];
+//         int data_pos = station_id2data_pos[station_id];
+//         int local_pos = nodetag2local_pos[nodeTag];
 
-        H5Sclose(memspace);
+//         double v[3][Nt];
 
-        if (errorflag < 0)
-        {
-            H5DRMerror << "Failed to read velocity array!!\n" <<
-                       " n = " << n << endln <<
-                       " nodeTag = " << nodeTag << endln <<
-                       " station_id = " << station_id << endln <<
-                       " i1 = " << i1 << endln <<
-                       " data_pos = " << data_pos << endln <<
-                       " local_pos = " << local_pos << endln <<
-                       " Nt = " << Nt << endln <<
-                       " last_integration_time = " << last_integration_time << endln <<
-                       " start   = [" << start[0] << ", " << start[1] << "]" << endln <<
-                       " mem_start  = [" << mem_start[0] << ", " << mem_start[1] << "]" << endln <<
-                       " stride  = [" << stride[0] << ", " << stride[1] << "]" << endln <<
-                       " count   = [" << count[0] << ", " << count[1] << "]" << endln <<
-                       " block   = [" << block[0] << ", " << block[1] << "]" << endln;
-            exit(-1);
-        }
+//         hsize_t start[2]  = {(hsize_t) data_pos , (hsize_t)i1};
+//         hsize_t stride[2] = {1                  , 1};
+//         hsize_t count[2]  = {1                  , 1};
+//         hsize_t block[2]  = {3                  , (hsize_t) Nt};
 
-        for (hsize_t i = 0; i <  Nt; ++i)
-        {
-            double v0 = v[0][i];
-            double v1 = v[1][i];
-            v[0][i] = v0;
-            v[1][i] = v1;
-            v[2][i] = -v[2][i];
-        }
+//         //Selection in dataspace
+//         H5Sselect_hyperslab(
+//             id_velocity_dataspace,
+//             H5S_SELECT_SET, start, stride, count, block );
+
+//         //Selection in memspace
+//         hsize_t rank_two_array = 2;
+//         hsize_t one_node_data_dims[2] = {3, Nt};
+//         hsize_t one_node_data_maxdims[2] = {3, Nt};
+//         hid_t memspace  = H5Screate_simple(rank_two_array, one_node_data_dims, one_node_data_maxdims);       // create dataspace of memory
 
 
-<<<<<<< HEAD
-		for (hsize_t i = 0; i < Nt; ++i)
-		{
-			double dtau = 0;
-			double tau_1 = tstart + i * dt;
-			double tau_2 = tstart + (i + 1) * dt;
-			tau_1 = tau_1 > t1 ? tau_1 : t1;
-			tau_2 = tau_2 < t2 ? tau_2 : t2;
-			dtau = tau_2 - tau_1;
+//         hsize_t mem_start[2] = {0 , 0};
+//         H5Sselect_hyperslab(
+//             memspace,
+//             H5S_SELECT_SET, mem_start, stride, count, block );
 
-			if (dtau <= 0)
-				continue;
+//         //Read data
+//         herr_t errorflag = H5Dread( id_velocity, H5T_NATIVE_DOUBLE, memspace,
+//                                     id_velocity_dataspace, id_xfer_plist,  v );
+
+//         H5Sclose(memspace);
+
+//         if (errorflag < 0)
+//         {
+//             H5DRMerror << "Failed to read velocity array!!\n" <<
+//                        " n = " << n << endln <<
+//                        " nodeTag = " << nodeTag << endln <<
+//                        " station_id = " << station_id << endln <<
+//                        " i1 = " << i1 << endln <<
+//                        " data_pos = " << data_pos << endln <<
+//                        " local_pos = " << local_pos << endln <<
+//                        " Nt = " << Nt << endln <<
+//                        " last_integration_time = " << last_integration_time << endln <<
+//                        " start   = [" << start[0] << ", " << start[1] << "]" << endln <<
+//                        " mem_start  = [" << mem_start[0] << ", " << mem_start[1] << "]" << endln <<
+//                        " stride  = [" << stride[0] << ", " << stride[1] << "]" << endln <<
+//                        " count   = [" << count[0] << ", " << count[1] << "]" << endln <<
+//                        " block   = [" << block[0] << ", " << block[1] << "]" << endln;
+//             exit(-1);
+//         }
+
+//         for (hsize_t i = 0; i <  Nt; ++i)
+//         {
+//             double v0 = v[0][i];
+//             double v1 = v[1][i];
+//             v[0][i] = v0;
+//             v[1][i] = v1;
+//             v[2][i] = -v[2][i];
+//         }
 
 
+// <<<<<<< HEAD
+// 		for (hsize_t i = 0; i < Nt; ++i)
+// 		{
+// 			double dtau = 0;
+// 			double tau_1 = tstart + i * dt;
+// 			double tau_2 = tstart + (i + 1) * dt;
+// 			tau_1 = tau_1 > t1 ? tau_1 : t1;
+// 			tau_2 = tau_2 < t2 ? tau_2 : t2;
+// 			dtau = tau_2 - tau_1;
 
-			if (DEBUG_DRM_INTEGRATION)
-			{
-				/* FMK
-				fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int) i, dtau, tau_1, tau_2, dt, local_pos, dir );
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
-				******/
-				fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i, dtau, tau_1, tau_2, dt, local_pos, dir);
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0 + i * Nt], v[0 + (i + 1)*3]);
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1 + i * Nt], v[1 + (i + 1)*3]);
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2 + i * Nt], v[2 + (i + 1)*3]);
-
-			}
-
-			double u1 = DRMDisplacements(3 * local_pos + 0);
-			double u2 = DRMDisplacements(3 * local_pos + 1);
-			double u3 = DRMDisplacements(3 * local_pos + 2);
-			/* FMK
-			double du1 = (v[0][i] + v[0][i + 1]) * (dir * dtau / 2);
-			double du2 = (v[1][i] + v[1][i + 1]) * (dir * dtau / 2);
-			double du3 = (v[2][i] + v[2][i + 1]) * (dir * dtau / 2);
-			******/
-			double du1 = (v[0 + i * 3] + v[0 + (i + 1)*3]) * (dir * dtau / 2);
-			double du2 = (v[1 + i * 3] + v[1 + (i + 1)*3]) * (dir * dtau / 2);
-			double du3 = (v[2 + i * 3] + v[2 + (i + 1)*3]) * (dir * dtau / 2);
-
-			DRMDisplacements(3 * local_pos + 0) += du1;
-			DRMDisplacements(3 * local_pos + 1) += du2;
-			DRMDisplacements(3 * local_pos + 2) += du3;
-
-			if (DEBUG_DRM_INTEGRATION)
-			{
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f \n", DRMDisplacements(3 * local_pos + 0));
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f \n", DRMDisplacements(3 * local_pos + 1));
-				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f \n", DRMDisplacements(3 * local_pos + 2));
-			}
-
-			// bool found_nan = false;
-			if (isnan(u1) || isnan(du1) ||
-				isnan(u2) || isnan(du2) ||
-				isnan(u3) || isnan(du3) ||
-				isnan(dt) || isnan(dtau))
-			{
-				H5DRMerror << "NAN Detected!!! \n";
-				H5DRMerror << "    nodeTag = " << nodeTag << endln;
-				H5DRMerror << "    local_pos = " << local_pos << endln;
-				printf("    i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i, dtau, tau_1, tau_2, dt, local_pos, dir);
-				printf("        u1 = %f du1 = %f \n", u1, du1);
-				printf("        u2 = %f du2 = %f \n", u2, du2);
-				printf("        u3 = %f du3 = %f \n", u3, du3);
-				/* FMK
-				printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
-				printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
-				printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
-				*/
-				printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0 + i * 3], v[0 + (i + 1)*3]);
-				printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1 + i * 3], v[1 + (i + 1)*3]);
-				printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2 + i * 3], v[2 + (i + 1)*3]);
-				exit(-1);
-			}
-
-		}
-=======
-        for (hsize_t i = 0; i <  Nt; ++i)
-        {
-            double dtau = 0;
-            double tau_1 = tstart + i * dt;
-            double tau_2 = tstart + (i + 1) * dt;
-            tau_1 = tau_1 > t1 ? tau_1 : t1;
-            tau_2 = tau_2 < t2 ? tau_2 : t2;
-            dtau = tau_2 - tau_1;
-
-            if (dtau <= 0)
-                continue;
+// 			if (dtau <= 0)
+// 				continue;
 
 
 
-            if (DEBUG_DRM_INTEGRATION)
-            {
-                fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int) i, dtau, tau_1, tau_2, dt, local_pos, dir );
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
-            }
+// 			if (DEBUG_DRM_INTEGRATION)
+// 			{
+// 				/* FMK
+// 				fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int) i, dtau, tau_1, tau_2, dt, local_pos, dir );
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
+// 				******/
+// 				fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i, dtau, tau_1, tau_2, dt, local_pos, dir);
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0 + i * Nt], v[0 + (i + 1)*3]);
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1 + i * Nt], v[1 + (i + 1)*3]);
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2 + i * Nt], v[2 + (i + 1)*3]);
 
-            double u1 = DRMDisplacements(3 * local_pos + 0);
-            double u2 = DRMDisplacements(3 * local_pos + 1);
-            double u3 = DRMDisplacements(3 * local_pos + 2);
-            double du1 = (v[0][i] + v[0][i + 1]) * (dir * dtau / 2);
-            double du2 = (v[1][i] + v[1][i + 1]) * (dir * dtau / 2);
-            double du3 = (v[2][i] + v[2][i + 1]) * (dir * dtau / 2);
+// 			}
 
-            DRMDisplacements(3 * local_pos + 0) += du1;
-            DRMDisplacements(3 * local_pos + 1) += du2;
-            DRMDisplacements(3 * local_pos + 2) += du3;
+// 			double u1 = DRMDisplacements(3 * local_pos + 0);
+// 			double u2 = DRMDisplacements(3 * local_pos + 1);
+// 			double u3 = DRMDisplacements(3 * local_pos + 2);
+// 			/* FMK
+// 			double du1 = (v[0][i] + v[0][i + 1]) * (dir * dtau / 2);
+// 			double du2 = (v[1][i] + v[1][i + 1]) * (dir * dtau / 2);
+// 			double du3 = (v[2][i] + v[2][i + 1]) * (dir * dtau / 2);
+// 			******/
+// 			double du1 = (v[0 + i * 3] + v[0 + (i + 1)*3]) * (dir * dtau / 2);
+// 			double du2 = (v[1 + i * 3] + v[1 + (i + 1)*3]) * (dir * dtau / 2);
+// 			double du3 = (v[2 + i * 3] + v[2 + (i + 1)*3]) * (dir * dtau / 2);
 
-            if (DEBUG_DRM_INTEGRATION)
-            {
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f \n", DRMDisplacements(3 * local_pos + 0) );
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f \n", DRMDisplacements(3 * local_pos + 1) );
-                fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f \n", DRMDisplacements(3 * local_pos + 2) );
-            }
+// 			DRMDisplacements(3 * local_pos + 0) += du1;
+// 			DRMDisplacements(3 * local_pos + 1) += du2;
+// 			DRMDisplacements(3 * local_pos + 2) += du3;
 
-            // bool found_nan = false;
-            if (isnan(u1) || isnan(du1) ||
-                    isnan(u2) || isnan(du2) ||
-                    isnan(u3) || isnan(du3) ||
-                    isnan(dt) || isnan(dtau) )
-            {
-                H5DRMerror << "NAN Detected!!! \n";
-                H5DRMerror << "    nodeTag = " << nodeTag << endln;
-                H5DRMerror << "    local_pos = " << local_pos << endln;
-                printf("    i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i,  dtau, tau_1, tau_2, dt, local_pos, dir );
-                printf("        u1 = %f du1 = %f \n", u1, du1);
-                printf("        u2 = %f du2 = %f \n", u2, du2);
-                printf("        u3 = %f du3 = %f \n", u3, du3);
-                printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
-                printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
-                printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
-                exit(-1);
-            }
+// 			if (DEBUG_DRM_INTEGRATION)
+// 			{
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f \n", DRMDisplacements(3 * local_pos + 0));
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f \n", DRMDisplacements(3 * local_pos + 1));
+// 				fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f \n", DRMDisplacements(3 * local_pos + 2));
+// 			}
 
-        }
->>>>>>> 732044f5b1846fa0047e4516e0717dc0d22bffc3
+// 			// bool found_nan = false;
+// 			if (isnan(u1) || isnan(du1) ||
+// 				isnan(u2) || isnan(du2) ||
+// 				isnan(u3) || isnan(du3) ||
+// 				isnan(dt) || isnan(dtau))
+// 			{
+// 				H5DRMerror << "NAN Detected!!! \n";
+// 				H5DRMerror << "    nodeTag = " << nodeTag << endln;
+// 				H5DRMerror << "    local_pos = " << local_pos << endln;
+// 				printf("    i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i, dtau, tau_1, tau_2, dt, local_pos, dir);
+// 				printf("        u1 = %f du1 = %f \n", u1, du1);
+// 				printf("        u2 = %f du2 = %f \n", u2, du2);
+// 				printf("        u3 = %f du3 = %f \n", u3, du3);
+// 				/* FMK
+// 				printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
+// 				printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
+// 				printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
+// 				*/
+// 				printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0 + i * 3], v[0 + (i + 1)*3]);
+// 				printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1 + i * 3], v[1 + (i + 1)*3]);
+// 				printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2 + i * 3], v[2 + (i + 1)*3]);
+// 				exit(-1);
+// 			}
 
-        int eval_i = (int) (t2 - t1) / dt;
+// 		}
+// =======
+//         for (hsize_t i = 0; i <  Nt; ++i)
+//         {
+//             double dtau = 0;
+//             double tau_1 = tstart + i * dt;
+//             double tau_2 = tstart + (i + 1) * dt;
+//             tau_1 = tau_1 > t1 ? tau_1 : t1;
+//             tau_2 = tau_2 < t2 ? tau_2 : t2;
+//             dtau = tau_2 - tau_1;
 
-
-        DRMAccelerations(3 * local_pos + 0) = (v[0][eval_i] - v[0][eval_i + 1]) / dt;
-        DRMAccelerations(3 * local_pos + 1) = (v[1][eval_i] - v[1][eval_i + 1]) / dt;
-        DRMAccelerations(3 * local_pos + 2) = (v[2][eval_i] - v[2][eval_i + 1]) / dt;
-
-        if (DEBUG_DRM_INTEGRATION)
-        {
-            fprintf(fptr, "eval_i = %d \n", eval_i );
-            fprintf(fptr, "     v[0][eval_i] = %f  v[0][eval_i+1] = %f\n",  v[0][eval_i], v[0][eval_i + 1] );
-            fprintf(fptr, "     v[1][eval_i] = %f  v[1][eval_i+1] = %f\n",  v[1][eval_i], v[1][eval_i + 1] );
-            fprintf(fptr, "     v[2][eval_i] = %f  v[2][eval_i+1] = %f\n",  v[2][eval_i], v[2][eval_i + 1] );
-            fprintf(fptr, "     DRMAccelerations(3 * local_pos + 0) = %f\n",  DRMAccelerations(3 * local_pos + 0) );
-            fprintf(fptr, "     DRMAccelerations(3 * local_pos + 1) = %f\n",  DRMAccelerations(3 * local_pos + 1) );
-            fprintf(fptr, "     DRMAccelerations(3 * local_pos + 2) = %f\n",  DRMAccelerations(3 * local_pos + 2) );
-
-        }
-    }
+//             if (dtau <= 0)
+//                 continue;
 
 
 
-    last_integration_time = t2;
+//             if (DEBUG_DRM_INTEGRATION)
+//             {
+//                 fprintf(fptr, "i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int) i, dtau, tau_1, tau_2, dt, local_pos, dir );
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
+//             }
 
-    return true;
+//             double u1 = DRMDisplacements(3 * local_pos + 0);
+//             double u2 = DRMDisplacements(3 * local_pos + 1);
+//             double u3 = DRMDisplacements(3 * local_pos + 2);
+//             double du1 = (v[0][i] + v[0][i + 1]) * (dir * dtau / 2);
+//             double du2 = (v[1][i] + v[1][i + 1]) * (dir * dtau / 2);
+//             double du3 = (v[2][i] + v[2][i + 1]) * (dir * dtau / 2);
+
+//             DRMDisplacements(3 * local_pos + 0) += du1;
+//             DRMDisplacements(3 * local_pos + 1) += du2;
+//             DRMDisplacements(3 * local_pos + 2) += du3;
+
+//             if (DEBUG_DRM_INTEGRATION)
+//             {
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 0) = %f \n", DRMDisplacements(3 * local_pos + 0) );
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 1) = %f \n", DRMDisplacements(3 * local_pos + 1) );
+//                 fprintf(fptr, "    DRMDisplacements(3 * local_pos + 2) = %f \n", DRMDisplacements(3 * local_pos + 2) );
+//             }
+
+//             // bool found_nan = false;
+//             if (isnan(u1) || isnan(du1) ||
+//                     isnan(u2) || isnan(du2) ||
+//                     isnan(u3) || isnan(du3) ||
+//                     isnan(dt) || isnan(dtau) )
+//             {
+//                 H5DRMerror << "NAN Detected!!! \n";
+//                 H5DRMerror << "    nodeTag = " << nodeTag << endln;
+//                 H5DRMerror << "    local_pos = " << local_pos << endln;
+//                 printf("    i = %d dtau=%f tau_1=%f tau_2=%f dt=%f local_pos=%d dir=%d\n", (int)i,  dtau, tau_1, tau_2, dt, local_pos, dir );
+//                 printf("        u1 = %f du1 = %f \n", u1, du1);
+//                 printf("        u2 = %f du2 = %f \n", u2, du2);
+//                 printf("        u3 = %f du3 = %f \n", u3, du3);
+//                 printf("        DRMDisplacements(3 * local_pos + 0) = %f -->  v[0][i] = %f  v[0][i+1] = %f\n", DRMDisplacements(3 * local_pos + 0), v[0][i], v[0][i + 1] );
+//                 printf("        DRMDisplacements(3 * local_pos + 1) = %f -->  v[1][i] = %f  v[1][i+1] = %f\n", DRMDisplacements(3 * local_pos + 1), v[1][i], v[1][i + 1] );
+//                 printf("        DRMDisplacements(3 * local_pos + 2) = %f -->  v[2][i] = %f  v[2][i+1] = %f\n", DRMDisplacements(3 * local_pos + 2), v[2][i], v[2][i + 1] );
+//                 exit(-1);
+//             }
+
+//         }
+// >>>>>>> 732044f5b1846fa0047e4516e0717dc0d22bffc3
+
+//         int eval_i = (int) (t2 - t1) / dt;
+
+
+//         DRMAccelerations(3 * local_pos + 0) = (v[0][eval_i] - v[0][eval_i + 1]) / dt;
+//         DRMAccelerations(3 * local_pos + 1) = (v[1][eval_i] - v[1][eval_i + 1]) / dt;
+//         DRMAccelerations(3 * local_pos + 2) = (v[2][eval_i] - v[2][eval_i + 1]) / dt;
+
+//         if (DEBUG_DRM_INTEGRATION)
+//         {
+//             fprintf(fptr, "eval_i = %d \n", eval_i );
+//             fprintf(fptr, "     v[0][eval_i] = %f  v[0][eval_i+1] = %f\n",  v[0][eval_i], v[0][eval_i + 1] );
+//             fprintf(fptr, "     v[1][eval_i] = %f  v[1][eval_i+1] = %f\n",  v[1][eval_i], v[1][eval_i + 1] );
+//             fprintf(fptr, "     v[2][eval_i] = %f  v[2][eval_i+1] = %f\n",  v[2][eval_i], v[2][eval_i + 1] );
+//             fprintf(fptr, "     DRMAccelerations(3 * local_pos + 0) = %f\n",  DRMAccelerations(3 * local_pos + 0) );
+//             fprintf(fptr, "     DRMAccelerations(3 * local_pos + 1) = %f\n",  DRMAccelerations(3 * local_pos + 1) );
+//             fprintf(fptr, "     DRMAccelerations(3 * local_pos + 2) = %f\n",  DRMAccelerations(3 * local_pos + 2) );
+
+//         }
+//     }
+
+
+
+//     last_integration_time = t2;
+
+//     return true;
 }
 
 

--- a/SRC/element/RockingBC/RockingBC.cpp
+++ b/SRC/element/RockingBC/RockingBC.cpp
@@ -273,8 +273,8 @@ RockingBC::RockingBC(int tag, int Nd1, int Nd2, int nw,
   ey = sy / E;
 
   for (size_t i = 0; i != Nw - 1; i++) {
-	  Vec vvv1{ Yw[i],Yw[i + 1] };
-	  Vec vvv2{ 0.0, 0.0 };
+	  RBCVec vvv1{ Yw[i],Yw[i + 1] };
+	  RBCVec vvv2{ 0.0, 0.0 };
 	  Vecint vvv3{ 0 };
 	  Matrix mmm4{};
 	  Ysi.push_back(vvv1);
@@ -2117,7 +2117,7 @@ void RockingBC::Uel_K_calc()
 		}
 	}
 
-	UBnew_R = Vec(Ydks.Size(), 0.0);
+	UBnew_R = RBCVec(Ydks.Size(), 0.0);
 	UBnew = Matrix(Nw, Ydks.Size());
 	dUBnew_dR = Matrix(Nw, Ydks.Size());
 
@@ -3471,12 +3471,12 @@ void RockingBC::Up_interval_split(const Vector& Yup, const Vector& Up, const Vec
 	Yup_ints.clear();
 	Up_ints.clear();
 	for (size_t i = 0; i != Yind.size() - 1; i++) {
-		Vec X1{};
+		RBCVec X1{};
 		for (size_t j = Yind[i]; j != Yind[i + 1] +1; j++) {
 			X1.push_back(Up[j]);
 		}
 		Up_ints.push_back(X1);
-		Vec X2{};
+		RBCVec X2{};
 		for (size_t j = Yind[i]; j != Yind[i + 1] +1; j++) {
 			X2.push_back(Yup[j]);
 		}
@@ -3486,7 +3486,7 @@ void RockingBC::Up_interval_split(const Vector& Yup, const Vector& Up, const Vec
 }
 
 Vector RockingBC::interval_join(const VecVec& X_ints) {
-	static Vec X{};
+	static RBCVec X{};
 	X.clear();
 
 	for (size_t i = 0; i != X_ints.size(); i++) {
@@ -3532,7 +3532,7 @@ Matrix RockingBC::interval_join(const VecMatOS& X_ints) {
 }
 
 Vector RockingBC::array_join(const VecVec& X_ints) {
-	Vec X{};
+	RBCVec X{};
 	for (size_t i = 0; i != X_ints.size(); i++) {
 		for (size_t j = 0; j != X_ints.at(i).size(); j++) {
 			X.push_back(X_ints[i][j]);
@@ -3563,7 +3563,7 @@ Matrix RockingBC::array_join(const VecMatOS& X_ints) {
 	return res;
 }
 
-void RockingBC::commony(const Vec& ya, const Vec& fa, const Vec& yb, const Vec& fb, Vec& Y, Vec& FA, Vec& FB)
+void RockingBC::commony(const RBCVec& ya, const RBCVec& fa, const RBCVec& yb, const RBCVec& fb, RBCVec& Y, RBCVec& FA, RBCVec& FB)
 {
 	Y.clear();
 	FA.clear();
@@ -3599,10 +3599,10 @@ void RockingBC::commony(const Vec& ya, const Vec& fa, const Vec& yb, const Vec& 
 	return;
 }
 
-void RockingBC::interval_interior(double wl, double wr, double ey, double dy, const Vec& up_com, const Vec& yup_com,
-	const Vec& ys_com, const Vec& s_com, double beta_Dt,
-	Vec& ys_new, Vec& s_new, Vecint& ys_cats, Vec& yup_new, Vec& up_new, 
-	Vec& dys_new_dwl, Vec& dys_new_dwr, Vec& ds_new_dwl, Vec& ds_new_dwr, Vec& ua_pos)
+void RockingBC::interval_interior(double wl, double wr, double ey, double dy, const RBCVec& up_com, const RBCVec& yup_com,
+	const RBCVec& ys_com, const RBCVec& s_com, double beta_Dt,
+	RBCVec& ys_new, RBCVec& s_new, Vecint& ys_cats, RBCVec& yup_new, RBCVec& up_new, 
+	RBCVec& dys_new_dwl, RBCVec& dys_new_dwr, RBCVec& ds_new_dwl, RBCVec& ds_new_dwr, RBCVec& ua_pos)
 {
 	
 	static const double pi{ std::atan(1.) * 4 };
@@ -3613,14 +3613,14 @@ void RockingBC::interval_interior(double wl, double wr, double ey, double dy, co
 	}
 	double eyn = ey*DU_DS;
 
-	static Vec Y{};
-	static Vec Up{};
-	static Vec S{};
+	static RBCVec Y{};
+	static RBCVec Up{};
+	static RBCVec S{};
 
 	commony(yup_com,up_com,ys_com,s_com,Y,Up,S);
 
 	// Plastic displacements differences
-	static Vec Upd; Upd.clear();
+	static RBCVec Upd; Upd.clear();
 	double yline{};
 	double kyline = (Up[Up.size()-1]-Up[0])/(Y[Y.size()-1]-Y[0]);
 	for (size_t iy = 0; iy != Y.size(); iy++)
@@ -3630,8 +3630,8 @@ void RockingBC::interval_interior(double wl, double wr, double ey, double dy, co
 	}
 	
 	// Limits
-	static Vec Slim; Slim.clear();
-	static Vec Slimn; Slimn.clear();
+	static RBCVec Slim; Slim.clear();
+	static RBCVec Slimn; Slimn.clear();
 	for (size_t i = 0; i != Y.size(); i++)
 	{
 		Slim.push_back(S[i]*DAMPC);
@@ -3674,9 +3674,9 @@ void RockingBC::interval_interior(double wl, double wr, double ey, double dy, co
     double dkwnline_dwr=dwrn_dwr/dy;
 
 	// Plastic displacements into stresses insertion
-	static Vec Wn; Wn.clear();
-	static Vec dWn_dwl; dWn_dwl.clear();
-	static Vec dWn_dwr; dWn_dwr.clear();
+	static RBCVec Wn; Wn.clear();
+	static RBCVec dWn_dwl; dWn_dwl.clear();
+	static RBCVec dWn_dwr; dWn_dwr.clear();
 	double wline{};
 	for (size_t iy = 0; iy != Y.size(); iy++)
 	{
@@ -3686,16 +3686,16 @@ void RockingBC::interval_interior(double wl, double wr, double ey, double dy, co
 	}
 
 	// Crossings
-	static Vec Yf{}; Yf.clear();
-	static Vec Wnf{}; Wnf.clear();
-	static Vec Upf{}; Upf.clear();
-	static Vec Slimnf{}; Slimnf.clear();
-	static Vec dYf_dwl{}; dYf_dwl.clear();
-	static Vec dWnf_dwl{}; dWnf_dwl.clear();
-	static Vec dSlimnf_dwl{}; dSlimnf_dwl.clear();
-	static Vec dYf_dwr{}; dYf_dwr.clear();
-	static Vec dWnf_dwr{}; dWnf_dwr.clear();
-	static Vec dSlimnf_dwr{}; dSlimnf_dwr.clear();
+	static RBCVec Yf{}; Yf.clear();
+	static RBCVec Wnf{}; Wnf.clear();
+	static RBCVec Upf{}; Upf.clear();
+	static RBCVec Slimnf{}; Slimnf.clear();
+	static RBCVec dYf_dwl{}; dYf_dwl.clear();
+	static RBCVec dWnf_dwl{}; dWnf_dwl.clear();
+	static RBCVec dSlimnf_dwl{}; dSlimnf_dwl.clear();
+	static RBCVec dYf_dwr{}; dYf_dwr.clear();
+	static RBCVec dWnf_dwr{}; dWnf_dwr.clear();
+	static RBCVec dSlimnf_dwr{}; dSlimnf_dwr.clear();
 	
 	double wnf1{}, wnf2{};
 	bool wnf1found = false;
@@ -3848,11 +3848,11 @@ void RockingBC::interval_interior(double wl, double wr, double ey, double dy, co
 
 	//Separation into stresses, plastic displacements
 	
-	static Vec Sf_new{}; Sf_new.clear();
-	static Vec dSf_new_dwl{}; dSf_new_dwl.clear();
-	static Vec dSf_new_dwr{}; dSf_new_dwr.clear();
-	static Vec Upf_new{}; Upf_new.clear();
-	static Vec Ua_pos{}; Ua_pos.clear();
+	static RBCVec Sf_new{}; Sf_new.clear();
+	static RBCVec dSf_new_dwl{}; dSf_new_dwl.clear();
+	static RBCVec dSf_new_dwr{}; dSf_new_dwr.clear();
+	static RBCVec Upf_new{}; Upf_new.clear();
+	static RBCVec Ua_pos{}; Ua_pos.clear();
 
 	for (size_t i = 0; i != Wnf.size(); i++) {
 		if (Wnf[i] > Slimnf[i]) {
@@ -3959,8 +3959,8 @@ void RockingBC::interval_dists(const Vector& Yw, const Vector& W, const VecVec& 
 	
 	for (size_t i = 0; i != W.Size() - 1; i++) {
 		
-		Vec dwl_dW(W.Size()); dwl_dW[i] = 1.0;
-		Vec dwr_dW(W.Size()); dwr_dW[i+1] = 1.0;
+		RBCVec dwl_dW(W.Size()); dwl_dW[i] = 1.0;
+		RBCVec dwr_dW(W.Size()); dwr_dW[i+1] = 1.0;
 		Matrix dys_dW = Matrix(dys_dwl_list[i].size(), W.Size());
 		Matrix ds_dW = Matrix(ds_dwl_list[i].size(), W.Size());
 		for (size_t l = 0; l != W.Size(); l++) {
@@ -3983,7 +3983,7 @@ void RockingBC::interval_dists(const Vector& Yw, const Vector& W, const VecVec& 
 
 }
 
-void RockingBC::NM_calc_int(const Vec& Ys, const Matrix& dYs_dW, const Vec& S, const Matrix& dS_dW, double& N, double& M, Vector& dN_dW, Vector& dM_dW)
+void RockingBC::NM_calc_int(const RBCVec& Ys, const Matrix& dYs_dW, const RBCVec& S, const Matrix& dS_dW, double& N, double& M, Vector& dN_dW, Vector& dM_dW)
 {
 	N = 0;
 	M = 0;
@@ -4007,7 +4007,7 @@ void RockingBC::NM_calc_int(const Vec& Ys, const Matrix& dYs_dW, const Vec& S, c
 	return;
 }
 
-void RockingBC::critpoints(const Vec& y, const Vec& s, int rinit, int rend, Vecint& cp)
+void RockingBC::critpoints(const RBCVec& y, const RBCVec& s, int rinit, int rend, Vecint& cp)
 {
 	cp.clear();
 
@@ -4030,8 +4030,8 @@ void RockingBC::critpoints(const Vec& y, const Vec& s, int rinit, int rend, Veci
 	return;
 }
 
-void RockingBC::int_bilin(const Vecint& ys_cats, const Vec& ys, const Vec& s, const Vec& yup, const Vec& up, const Vec& ua_pos, double ey,
-	Vec& ys_new, Vec& s_new, Vec& yup_new, Vec& up_new)
+void RockingBC::int_bilin(const Vecint& ys_cats, const RBCVec& ys, const RBCVec& s, const RBCVec& yup, const RBCVec& up, const RBCVec& ua_pos, double ey,
+	RBCVec& ys_new, RBCVec& s_new, RBCVec& yup_new, RBCVec& up_new)
 {
 
 	if ((ys.size() != yup.size()) || (ys_cats.size() != ys.size() - 1) || (ys.size() != ua_pos.size())) {
@@ -4045,8 +4045,8 @@ void RockingBC::int_bilin(const Vecint& ys_cats, const Vec& ys, const Vec& s, co
 	static const double pi{ std::atan(1.) * 4 };
 	double DU_DS = (ys[ys.size()-1] - ys[0]) / pi;
 
-	static Vec w{}; w.clear();
-	static Vec sm{}; sm.clear();
+	static RBCVec w{}; w.clear();
+	static RBCVec sm{}; sm.clear();
 	for (size_t i = 0; i != s.size(); i++) {
 		w.push_back(s[i] * DU_DS + ua_pos[i]);
 		sm.push_back(s[i] * DU_DS);
@@ -4099,20 +4099,20 @@ void RockingBC::int_bilin(const Vecint& ys_cats, const Vec& ys, const Vec& s, co
 	static VecVec up_bl{}; up_bl.clear();
 	static VecVec yup_bl{}; yup_bl.clear();
 
-	static Vec ysp{};
-	static Vec smp{};
-	static Vec sp{};
-	static Vec wp{};
-	static Vec ss{};
-	static Vec ys_try{}, sm_try{}, yw_try{}, w_try{}, s_try{};
+	static RBCVec ysp{};
+	static RBCVec smp{};
+	static RBCVec sp{};
+	static RBCVec wp{};
+	static RBCVec ss{};
+	static RBCVec ys_try{}, sm_try{}, yw_try{}, w_try{}, s_try{};
 	static Vecint v{};
 
 	for (size_t ir = 0; ir != regs2.size(); ir++) {
 		Vecint r = regs2[ir];
 		if (regs2_cats[ir] == 0) {
-			ysp = Vec(ys.begin() + r[0], ys.begin() + r[1] + 1);
-			smp = Vec(sm.begin() + r[0], sm.begin() + r[1] + 1);
-			wp = Vec(w.begin() + r[0], w.begin() + r[1] + 1);
+			ysp = RBCVec(ys.begin() + r[0], ys.begin() + r[1] + 1);
+			smp = RBCVec(sm.begin() + r[0], sm.begin() + r[1] + 1);
+			wp = RBCVec(w.begin() + r[0], w.begin() + r[1] + 1);
 			ys_try.clear(); sm_try.clear(); yw_try.clear(); w_try.clear();
 			bool suc = bilin_two(ysp, smp, ysp, wp, ys_try, sm_try, yw_try, w_try);
 			if (suc) {
@@ -4157,8 +4157,8 @@ void RockingBC::int_bilin(const Vecint& ys_cats, const Vec& ys, const Vec& s, co
 			}
 		}
 		else {
-			ysp = Vec(ys.begin() + r[0], ys.begin() + r[1] + 1);
-			sp = Vec(s.begin() + r[0], s.begin() + r[1] + 1);
+			ysp = RBCVec(ys.begin() + r[0], ys.begin() + r[1] + 1);
+			sp = RBCVec(s.begin() + r[0], s.begin() + r[1] + 1);
 			ys_try.clear(); s_try.clear();
 			bool suc = bilin_one(ysp, sp, ys_try, s_try);
 			if (suc) {
@@ -4299,7 +4299,7 @@ void RockingBC::Up_interval_split_K(const Vector& Yup, const Vector& Up, const V
 	return;
 }
 
-void RockingBC::commony_K(const Vector& ya, const Vector& fa, const Vector& ka, const Vector& yb, const Vector& fb, const Vector& kb, Vec& Y, Vec& FA, Vec& FB, Vec& KA, Vec& KB)
+void RockingBC::commony_K(const Vector& ya, const Vector& fa, const Vector& ka, const Vector& yb, const Vector& fb, const Vector& kb, RBCVec& Y, RBCVec& FA, RBCVec& FB, RBCVec& KA, RBCVec& KB)
 {
 	Y.clear();
 	FA.clear();
@@ -4346,27 +4346,27 @@ void RockingBC::commony_K(const Vector& ya, const Vector& fa, const Vector& ka, 
 
 void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, const Vector& up_com, const Vector& yup_com, const Vector& kup_com,
 	const Vector& ys_com, const Vector& s_com, const Vector& ks_com, double beta_Dt,
-	Vec& ys_new, Vec& s_new, Vec& ks_new, Vecint& ys_cats, Vec& yup_new, Vec& up_new, Vec& kup_new,
-	Vec& dys_new_dwl, Vec& dys_new_dwr, Vec& ds_new_dwl, Vec& ds_new_dwr, Vec& dks_new_dwl, Vec& dks_new_dwr,
-	Vec& ydks, Vec& dks, Vec& dydks_dwl, Vec& dydks_dwr, Vec& ddks_dwl, Vec& ddks_dwr,
-	Vec& ds, Vec& dds_dwl, Vec& dds_dwr)
+	RBCVec& ys_new, RBCVec& s_new, RBCVec& ks_new, Vecint& ys_cats, RBCVec& yup_new, RBCVec& up_new, RBCVec& kup_new,
+	RBCVec& dys_new_dwl, RBCVec& dys_new_dwr, RBCVec& ds_new_dwl, RBCVec& ds_new_dwr, RBCVec& dks_new_dwl, RBCVec& dks_new_dwr,
+	RBCVec& ydks, RBCVec& dks, RBCVec& dydks_dwl, RBCVec& dydks_dwr, RBCVec& ddks_dwl, RBCVec& ddks_dwr,
+	RBCVec& ds, RBCVec& dds_dwl, RBCVec& dds_dwr)
 {
 	static const double pi{ std::atan(1.) * 4 };
 	double DU_DS = dy / pi;
 	double DAMPC = beta_Dt / (1.0 + beta_Dt);
 	double eyn = ey * DU_DS;
 
-	static Vec Y{};
-	static Vec Up{};
-	static Vec S{};
-	static Vec KUp{};
-	static Vec KS{};
+	static RBCVec Y{};
+	static RBCVec Up{};
+	static RBCVec S{};
+	static RBCVec KUp{};
+	static RBCVec KS{};
 
 	commony_K(yup_com, up_com, kup_com, ys_com, s_com, ks_com, Y, Up, S, KUp, KS);
 
 	// Plastic displacements differences
-	static Vec Upd; Upd.clear();
-	static Vec KUpd; KUpd.clear();
+	static RBCVec Upd; Upd.clear();
+	static RBCVec KUpd; KUpd.clear();
 	double yline{};
 	double kyline = (Up[Up.size() - 1] - Up[0]) / (Y[Y.size() - 1] - Y[0]);
 	for (size_t iy = 0; iy != Y.size(); iy++)
@@ -4380,9 +4380,9 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 	}
 
 	// Limits
-	static Vec Slim; Slim.clear();
-	static Vec Slimn; Slimn.clear();
-	static Vec KSlim; KSlim.clear();
+	static RBCVec Slim; Slim.clear();
+	static RBCVec Slimn; Slimn.clear();
+	static RBCVec KSlim; KSlim.clear();
 	for (size_t i = 0; i != Y.size(); i++)
 	{
 		Slim.push_back(S[i] * DAMPC);
@@ -4429,12 +4429,12 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 	double dkwnline_dwr = dwrn_dwr / dy;
 
 	// Plastic displacements into stresses insertion
-	static Vec Wn; Wn.clear();
-	static Vec dWn_dwl; dWn_dwl.clear();
-	static Vec dWn_dwr; dWn_dwr.clear();
-	static Vec KWn; KWn.clear();
-	static Vec dKWn_dwl; dKWn_dwl.clear();
-	static Vec dKWn_dwr; dKWn_dwr.clear();
+	static RBCVec Wn; Wn.clear();
+	static RBCVec dWn_dwl; dWn_dwl.clear();
+	static RBCVec dWn_dwr; dWn_dwr.clear();
+	static RBCVec KWn; KWn.clear();
+	static RBCVec dKWn_dwl; dKWn_dwl.clear();
+	static RBCVec dKWn_dwr; dKWn_dwr.clear();
 	double wline{};
 	for (size_t iy = 0; iy != Y.size(); iy++)
 	{
@@ -4450,21 +4450,21 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 	}
 
 	// Crossings
-	static Vec Yf{}; Yf.clear();
-	static Vec Wnf{}; Wnf.clear();
-	static Vec Upf{}; Upf.clear();
-	static Vec Slimnf{}; Slimnf.clear();
-	static Vec dYf_dwl{}; dYf_dwl.clear();
-	static Vec dWnf_dwl{}; dWnf_dwl.clear();
-	static Vec dSlimnf_dwl{}; dSlimnf_dwl.clear();
-	static Vec dYf_dwr{}; dYf_dwr.clear();
-	static Vec dWnf_dwr{}; dWnf_dwr.clear();
-	static Vec dSlimnf_dwr{}; dSlimnf_dwr.clear();
-	static Vec KWnf{}; KWnf.clear();
-	static Vec KUpf{}; KUpf.clear();
-	static Vec KSlimf{}; KSlimf.clear();
-	static Vec dKWnf_dwl{}; dKWnf_dwl.clear();
-	static Vec dKWnf_dwr{}; dKWnf_dwr.clear();
+	static RBCVec Yf{}; Yf.clear();
+	static RBCVec Wnf{}; Wnf.clear();
+	static RBCVec Upf{}; Upf.clear();
+	static RBCVec Slimnf{}; Slimnf.clear();
+	static RBCVec dYf_dwl{}; dYf_dwl.clear();
+	static RBCVec dWnf_dwl{}; dWnf_dwl.clear();
+	static RBCVec dSlimnf_dwl{}; dSlimnf_dwl.clear();
+	static RBCVec dYf_dwr{}; dYf_dwr.clear();
+	static RBCVec dWnf_dwr{}; dWnf_dwr.clear();
+	static RBCVec dSlimnf_dwr{}; dSlimnf_dwr.clear();
+	static RBCVec KWnf{}; KWnf.clear();
+	static RBCVec KUpf{}; KUpf.clear();
+	static RBCVec KSlimf{}; KSlimf.clear();
+	static RBCVec dKWnf_dwl{}; dKWnf_dwl.clear();
+	static RBCVec dKWnf_dwr{}; dKWnf_dwr.clear();
 
 	double wnf1{}, wnf2{};
 	bool wnf1found = false;
@@ -4642,10 +4642,10 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 
 	//Separation into stresses, plastic displacements
 
-	static Vec Sf_new{}; Sf_new.clear();
-	static Vec dSf_new_dwl{}; dSf_new_dwl.clear();
-	static Vec dSf_new_dwr{}; dSf_new_dwr.clear();
-	static Vec Upf_new{}; Upf_new.clear();
+	static RBCVec Sf_new{}; Sf_new.clear();
+	static RBCVec dSf_new_dwl{}; dSf_new_dwl.clear();
+	static RBCVec dSf_new_dwr{}; dSf_new_dwr.clear();
+	static RBCVec Upf_new{}; Upf_new.clear();
 
 	for (size_t i = 0; i != Wnf.size(); i++) {
 		if (Wnf[i] > Slimnf[i]) {
@@ -4668,9 +4668,9 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 		}
 	}
 
-	static Vec DSf{}; DSf.clear();
-	static Vec dDSf_dwl{}; dDSf_dwl.clear();
-	static Vec dDSf_dwr{}; dDSf_dwr.clear();
+	static RBCVec DSf{}; DSf.clear();
+	static RBCVec dDSf_dwl{}; dDSf_dwl.clear();
+	static RBCVec dDSf_dwr{}; dDSf_dwr.clear();
 
 	for (size_t i = 0; i != Sf_new.size(); i++) {
 		DSf.push_back(Sf_new[i] - Slimnf[i] / DU_DS);
@@ -4680,13 +4680,13 @@ void RockingBC::interval_interior_K(double wl, double wr, double ey, double dy, 
 
 	//Slopes
 
-	static Vec KSf_new{}; KSf_new.clear();
-	static Vec dKSf_new_dwl{}; dKSf_new_dwl.clear();
-	static Vec dKSf_new_dwr{}; dKSf_new_dwr.clear();
-	static Vec KUpf_new{}; KUpf_new.clear();
-	static Vec DKSf{}; DKSf.clear();
-	static Vec dDKSf_dwl{}; dDKSf_dwl.clear();
-	static Vec dDKSf_dwr{}; dDKSf_dwr.clear();
+	static RBCVec KSf_new{}; KSf_new.clear();
+	static RBCVec dKSf_new_dwl{}; dKSf_new_dwl.clear();
+	static RBCVec dKSf_new_dwr{}; dKSf_new_dwr.clear();
+	static RBCVec KUpf_new{}; KUpf_new.clear();
+	static RBCVec DKSf{}; DKSf.clear();
+	static RBCVec dDKSf_dwl{}; dDKSf_dwl.clear();
+	static RBCVec dDKSf_dwr{}; dDKSf_dwr.clear();
 
 	for (size_t i = 0; i != intcats.size(); i++) {
 		if (intcats[i] == 0) {
@@ -4897,8 +4897,8 @@ void RockingBC::interval_dists_K(const Vector& Yw, const Vector& W, const Vector
 
 	for (size_t i = 0; i != W.Size() - 1; i++) {
 
-		Vec dwl_dW(W.Size()); dwl_dW[i] = 1.0;
-		Vec dwr_dW(W.Size()); dwr_dW[i + 1] = 1.0;
+		RBCVec dwl_dW(W.Size()); dwl_dW[i] = 1.0;
+		RBCVec dwr_dW(W.Size()); dwr_dW[i + 1] = 1.0;
 		Matrix dys_dW = Matrix(dys_dwl_list[i].size(), W.Size());
 		Matrix ds_dW = Matrix(ds_dwl_list[i].size(), W.Size());
 		Matrix dks_dW = Matrix(dks_dwl_list[i].size(), W.Size());
@@ -4966,7 +4966,7 @@ void RockingBC::Ys_cats_dist_calc(const VecVecint& Ys_cats, Vecint& Ys_cats_dist
 
 // bilin funcs 
 
-void RockingBC::commony_BL(const Vec& ya, const Vec& fa, const Vec& yb, const Vec& fb, Vec& Y, Vec& FA, Vec& FB)
+void RockingBC::commony_BL(const RBCVec& ya, const RBCVec& fa, const RBCVec& yb, const RBCVec& fb, RBCVec& Y, RBCVec& FA, RBCVec& FB)
 {
 	Y.clear();
 	FA.clear();
@@ -5003,11 +5003,11 @@ void RockingBC::commony_BL(const Vec& ya, const Vec& fa, const Vec& yb, const Ve
 	return;
 }
 
-bool RockingBC::distintersec(const Vec& YP, const Vec& P, const Vec& YQ, const Vec& Q)
+bool RockingBC::distintersec(const RBCVec& YP, const RBCVec& P, const RBCVec& YQ, const RBCVec& Q)
 {
-	static Vec Y{};
-	static Vec PT{};
-	static Vec QT{};
+	static RBCVec Y{};
+	static RBCVec PT{};
+	static RBCVec QT{};
 	commony_BL(YP, P, YQ, Q, Y, PT, QT);
 
 	int sgn = 0;
@@ -5056,7 +5056,7 @@ bool RockingBC::twobilinintersec(double y1, double y2, double p1, double p2, dou
 	}
 }
 
-void RockingBC::NM_BL(const Vec& Y, const Vec& S, double& N, double& M, double& Nd, double& Md)
+void RockingBC::NM_BL(const RBCVec& Y, const RBCVec& S, double& N, double& M, double& Nd, double& Md)
 {
 	N = 0.;
 	M = 0.;
@@ -5085,7 +5085,7 @@ bool RockingBC::bilinable(double Nd, double Md, double y1, double y2, double BIL
 	}
 }
 
-void RockingBC::bilindist(const Vec& Y, const Vec& S, double Nd, double Md, Vec& Ybl, Vec& Sbl, double BILINLIM)
+void RockingBC::bilindist(const RBCVec& Y, const RBCVec& S, double Nd, double Md, RBCVec& Ybl, RBCVec& Sbl, double BILINLIM)
 {
 	Ybl.clear();
 	Sbl.clear();
@@ -5106,7 +5106,7 @@ void RockingBC::bilindist(const Vec& Y, const Vec& S, double Nd, double Md, Vec&
 
 }
 
-bool RockingBC::bilin_two(const Vec& YP, const Vec& P, const Vec& YQ, const Vec& Q, Vec& YPn, Vec& Pn, Vec& YQn, Vec& Qn)
+bool RockingBC::bilin_two(const RBCVec& YP, const RBCVec& P, const RBCVec& YQ, const RBCVec& Q, RBCVec& YPn, RBCVec& Pn, RBCVec& YQn, RBCVec& Qn)
 {
 	double NP{}, MP{}, NPd{}, MPd{}, NQ{}, MQ{}, NQd{}, MQd{};
 	NM_BL(YP, P, NP, MP, NPd, MPd);
@@ -5147,7 +5147,7 @@ bool RockingBC::bilin_two(const Vec& YP, const Vec& P, const Vec& YQ, const Vec&
 
 }
 
-bool RockingBC::bilin_one(const Vec& YP, const Vec& P, Vec& YPn, Vec& Pn) {
+bool RockingBC::bilin_one(const RBCVec& YP, const RBCVec& P, RBCVec& YPn, RBCVec& Pn) {
 	double NP{}, MP{}, NPd{}, MPd{};
 	NM_BL(YP, P, NP, MP, NPd, MPd);
 

--- a/SRC/element/RockingBC/RockingBC.h
+++ b/SRC/element/RockingBC/RockingBC.h
@@ -61,7 +61,7 @@
 
 // #include "Eigen/Dense" // REMOVE EIGEN
 
-using Vec = std::vector<double>;
+using RBCVec = std::vector<double>;
 using Vecint = std::vector<int>;
 using VecVecOS = std::vector< Vector >;
 using VecVecXd = std::vector<Vector>;
@@ -194,7 +194,7 @@ private:
 	VecVec Ysi, Si, Yupi, Upi, Ysi_com, Si_com, Yupi_com, Upi_com, Ua_pos;
 	VecMatOS dYsi_dW{}; VecMatOS dSi_dW{};
 
-	Vec ysi_new, si_new, yupi_new, upi_new;
+	RBCVec ysi_new, si_new, yupi_new, upi_new;
 
 	Vector Ys, S, Ud;
 	Matrix dYs_dW, dS_dW;
@@ -364,7 +364,7 @@ private:
 
 	Vector Ks, Ks_com, Ydks, Kup, Kup_com, DS, Dks, DDKs;
 	Matrix dKs_dW, dYdks_dW, dDks_dW, dDDKs_dW, dDS_dW;
-	Vec rnotfound{};
+	RBCVec rnotfound{};
 	std::vector<int> rfoundi{};
 	std::vector<int> ifound{};
 	std::vector<int> inotfound{};
@@ -374,10 +374,10 @@ private:
 	Matrix dUnf_dR;
 	Matrix UB{};
 	Matrix dUB_dR{};
-	Vec UB_R{};
+	RBCVec UB_R{};
 	Matrix UBnew{};
 	Matrix dUBnew_dR{};
-	Vec UBnew_R{};
+	RBCVec UBnew_R{};
 	Vector Im1, Jm1;
 	Vector Uel_com;
 
@@ -531,36 +531,36 @@ private:
 	Vector array_join(const VecVec& X_ints);
 	Matrix array_join(const VecMatOS& X_ints);
 
-	void commony(const Vec& ya, const Vec& fa, const Vec& yb, const Vec& fb, Vec& Y, Vec& FA, Vec& FB);
+	void commony(const RBCVec& ya, const RBCVec& fa, const RBCVec& yb, const RBCVec& fb, RBCVec& Y, RBCVec& FA, RBCVec& FB);
 
-	void interval_interior(double wl, double wr, double ey, double dy, const Vec& up_com, const Vec& yup_com,
-		const Vec& ys_com, const Vec& s_com, double beta_Dt,
-		Vec& ys_new, Vec& s_new, Vecint& ys_cats, Vec& yup_new, Vec& up_new,
-		Vec& dys_new_dwl, Vec& dys_new_dwr, Vec& ds_new_dwl, Vec& ds_new_dwr,
-		Vec& ua_pos);
+	void interval_interior(double wl, double wr, double ey, double dy, const RBCVec& up_com, const RBCVec& yup_com,
+		const RBCVec& ys_com, const RBCVec& s_com, double beta_Dt,
+		RBCVec& ys_new, RBCVec& s_new, Vecint& ys_cats, RBCVec& yup_new, RBCVec& up_new,
+		RBCVec& dys_new_dwl, RBCVec& dys_new_dwr, RBCVec& ds_new_dwl, RBCVec& ds_new_dwr,
+		RBCVec& ua_pos);
 
-	void NM_calc_int(const Vec& Ys, const Matrix& dYs_dW, const Vec& S, const Matrix& dS_dW, double& N, double& M, Vector& dN_dW, Vector& dM_dW);
+	void NM_calc_int(const RBCVec& Ys, const Matrix& dYs_dW, const RBCVec& S, const Matrix& dS_dW, double& N, double& M, Vector& dN_dW, Vector& dM_dW);
 
 	void interval_dists(const Vector& Yw, const Vector& W, const VecVec& Yupi_com, const VecVec& Upi_com, const VecVec& Ysi_com, const VecVec& Si_com, double ey, double beta_Dt,
 		VecVec& Ysi, VecVec& Si, VecVec& Yupi_new, VecVec& Upi_new,
 		VecVecint& Ys_cats, Vector& Nints, Vector& Mints, Matrix& dNints_dW, Matrix& dMints_dW, VecVec& Ua_pos, VecMatOS& dYsi_dW, VecMatOS& dSi_dW);
 
-	void critpoints(const Vec& y, const Vec& s, int rinit, int rend, Vecint& cp);
+	void critpoints(const RBCVec& y, const RBCVec& s, int rinit, int rend, Vecint& cp);
 
-	void int_bilin(const Vecint& ys_cats, const Vec& ys, const Vec& s, const Vec& yup, const Vec& up, const Vec& ua_pos, double ey,
-		Vec& ys_new, Vec& s_new, Vec& yup_new, Vec& up_new);
+	void int_bilin(const Vecint& ys_cats, const RBCVec& ys, const RBCVec& s, const RBCVec& yup, const RBCVec& up, const RBCVec& ua_pos, double ey,
+		RBCVec& ys_new, RBCVec& s_new, RBCVec& yup_new, RBCVec& up_new);
 
 	void Up_interval_split_K(const Vector& Yup, const Vector& Up, const Vector& Kup, const Vector& Yw,
 		VecVecOS& Yup_ints, VecVecOS& Up_ints, VecVecOS& Kup_ints);
 
-	void commony_K(const Vector& ya, const Vector& fa, const Vector& ka, const Vector& yb, const Vector& fb, const Vector& kb, Vec& Y, Vec& FA, Vec& FB, Vec& KA, Vec& KB);
+	void commony_K(const Vector& ya, const Vector& fa, const Vector& ka, const Vector& yb, const Vector& fb, const Vector& kb, RBCVec& Y, RBCVec& FA, RBCVec& FB, RBCVec& KA, RBCVec& KB);
 
 	void interval_interior_K(double wl, double wr, double ey, double dy, const Vector& up_com, const Vector& yup_com, const Vector& kup_com,
 		const Vector& ys_com, const Vector& s_com, const Vector& ks_com, double beta_Dt,
-		Vec& ys_new, Vec& s_new, Vec& ks_new, Vecint& ys_cats, Vec& yup_new, Vec& up_new, Vec& kup_new,
-		Vec& dys_new_dwl, Vec& dys_new_dwr, Vec& ds_new_dwl, Vec& ds_new_dwr, Vec& dks_new_dwl, Vec& dks_new_dwr,
-		Vec& ydks, Vec& dks, Vec& dydks_dwl, Vec& dydks_dwr, Vec& ddks_dwl, Vec& ddks_dwr,
-		Vec& ds, Vec& dds_dwl, Vec& dds_dwr);
+		RBCVec& ys_new, RBCVec& s_new, RBCVec& ks_new, Vecint& ys_cats, RBCVec& yup_new, RBCVec& up_new, RBCVec& kup_new,
+		RBCVec& dys_new_dwl, RBCVec& dys_new_dwr, RBCVec& ds_new_dwl, RBCVec& ds_new_dwr, RBCVec& dks_new_dwl, RBCVec& dks_new_dwr,
+		RBCVec& ydks, RBCVec& dks, RBCVec& dydks_dwl, RBCVec& dydks_dwr, RBCVec& ddks_dwl, RBCVec& ddks_dwr,
+		RBCVec& ds, RBCVec& dds_dwl, RBCVec& dds_dwr);
 
 	void interval_dists_K(const Vector& Yw, const Vector& W, const Vector& Yup_com, const Vector& Up_com, const Vector& Kup_com, const Vector& Ys_com, const Vector& S_com, const Vector& Ks_com, double ey, double beta_Dt,
 		Vector& Ys, Vector& S, Vector& Ks, Vector& Yup_new, Vector& Up_new, Vector& Kup_new,
@@ -570,14 +570,14 @@ private:
 
 	// bilin
 
-	void commony_BL(const Vec& ya, const Vec& fa, const Vec& yb, const Vec& fb, Vec& Y, Vec& FA, Vec& FB);
-	bool distintersec(const Vec& YP, const Vec& P, const Vec& YQ, const Vec& Q);
+	void commony_BL(const RBCVec& ya, const RBCVec& fa, const RBCVec& yb, const RBCVec& fb, RBCVec& Y, RBCVec& FA, RBCVec& FB);
+	bool distintersec(const RBCVec& YP, const RBCVec& P, const RBCVec& YQ, const RBCVec& Q);
 	bool twobilinintersec(double y1, double y2, double p1, double p2, double q1, double q2, double yp, double p0, double yq, double q0);
-	void NM_BL(const Vec& Y, const Vec& S, double& N, double& M, double& Nd, double& Md);
+	void NM_BL(const RBCVec& Y, const RBCVec& S, double& N, double& M, double& Nd, double& Md);
 	bool bilinable(double Nd, double Md, double y1, double y2, double BILINLIM = 1.0e-18);
-	void bilindist(const Vec& Y, const Vec& S, double Nd, double Md, Vec& Ybl, Vec& Sbl, double BILINLIM = 1.0e-18);
-	bool bilin_two(const Vec& YP, const Vec& P, const Vec& YQ, const Vec& Q, Vec& YPn, Vec& Pn, Vec& YQn, Vec& Qn);
-	bool bilin_one(const Vec& YP, const Vec& P, Vec& YPn, Vec& Pn);
+	void bilindist(const RBCVec& Y, const RBCVec& S, double Nd, double Md, RBCVec& Ybl, RBCVec& Sbl, double BILINLIM = 1.0e-18);
+	bool bilin_two(const RBCVec& YP, const RBCVec& P, const RBCVec& YQ, const RBCVec& Q, RBCVec& YPn, RBCVec& Pn, RBCVec& YQn, RBCVec& Qn);
+	bool bilin_one(const RBCVec& YP, const RBCVec& P, RBCVec& YPn, RBCVec& Pn);
 
 
 


### PR DESCRIPTION
Hi friends!

I was trying to compile OpenSeesSP with PETSC compatibility (using the `_PETSC` compiler flag and the `HAVEPETSC = YES` makefile variable) and ran into a clash between the `petsc.h` header files and definitions in `RockingBC.h`. 

The conflict is that both define the type `Vec` without a namespace qualification. 

Since its easier for us to manage our sources, I went ahead and renamed the "using" declaration in line 64 on RockingBC.h from:

`using RBCVec = std::vector<double>;
`
to 

`using RBCVec = std::vector<double>;
`

and then changed all appearances of `Vec` to `RBCVec` in both .h and .cpp files. 

Alternatively, I could do this with a namespace in the RBC source, which would require a less-invasive change to the source code. 

The rest of the changes include fixes to the H5DRM source, that contained some merge conflict messages and also a mechanism to include PETSC in the build with a compiler flag. 

