### PR TITLE
Inertia Truss element messed up visual studio filters

### DIFF
--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -979,6 +979,7 @@
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ChebyshevBeamIntegration.cpp">
       <Filter>forceBeamColumn\beamIntegration</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\truss\InertiaTruss.cpp">
       <Filter>truss</Filter>
     </ClCompile>


### PR DESCRIPTION
@fmckenna @mhscott  A missing line in the visual studio filter file messed up all filters in visual studio projects