### PR TITLE
Adding getNodeLoadTags and getNodeLoadData output commands

### DIFF
--- a/SRC/domain/node/NodalLoad.cpp
+++ b/SRC/domain/node/NodalLoad.cpp
@@ -334,8 +334,9 @@ NodalLoad::applyLoad(Vector& loadFactors) {
 
 const Vector&
 NodalLoad::getData(int& type) {
-  Vector* Empty = new Vector();
-  return *Empty;
+  // Vector* Empty = new Vector();
+  // return *Empty;
+  return *load;
 }
 
 //Adding general function for using NodalThermalAction, L.Jiang [SIF]

--- a/SRC/domain/node/NodalLoad.cpp
+++ b/SRC/domain/node/NodalLoad.cpp
@@ -334,8 +334,6 @@ NodalLoad::applyLoad(Vector& loadFactors) {
 
 const Vector&
 NodalLoad::getData(int& type) {
-  // Vector* Empty = new Vector();
-  // return *Empty;
   return *load;
 }
 

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -289,6 +289,7 @@ int OPS_getEleClassTags();
 int OPS_getEleLoadClassTags();
 int OPS_getEleLoadTags();
 int OPS_getEleLoadData();
+int OPS_getNodeLoadTags();
 // Sensitivity:END /////////////////////////////////////////////
 
 /* OpenSeesMiscCommands.cpp */

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -290,6 +290,7 @@ int OPS_getEleLoadClassTags();
 int OPS_getEleLoadTags();
 int OPS_getEleLoadData();
 int OPS_getNodeLoadTags();
+int OPS_getNodeLoadData();
 // Sensitivity:END /////////////////////////////////////////////
 
 /* OpenSeesMiscCommands.cpp */

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -3575,6 +3575,78 @@ int OPS_getNodeLoadTags()
     return 0;
 }
 
+int OPS_getNodeLoadData()
+{
+    Domain* theDomain = OPS_GetDomain();
+    if (theDomain == 0) return -1;
+
+    int numdata = OPS_GetNumRemainingInputArgs();
+
+	std::vector <double> data;
+
+    if (numdata < 1) {
+	  LoadPattern *thePattern;
+	  LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
+
+	  int typeEL;
+
+	  while ((thePattern = thePatterns()) != 0) {
+		NodalLoadIter &theNodLoads = thePattern->getNodalLoads();
+		NodalLoad* theNodLoad;
+
+		while ((theNodLoad = theNodLoads()) != 0) {
+		  const Vector &nodeLoadData = theNodLoad->getData(typeEL);
+
+		  int nodeLoadDataSize = nodeLoadData.Size();
+		  for (int i = 0; i < nodeLoadDataSize; i++) {
+			data.push_back(nodeLoadData(i));
+		  }
+		}
+	  }
+
+	} else if (numdata == 1) {
+
+	  int patternTag;
+	  if (OPS_GetIntInput(&numdata, &patternTag) < 0) {
+		opserr << "could not read patternTag\n";
+		return -1;
+	  }
+
+	  LoadPattern* thePattern = theDomain->getLoadPattern(patternTag);
+	  if (thePattern == nullptr) {
+		opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getNodeLoadData\n";
+		return -1;
+	  }
+	  NodalLoadIter& theNodLoads = thePattern->getNodalLoads();
+	  NodalLoad* theNodLoad;
+
+	  int typeEL;
+
+	  while ((theNodLoad = theNodLoads()) != 0) {
+		const Vector &nodeLoadData = theNodLoad->getData(typeEL);
+
+		int nodeLoadDataSize = nodeLoadData.Size();
+		for (int i = 0; i < nodeLoadDataSize; i++) {
+		  data.push_back(nodeLoadData(i));
+		}
+	  }
+
+	} else {
+	opserr << "WARNING want - getNodeLoadData <patternTag?>\n";
+	return -1;
+    }
+
+	int size = data.size();
+
+	if (OPS_SetDoubleOutput(&size, data.data(), false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
+
 int OPS_getNumElements()
 {
     Domain* theDomain = OPS_GetDomain();

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -2088,6 +2088,18 @@ static PyObject *Py_ops_getEleLoadData(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getNodeLoadTags(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getNodeLoadTags() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_randomVariable(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2506,6 +2518,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("getEleLoadClassTags", &Py_ops_getEleLoadClassTags);
     addCommand("getEleLoadTags", &Py_ops_getEleLoadTags);
     addCommand("getEleLoadData", &Py_ops_getEleLoadData);
+    addCommand("getNodeLoadTags", &Py_ops_getNodeLoadTags);
     addCommand("randomVariable", &Py_ops_randomVariable);
     addCommand("getRVTags", &Py_ops_getRVTags);
     addCommand("getMean", &Py_ops_getRVMean);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -2100,6 +2100,18 @@ static PyObject *Py_ops_getNodeLoadTags(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getNodeLoadData(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getNodeLoadData() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_randomVariable(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2519,6 +2531,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("getEleLoadTags", &Py_ops_getEleLoadTags);
     addCommand("getEleLoadData", &Py_ops_getEleLoadData);
     addCommand("getNodeLoadTags", &Py_ops_getNodeLoadTags);
+    addCommand("getNodeLoadData", &Py_ops_getNodeLoadData);
     addCommand("randomVariable", &Py_ops_randomVariable);
     addCommand("getRVTags", &Py_ops_getRVTags);
     addCommand("getMean", &Py_ops_getRVMean);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1370,6 +1370,15 @@ static int Tcl_ops_getNodeLoadTags(ClientData clientData, Tcl_Interp *interp, in
     return TCL_OK;
 }
 
+static int Tcl_ops_getNodeLoadData(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getNodeLoadData() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_randomVariable(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
 {
     wrapper->resetCommandLine(argc, 1, argv);
@@ -1721,6 +1730,7 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"getEleLoadTags", &Tcl_ops_getEleLoadTags);
     addCommand(interp,"getEleLoadData", &Tcl_ops_getEleLoadData);
     addCommand(interp,"getNodeLoadTags", &Tcl_ops_getNodeLoadTags);
+    addCommand(interp,"getNodeLoadData", &Tcl_ops_getNodeLoadData);
     addCommand(interp,"randomVariable", &Tcl_ops_randomVariable);
     addCommand(interp,"getRVTags", &Tcl_ops_getRVTags);
     addCommand(interp,"getMean", &Tcl_ops_getRVMean);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -1361,6 +1361,15 @@ static int Tcl_ops_getEleLoadData(ClientData clientData, Tcl_Interp *interp, int
     return TCL_OK;
 }
 
+static int Tcl_ops_getNodeLoadTags(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
+{
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_getNodeLoadTags() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_randomVariable(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv)
 {
     wrapper->resetCommandLine(argc, 1, argv);
@@ -1711,6 +1720,7 @@ TclWrapper::addOpenSeesCommands(Tcl_Interp* interp)
     addCommand(interp,"getEleLoadClassTags", &Tcl_ops_getEleLoadClassTags);
     addCommand(interp,"getEleLoadTags", &Tcl_ops_getEleLoadTags);
     addCommand(interp,"getEleLoadData", &Tcl_ops_getEleLoadData);
+    addCommand(interp,"getNodeLoadTags", &Tcl_ops_getNodeLoadTags);
     addCommand(interp,"randomVariable", &Tcl_ops_randomVariable);
     addCommand(interp,"getRVTags", &Tcl_ops_getRVTags);
     addCommand(interp,"getMean", &Tcl_ops_getRVMean);

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -1038,6 +1038,8 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
     Tcl_CreateCommand(interp, "getNodeLoadTags", &getNodeLoadTags,
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
+    Tcl_CreateCommand(interp, "getNodeLoadData", &getNodeLoadData,
+		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);
 
     Tcl_CreateCommand(interp, "sdfResponse", &sdfResponse, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
@@ -9187,6 +9189,72 @@ getNodeLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **
 	while ((theNodLoad = theNodLoads()) != 0) {
 	  sprintf(buffer, "%d ", theNodLoad->getNodeTag());
 	  Tcl_AppendResult(interp, buffer, NULL);
+	}
+
+  } else {
+    opserr << "WARNING want - getNodeLoadTags <patternTag?>\n" << endln;
+    return TCL_ERROR;
+  }
+
+  return TCL_OK;
+}
+
+int
+getNodeLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+
+  if (argc == 1) {
+	LoadPattern *thePattern;
+	LoadPatternIter &thePatterns = theDomain.getLoadPatterns();
+
+	char buffer[40];
+	int typeEL;
+
+	while ((thePattern = thePatterns()) != 0) {
+	  NodalLoadIter &theNodeLoads = thePattern->getNodalLoads();
+	  NodalLoad *theNodLoad;
+
+	  while ((theNodLoad = theNodeLoads()) != 0) {
+		const Vector &eleLoadData = theNodLoad->getData(typeEL);
+
+		int eleLoadDataSize = eleLoadData.Size();
+		opserr << "eleLoadDataSize: "<< eleLoadDataSize << "\n";
+		for (int i = 0; i < eleLoadDataSize; i++) {
+		  sprintf(buffer, "%35.20f ", eleLoadData(i));
+		  Tcl_AppendResult(interp, buffer, NULL);
+		}
+	  }
+	}
+
+  } else if (argc == 2) {
+	int patternTag;
+
+	if (Tcl_GetInt(interp, argv[1], &patternTag) != TCL_OK) {
+	  opserr << "WARNING getNodeLoadData -- could not read patternTag \n";
+	  return TCL_ERROR;
+	}
+
+	LoadPattern *thePattern = theDomain.getLoadPattern(patternTag);
+    if (thePattern == nullptr) {
+	  opserr << "ERROR load pattern with tag " << patternTag << " not found in domain -- getNodeLoadData\n";
+	  return TCL_ERROR;
+	}
+
+	NodalLoadIter theNodeLoads = thePattern->getNodalLoads();
+	NodalLoad* theNodLoad;
+
+	int typeEL;
+	char buffer[40];
+
+	while ((theNodLoad = theNodeLoads()) != 0) {
+		const Vector &eleLoadData = theNodLoad->getData(typeEL);
+
+		int eleLoadDataSize = eleLoadData.Size();
+		for (int i = 0; i < eleLoadDataSize; i++) {
+		  sprintf(buffer, "%35.20f ", eleLoadData(i));
+		  Tcl_AppendResult(interp, buffer, NULL);
+		}
+
 	}
 
   } else {

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -297,6 +297,9 @@ int
 getEleLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 
+getNodeLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
 startTimer(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -300,6 +300,9 @@ int
 getNodeLoadTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 
+getNodeLoadData(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
 startTimer(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 


### PR DESCRIPTION
This PR adds two output commands `getNodeLoadTags` and `getNodeLoadData` similar to the commands added in https://github.com/OpenSees/OpenSees/pull/575 (already merged in OpenSees)

So far I've been using a `ops.nodeUnbalance(node_tag)` command for getting the nodal loads (used for example in `opsv.plot_supports_and_loads_2d` of the opsvis visualization library), however the `nodeUnbalance` works only after running the `analyze` command. 

A usage example for a 2d frame model would be:

```
...
ts_tag = 1
ops.timeSeries('Constant', ts_tag)

ops.pattern('Plain', 1, ts_tag)
ops.load(1, 1., 2., 3.)
ops.load(2, 4., 5., 6.)

ops.pattern('Plain', 2, ts_tag)
ops.load(3, 7., 8., 9.)

node_load_tags = ops.getNodeLoadTags(1)
print(f'node_load_tags: {node_load_tags}')
node_load_tags_all_patterns = ops.getNodeLoadTags()
print(f'node_load_tags_all_patterns: {node_load_tags_all_patterns}')

node_load_data = ops.getNodeLoadData(1)
print(f'node_load_data: {node_load_data}')
node_load_data_all_patterns = ops.getNodeLoadData()
print(f'node_load_data_all_patterns: {node_load_data_all_patterns}')
```

and the output is:
```
node_load_tags: [1, 2]
node_load_tags_all_patterns: [1, 2, 3]
node_load_data: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
node_load_data_all_patterns: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
```
