### PR TITLE
Fixing cmake build fail due to new UANDES materials not having a CMakeList.txt

### DIFF
--- a/SRC/material/nD/CMakeLists.txt
+++ b/SRC/material/nD/CMakeLists.txt
@@ -152,5 +152,6 @@ add_subdirectory(reinforcedConcretePlaneStress)
 add_subdirectory(UWmaterials)
 add_subdirectory(matCMM)
 add_subdirectory(stressDensityModel)
+add_subdirectory(UANDESmaterials)
 
 

--- a/SRC/material/nD/UANDESmaterials/CMakeLists.txt
+++ b/SRC/material/nD/UANDESmaterials/CMakeLists.txt
@@ -1,0 +1,18 @@
+#==============================================================================
+# 
+#        OpenSees -- Open System For Earthquake Engineering Simulation
+#                Pacific Earthquake Engineering Research Center
+#
+#==============================================================================
+target_sources(OPS_Material
+    PRIVATE
+      SAniSandMS.cpp
+      SAniSandMS3D.cpp
+      SAniSandMSPlaneStrain.cpp
+    PUBLIC
+      SAniSandMS.h
+      SAniSandMS3D.h
+      SAniSandMSPlaneStrain.h
+)
+
+target_include_directories(OPS_Material PUBLIC ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
@fmckenna @mhscott the recently added UANDES materials (@jaabell) are missing the CMakeList.txt and the CMake build fails in linking.