### PR TITLE
Adding getNDM and getNDF output commands to OpenSeesPy

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -251,6 +251,7 @@ int OPS_nodeCoord();
 int OPS_setNodeCoord();
 int OPS_updateElementDomain();
 int OPS_eleNodes();
+int OPS_getNDFF();
 int OPS_eleType();
 int OPS_nodeDOFs();
 int OPS_nodeMass();

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -251,6 +251,7 @@ int OPS_nodeCoord();
 int OPS_setNodeCoord();
 int OPS_updateElementDomain();
 int OPS_eleNodes();
+int OPS_getNDMM();
 int OPS_getNDFF();
 int OPS_eleType();
 int OPS_nodeDOFs();

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -1576,6 +1576,50 @@ int OPS_updateElementDomain()
     return 0;
 }
 
+int OPS_getNDFF()
+{
+
+	int ndf;
+    int numdata = 1;
+
+    if (OPS_GetNumRemainingInputArgs() > 1) {
+
+	  int tag;
+
+	  if (OPS_GetIntInput(&numdata, &tag) < 0) {
+		opserr << "WARNING getNDFF nodeTag? \n";
+		return -1;
+	  }
+
+	  Domain* theDomain = OPS_GetDomain();
+	  if (theDomain == 0) return -1;
+	  Node *theNode = theDomain->getNode(tag);
+
+	  if (theNode == 0) {
+		opserr << "WARNING node "<< tag <<" does not exist\n";
+		return -1;
+	  }
+
+	  ndf = theNode->getNumberDOF();
+
+    } else {
+
+	  ndf = OPS_GetNDF();
+	  return -1;
+
+	}
+
+	int size = 1;
+
+	if (OPS_SetIntOutput(&size, &ndf, false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
+
 int OPS_eleType()
 {
     if (OPS_GetNumRemainingInputArgs() < 1) {

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -1576,6 +1576,49 @@ int OPS_updateElementDomain()
     return 0;
 }
 
+int OPS_getNDMM()
+{
+
+	int ndm;
+    int numdata = 1;
+
+    if (OPS_GetNumRemainingInputArgs() > 0) {
+
+	  int tag;
+
+	  if (OPS_GetIntInput(&numdata, &tag) < 0) {
+		opserr << "WARNING getNDM nodeTag? \n";
+		return -1;
+	  }
+
+	  Domain* theDomain = OPS_GetDomain();
+	  if (theDomain == 0) return -1;
+	  Node *theNode = theDomain->getNode(tag);
+
+	  if (theNode == 0) {
+		opserr << "WARNING node "<< tag <<" does not exist\n";
+		return -1;
+	  }
+
+	  const Vector& crds = theNode->getCrds();
+	  ndm = crds.Size();
+
+    } else {
+
+	  ndm = OPS_GetNDM();
+
+	}
+
+	int size = 1;
+
+	if (OPS_SetIntOutput(&size, &ndm, false) < 0) {
+	  opserr << "WARNING failed to set output\n";
+	  return -1;
+	}
+
+    return 0;
+}
+
 int OPS_getNDFF()
 {
 

--- a/SRC/interpreter/OpenSeesOutputCommands.cpp
+++ b/SRC/interpreter/OpenSeesOutputCommands.cpp
@@ -1582,12 +1582,12 @@ int OPS_getNDFF()
 	int ndf;
     int numdata = 1;
 
-    if (OPS_GetNumRemainingInputArgs() > 1) {
+    if (OPS_GetNumRemainingInputArgs() > 0) {
 
 	  int tag;
 
 	  if (OPS_GetIntInput(&numdata, &tag) < 0) {
-		opserr << "WARNING getNDFF nodeTag? \n";
+		opserr << "WARNING getNDF nodeTag? \n";
 		return -1;
 	  }
 
@@ -1605,7 +1605,6 @@ int OPS_getNDFF()
     } else {
 
 	  ndf = OPS_GetNDF();
-	  return -1;
 
 	}
 
@@ -1618,7 +1617,6 @@ int OPS_getNDFF()
 
     return 0;
 }
-
 
 int OPS_eleType()
 {

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1115,6 +1115,18 @@ static PyObject *Py_ops_updateElementDomain(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getNDFF(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getNDFF() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_eleNodes(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2448,6 +2460,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("nodeCoord", &Py_ops_nodeCoord);
     addCommand("setNodeCoord", &Py_ops_setNodeCoord);
     addCommand("updateElementDomain", &Py_ops_updateElementDomain);
+    addCommand("getNDF", &Py_ops_getNDFF);
     addCommand("eleNodes", &Py_ops_eleNodes);
     addCommand("eleType", &Py_ops_eleType);    
     addCommand("nodeDOFs", &Py_ops_nodeDOFs);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1115,6 +1115,18 @@ static PyObject *Py_ops_updateElementDomain(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_getNDMM(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_getNDMM() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_getNDFF(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -2460,6 +2472,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("nodeCoord", &Py_ops_nodeCoord);
     addCommand("setNodeCoord", &Py_ops_setNodeCoord);
     addCommand("updateElementDomain", &Py_ops_updateElementDomain);
+    addCommand("getNDM", &Py_ops_getNDMM);
     addCommand("getNDF", &Py_ops_getNDFF);
     addCommand("eleNodes", &Py_ops_eleNodes);
     addCommand("eleType", &Py_ops_eleType);    

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -7062,7 +7062,7 @@ getNDM(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
     if (argc > 1) {
         int tag;
         if (Tcl_GetInt(interp, argv[1], &tag) != TCL_OK) {
-            opserr << "WARNING ndm nodeTag? \n";
+            opserr << "WARNING getNDM nodeTag? \n";
             return TCL_ERROR;
         }
         Node* theNode = theDomain.getNode(tag);
@@ -7096,7 +7096,7 @@ getNDF(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
     if (argc > 1) {
         int tag;
         if (Tcl_GetInt(interp, argv[1], &tag) != TCL_OK) {
-            opserr << "WARNING ndf nodeTag? \n";
+            opserr << "WARNING getNDF nodeTag? \n";
             return TCL_ERROR;
         }
         Node* theNode = theDomain.getNode(tag);


### PR DESCRIPTION
This PR adds getNDM and getNDF output commands to OpenSeesPy. Similar Tcl commands already exist, added in PR https://github.com/OpenSees/OpenSees/pull/561

Note that due to name conflicts (probably because of the `getNDM` and `getNDF` defined in `OpenSeesCommands.h` and `ElementAPI.h` - I'm not sure) I used the function names `OPS_getNDMM` and `OPS_getNDFF` in `OpenSeesOutputCommands.cpp`, but the actual OpenSeesPy command names are: `getNDM` and `getNDF`.

Anyway I tested them on a 2d frame model.

```
...
ndm = ops.getNDM()
print(f'ndm: {ndm}')
ndm2 = ops.getNDM(2)
print(f'ndm2: {ndm2}')

ndf = ops.getNDF()
print(f'ndf: {ndf}')
ndf2 = ops.getNDF(2)
print(f'ndf2: {ndf2}')
```

and the output is:
```
ndm: [2]
ndm2: [2]
ndf: [3]
ndf2: [3]
```
as expected.