### PR TITLE
Implements getCrdTransfTags

### DIFF
--- a/SRC/coordTransformation/CrdTransf.cpp
+++ b/SRC/coordTransformation/CrdTransf.cpp
@@ -95,7 +95,7 @@ void OPS_printCrdTransf(OPS_Stream &s, int flag) {
 
 ID OPS_getAllCrdTransfTags() {
 
-    ID tags(0);
+    ID allCrdTransfTags(0);
       
     MapOfTaggedObjectsIter theObjects = theCrdTransfObjects.getIter();
     theObjects.reset();
@@ -103,8 +103,10 @@ ID OPS_getAllCrdTransfTags() {
 
     while ((theObject = theObjects()) != 0) {
       CrdTransf *theTransf = (CrdTransf *)theObject;    
-      tags.insert(theTransf->getTag());
+      allCrdTransfTags.insert(theTransf->getTag());
     }
+
+    return allCrdTransfTags;
 }
 
 

--- a/SRC/coordTransformation/CrdTransf.cpp
+++ b/SRC/coordTransformation/CrdTransf.cpp
@@ -32,6 +32,7 @@
 // thus no objects of its type can be instatiated. 
 
 #include <CrdTransf.h>
+#include <ID.h>
 #include <Vector.h>
 
 #include <TaggedObject.h>
@@ -91,6 +92,21 @@ void OPS_printCrdTransf(OPS_Stream &s, int flag) {
     s << "\n\t\t]";
   }
 }
+
+ID OPS_getAllCrdTransfTags() {
+
+    ID tags(0);
+      
+    MapOfTaggedObjectsIter theObjects = theCrdTransfObjects.getIter();
+    theObjects.reset();
+    TaggedObject *theObject;
+
+    while ((theObject = theObjects()) != 0) {
+      CrdTransf *theTransf = (CrdTransf *)theObject;    
+      tags.insert(theTransf->getTag());
+    }
+}
+
 
 
 // constructor:

--- a/SRC/coordTransformation/CrdTransf.h
+++ b/SRC/coordTransformation/CrdTransf.h
@@ -41,6 +41,7 @@
 #include <TaggedObject.h>
 
 class Vector;
+class ID;
 class Matrix;
 class Node;
 class Response;
@@ -113,5 +114,6 @@ extern CrdTransf *OPS_getCrdTransf(int tag);
 extern bool       OPS_removeCrdTransf(int tag);
 extern void       OPS_clearAllCrdTransf(void);
 extern void       OPS_printCrdTransf(OPS_Stream &s, int flag=0);
+extern ID       OPS_getAllCrdTransfTags();
 
 #endif

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -199,6 +199,9 @@ extern "C" int         OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp
 //  recorders
 #include <Recorder.h> //SAJalali
 
+// transformations
+#include <CrdTransf.h>
+
 extern void *OPS_NewtonRaphsonAlgorithm(void);
 extern void *OPS_ExpressNewton(void);
 extern void *OPS_ModifiedNewton(void);
@@ -1008,6 +1011,8 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
     Tcl_CreateCommand(interp, "getNodeTags", &getNodeTags, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
+    Tcl_CreateCommand(interp, "getCrdTransfTags", &getCrdTransfTags, 
+          (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL); 
     Tcl_CreateCommand(interp, "getParamTags", &getParamTags, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);  
     Tcl_CreateCommand(interp, "getParamValue", &getParamValue, 
@@ -9291,6 +9296,22 @@ getNodeTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv
 
   while ((theEle = eleIter()) != 0) {
     sprintf(buffer, "%d ", theEle->getTag());
+    Tcl_AppendResult(interp, buffer, NULL);
+  }
+
+  return TCL_OK;
+}
+
+int
+getCrdTransfTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
+{
+  ID crdTransfTags = OPS_getAllCrdTransfTags();  // Function defined in CrdTransf.h
+
+  char buffer[20];
+
+  for (int i = 0; i < crdTransfTags.Size(); ++i)
+  {
+    sprintf(buffer, "%d ", crdTransfTags(i));
     Tcl_AppendResult(interp, buffer, NULL);
   }
 

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -212,6 +212,9 @@ int
 getNodeTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int 
+getCrdTransfTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
+
+int 
 getEleTags(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);
 
 int


### PR DESCRIPTION
This adds a new `getCrdTransfTags` TCL command to retrieve all the defined coordinate transformation tags as requested by user @BijanSeif.

Example,

```
model BasicBuilder -ndm 3 -ndf 6

geomTransf Linear 1        0                -1               0                -jntOffset 100              0                0                -0               -0               -0              
geomTransf Linear 2        0                -1               0                -jntOffset 0                0                0                -0               -0               -0              
geomTransf Linear 3        0                -1               0                -jntOffset 0                0                0                -0               -0               -0              
geomTransf Linear 4        0                -1               0                -jntOffset 0                0                0                -0               -0               -0              
geomTransf Linear 5        0                -1               0                -jntOffset 0                0                0                -0               -0               -0              

set tags [getCrdTransfTags]

puts $tags
```

produces:

```

         OpenSees -- Open System For Earthquake Engineering Simulation
                 Pacific Earthquake Engineering Research Center
                        Version 3.3.0 64-Bit

      (c) Copyright 1999-2016 The Regents of the University of California
                              All Rights Reserved
  (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)


1 2 3 4 5 
```