### PR TITLE
Adding MPCORecorder to Makefile to fix error on linux

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -421,6 +421,7 @@ RECORDER_LIBS = $(FE)/recorder/Recorder.o \
 	$(FE)/recorder/DamageRecorder.o \
 	$(FE)/recorder/RemoveRecorder.o \
 	$(FE)/recorder/PVDRecorder.o \
+	$(FE)/recorder/MPCORecorder.o \
 	$(FE)/recorder/GmshRecorder.o \
 	$(FE)/recorder/ElementRecorderRMS.o \
 	$(FE)/recorder/NodeRecorderRMS.o \


### PR DESCRIPTION
This PR adds MPCORecorder to Makefile to fix a run-time error in OpenSeesPy on linux.