### PR TITLE
bugfix setResponse method in SectionAggregator

### DIFF
--- a/SRC/material/section/SectionAggregator.cpp
+++ b/SRC/material/section/SectionAggregator.cpp
@@ -966,7 +966,7 @@ SectionAggregator::setResponse(const char **argv, int argc, OPS_Stream &output)
 	theResponse = theAdditions[i]->setResponse(&argv[2], argc-2, output);
   }
 
-  if (argc > 1 && strcmp(argv[0],"section") == 0)
+  if ((argc > 1) && (strcmp(argv[0],"section") == 0) && (theSection))
     theResponse = theSection->setResponse(&argv[1], argc-1, output);
 
   if (theResponse == 0)


### PR DESCRIPTION
@fmckenna @mhscott 

This PR

1. Fixes a bug in the setResponse method of the SectionAggregator which can result in a segmentation fault if one asks for "section" output when the sections inside the Aggregator is NULL.
2. Due to a recent clean-up in the SectionAggregator, if one wants to ask for the fiberSection response inside the aggregator, should use "_section $sec_tag **section** fiber $fiber_tag stress_" instead of "_section $sec_tag fiber $fiber_tag stress_". The MPCORecorder has been updated accordingly