### PR TITLE
Adding HarmonicSteadyState integrator

### DIFF
--- a/DEVELOPER/core/classTags.h
+++ b/DEVELOPER/core/classTags.h
@@ -910,6 +910,9 @@
 #define INTEGRATOR_TAGS_ExplicitDifference              55
 #define INTEGRATOR_TAGS_EQPath                          56
 #define INTEGRATOR_TAGS_GimmeMCK                        57
+#define INTEGRATOR_TAGS_StagedLoadControl               58
+#define INTEGRATOR_TAGS_StagedNewmark                   59
+#define INTEGRATOR_TAGS_HarmonicSteadyState             60
 
 #define LinSOE_TAGS_FullGenLinSOE		1
 #define LinSOE_TAGS_BandGenLinSOE		2

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -1330,6 +1330,7 @@ ANALYSIS_LIBS = $(FE)/analysis/analysis/Analysis.o \
 	$(FE)/analysis/integrator/IncrementalIntegrator.o \
 	$(FE)/analysis/integrator/StaticIntegrator.o \
 	$(FE)/analysis/integrator/LoadControl.o \
+	$(FE)/analysis/integrator/HarmonicSteadyState.o \
 	$(FE)/analysis/integrator/StagedLoadControl.o \
 	$(FE)/analysis/integrator/StagedNewmark.o \
 	$(FE)/analysis/integrator/EQPath.o \

--- a/SRC/analysis/integrator/CMakeLists.txt
+++ b/SRC/analysis/integrator/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(OPS_Analysis
        IncrementalIntegrator.cpp
        Integrator.cpp
        LoadControl.cpp
+       HarmonicSteadyState.cpp
        LoadPath.cpp
        MinUnbalDispNorm.cpp
        Newmark.cpp
@@ -30,6 +31,7 @@ target_sources(OPS_Analysis
        IncrementalIntegrator.h
        Integrator.h
        LoadControl.h
+       HarmonicSteadyState.h
        LoadPath.h
        MinUnbalDispNorm.h
        Newmark.h

--- a/SRC/analysis/integrator/HarmonicSteadyState.cpp
+++ b/SRC/analysis/integrator/HarmonicSteadyState.cpp
@@ -1,0 +1,465 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.6 $
+// $Date: 2007-04-02 23:42:26 $
+// $Source: /usr/local/cvs/OpenSees/SRC/analysis/integrator/HarmonicSteadyState.cpp,v $
+
+
+//
+// Written: fmk
+// Created: 07/98
+// Revision: A
+//
+// Description: This file contains the class definition for HarmonicSteadyState.
+// HarmonicSteadyState is an algorithmic class for performing a static analysis
+// using a load control integration scheme.
+//
+// What: "@(#) HarmonicSteadyState.h, revA"
+
+#include "HarmonicSteadyState.h"
+#include <AnalysisModel.h>
+#include <LinearSOE.h>
+#include <Vector.h>
+#include <Channel.h>
+#include <FE_Element.h>
+#include <FE_EleIter.h>
+#include <Node.h>
+#include <DOF_Group.h>
+#include <DOF_GrpIter.h>
+#include <LoadPattern.h>
+#include <LoadPatternIter.h>
+#include <Domain.h>
+#include<Parameter.h>
+#include<ParameterIter.h>
+#include<EquiSolnAlgo.h>
+#include <elementAPI.h>
+#include <iostream>
+
+void* OPS_HarmonicSteadyState()
+{
+    if(OPS_GetNumRemainingInputArgs() < 1) {
+	opserr<<"insufficient arguments\n";
+	return 0;
+    }
+
+    double lambda;
+    int numData = 1;
+    if(OPS_GetDoubleInput(&numData,&lambda) < 0) {
+	opserr<<"WARNING failed to read double lambda\n";
+	return 0;
+    }
+
+    int numIter = 1;
+    double mLambda[2] = {lambda,lambda};
+	double prads = 0;
+    if(OPS_GetNumRemainingInputArgs() > 2) {
+	if(OPS_GetIntInput(&numData,&numIter) < 0) {
+	    opserr<<"WARNING failed to read int numIter\n";
+	    return 0;
+	}
+	numData = 2;
+	if(OPS_GetDoubleInput(&numData,&mLambda[0]) < 0) {
+	    opserr<<"WARNING failed to read double min and max\n";
+	    return 0;
+	}
+	numData = 1;
+	// numData = 3; // sewi ??
+	if(OPS_GetDoubleInput(&numData,&prads) < 0) {
+	    opserr<<"WARNING failed to read double min and max\n";
+	    return 0;
+	}
+    }
+
+    return new HarmonicSteadyState(lambda,numIter,mLambda[0],mLambda[1],prads);
+}
+
+HarmonicSteadyState::HarmonicSteadyState(double dLambda, int numIncr, double min, double max, double prads,  int classtag)
+    : StaticIntegrator(classtag),
+ deltaLambda(dLambda),
+ specNumIncrStep(numIncr), numIncrLastStep(numIncr),
+	  dLambdaMin(min), dLambdaMax(max), loadCircFreq(prads), gradNumber(0), sensitivityFlag(0)
+{
+  // to avoid divide-by-zero error on first update() ensure numIncr != 0
+  if (numIncr == 0) {
+    opserr << "WARNING HarmonicSteadyState::HarmonicSteadyState() - numIncr set to 0, 1 assumed\n";
+    specNumIncrStep = 1.0;
+    numIncrLastStep = 1.0;
+  }
+}
+
+
+HarmonicSteadyState::~HarmonicSteadyState()
+{
+
+}
+
+int
+HarmonicSteadyState::newStep(void)
+{
+    AnalysisModel *theModel = this->getAnalysisModel();
+    if (theModel == 0) {
+	opserr << "HarmonicSteadyState::newStep() - no associated AnalysisModel\n";
+	return -1;
+    }
+
+    // determine delta lambda for this step based on dLambda and #iter of last step
+    double factor = specNumIncrStep/numIncrLastStep;
+    deltaLambda *=factor;
+
+    if (deltaLambda < dLambdaMin)
+      deltaLambda = dLambdaMin;
+    else if (deltaLambda > dLambdaMax)
+      deltaLambda = dLambdaMax;
+
+    double currentLambda = theModel->getCurrentDomainTime();
+
+    currentLambda += deltaLambda;
+    theModel->applyLoadDomain(currentLambda);
+
+    numIncrLastStep = 0;
+
+     return 0;
+}
+
+int
+HarmonicSteadyState::update(const Vector &deltaU)
+{
+    AnalysisModel *myModel = this->getAnalysisModel();
+    LinearSOE *theSOE = this->getLinearSOE();
+    if (myModel == 0 || theSOE == 0) {
+	opserr << "WARNING HarmonicSteadyState::update() ";
+	opserr << "No AnalysisModel or LinearSOE has been set\n";
+	return -1;
+    }
+
+    myModel->incrDisp(deltaU);
+    if (myModel->updateDomain() < 0) {
+      opserr << "HarmonicSteadyState::update - model failed to update for new dU\n";
+      return -1;
+    }
+
+    // Set deltaU for the convergence test
+    theSOE->setX(deltaU);
+
+    numIncrLastStep++;
+
+    return 0;
+}
+
+
+int
+HarmonicSteadyState::setDeltaLambda(double newValue)
+{
+  // we set the #incr at last step = #incr so get newValue incr
+  numIncrLastStep = specNumIncrStep;
+  deltaLambda = newValue;
+  return 0;
+}
+
+
+int
+HarmonicSteadyState::sendSelf(int cTag,
+		      Channel &theChannel)
+{
+  // Vector data(5);
+  Vector data(6); // sewi
+  data(0) = deltaLambda;
+  data(1) = specNumIncrStep;
+  data(2) = numIncrLastStep;
+  data(3) = dLambdaMin;
+  data(4) = dLambdaMax;
+  data(5) = loadCircFreq;
+  if (theChannel.sendVector(this->getDbTag(), cTag, data) < 0) {
+      opserr << "HarmonicSteadyState::sendSelf() - failed to send the Vector\n";
+      return -1;
+  }
+  return 0;
+}
+
+
+int
+HarmonicSteadyState::recvSelf(int cTag,
+		      Channel &theChannel, FEM_ObjectBroker &theBroker)
+{
+  // Vector data(5);
+  Vector data(6); // sewi
+  if (theChannel.recvVector(this->getDbTag(), cTag, data) < 0) {
+      opserr << "HarmonicSteadyState::sendSelf() - failed to send the Vector\n";
+      deltaLambda = 0;
+      return -1;
+  }
+  deltaLambda = data(0);
+  specNumIncrStep = data(1);
+  numIncrLastStep = data(2);
+  dLambdaMin = data(3);
+  dLambdaMax = data(4);
+  loadCircFreq = data(5);
+  return 0;
+}
+
+
+
+void
+HarmonicSteadyState::Print(OPS_Stream &s, int flag)
+{
+     AnalysisModel *theModel = this->getAnalysisModel();
+    if (theModel != 0) {
+	double currentLambda = theModel->getCurrentDomainTime();
+	s << "\t HarmonicSteadyState - currentLambda: " << currentLambda;
+	s << "  deltaLambda: " << deltaLambda << endln;
+	s << "  loadCircFreq: " << loadCircFreq << " rad/s" << endln;
+    } else
+	s << "\t HarmonicSteadyState - no associated AnalysisModel\n";
+
+}
+
+int
+HarmonicSteadyState::formEleTangent(FE_Element *theEle)
+{
+    theEle->zeroTangent();
+    theEle->addKtToTang();
+	theEle->addMtoTang(-loadCircFreq*loadCircFreq);
+    return 0;
+}
+
+
+int
+HarmonicSteadyState::formEleResidual(FE_Element* theEle)
+{
+    if(sensitivityFlag == 0) {  // no sensitivity
+	this->StaticIntegrator::formEleResidual(theEle);
+    } else {
+	theEle->zeroResidual();
+	theEle->addResistingForceSensitivity(gradNumber);
+    }
+    return 0;
+}
+
+int
+HarmonicSteadyState::formIndependentSensitivityRHS()
+{
+    return 0;
+}
+
+int
+HarmonicSteadyState::formSensitivityRHS(int passedGradNumber)
+{
+    sensitivityFlag = 1;
+
+    // Set a couple of data members
+    gradNumber = passedGradNumber;
+
+    // get model
+    AnalysisModel* theAnalysisModel = this->getAnalysisModel();
+    LinearSOE* theSOE = this->getLinearSOE();
+
+    // Loop through elements
+    FE_Element *elePtr;
+    FE_EleIter &theEles = theAnalysisModel->getFEs();
+    while((elePtr = theEles()) != 0) {
+      theSOE->addB(  elePtr->getResidual(this),  elePtr->getID()  );
+    }
+
+    // Loop through the loadPatterns and add the dPext/dh contributions
+    static Vector oneDimVectorWithOne(1);
+    oneDimVectorWithOne(0) = 1.0;
+    static ID oneDimID(1);
+
+    Node *aNode;
+    DOF_Group *aDofGroup;
+    int nodeNumber, dofNumber, relevantID, i, sizeRandomLoads, numRandomLoads;
+    LoadPattern *loadPatternPtr;
+
+    Domain *theDomain = theAnalysisModel->getDomainPtr();
+    LoadPatternIter &thePatterns = theDomain->getLoadPatterns();
+    while((loadPatternPtr = thePatterns()) != 0) {
+	const Vector &randomLoads = loadPatternPtr->getExternalForceSensitivity(gradNumber);
+	sizeRandomLoads = randomLoads.Size();
+	if (sizeRandomLoads == 1) {
+	    // No random loads in this load pattern
+	}
+	else {
+	    // Random loads: add contributions to the 'B' vector
+	    numRandomLoads = (int)(sizeRandomLoads/2);
+	    for (i=0; i<numRandomLoads*2; i=i+2) {
+		nodeNumber = (int)randomLoads(i);
+		dofNumber = (int)randomLoads(i+1);
+		aNode = theDomain->getNode(nodeNumber);
+		aDofGroup = aNode->getDOF_GroupPtr();
+		const ID &anID = aDofGroup->getID();
+		relevantID = anID(dofNumber-1);
+		oneDimID(0) = relevantID;
+		theSOE->addB(oneDimVectorWithOne, oneDimID);
+	    }
+	}
+    }
+
+    // reset sensitivity flag
+    sensitivityFlag = 0;
+
+    return 0;
+}
+
+int
+HarmonicSteadyState::saveSensitivity(const Vector &v, int gradNum, int numGrads)
+{
+    // get model
+    AnalysisModel* theAnalysisModel = this->getAnalysisModel();
+
+    DOF_GrpIter &theDOFGrps = theAnalysisModel->getDOFs();
+    DOF_Group 	*dofPtr;
+
+    while ( (dofPtr = theDOFGrps() ) != 0)  {
+//	dofPtr->saveSensitivity(v,0,0,gradNum,numGrads);
+	dofPtr->saveDispSensitivity(v,gradNum,numGrads);
+
+    }
+
+    return 0;
+}
+
+int
+HarmonicSteadyState::commitSensitivity(int gradNum, int numGrads)
+{
+      // get model
+    AnalysisModel* theAnalysisModel = this->getAnalysisModel();
+
+    // Loop through the FE_Elements and set unconditional sensitivities
+    FE_Element *elePtr;
+    FE_EleIter &theEles = theAnalysisModel->getFEs();
+    while((elePtr = theEles()) != 0) {
+	elePtr->commitSensitivity(gradNum, numGrads);
+    }
+
+    return 0;
+}
+
+
+
+// false for LC and true for DC
+   bool
+HarmonicSteadyState::computeSensitivityAtEachIteration()
+{
+
+return false;
+}
+
+
+
+
+
+int
+HarmonicSteadyState::computeSensitivities(void)
+{
+//  opserr<<" computeSensitivity::start"<<endln;
+    LinearSOE *theSOE = this->getLinearSOE();
+
+    /*
+  if (theAlgorithm == 0) {
+    opserr << "ERROR the FE algorithm must be defined before ";
+    opserr << "the sensitivity algorithm\n";
+    return -1;
+  }
+*/
+/*
+   // Get pointer to the system of equations (SOE)
+	LinearSOE *theSOE = theAlgorithm->getLinearSOEptr();
+	if (theSOE == 0) {
+	  opserr << "ERROR the FE linearSOE must be defined before ";
+	  opserr << "the sensitivity algorithm\n";
+	  return -1;
+	}
+
+	// Get pointer to incremental integrator
+	IncrementalIntegrator *theIncInt = theAlgorithm->getIncrementalIntegratorPtr();
+//	IncrementalIntegrator *theIncIntSens=theAlgorithm->getIncrementalIntegratorPtr();//Abbas
+	if (theIncInt == 0 ) {
+	  opserr << "ERROR the FE integrator must be defined before ";
+	  opserr << "the sensitivity algorithm\n";
+	  return -1;
+	}
+
+	// Form current tangent at converged state
+	// (would be nice with an if-statement here in case
+	// the current tangent is already formed)
+	if (this->formTangent(CURRENT_TANGENT) < 0){
+		opserr << "WARNING SensitivityAlgorithm::computeGradients() -";
+		opserr << "the Integrator failed in formTangent()\n";
+		return -1;
+	}
+	*/
+	// Zero out the old right-hand side of the SOE
+	theSOE->zeroB();
+
+
+	if (this == 0) {
+	  opserr << "ERROR SensitivityAlgorithm::computeSensitivities() -";
+	  opserr << "the SensitivityIntegrator is NULL\n";
+	  return -1;
+	}
+
+	// Form the part of the RHS which are indepent of parameter
+	this->formIndependentSensitivityRHS();
+	AnalysisModel *theModel = this->getAnalysisModel();
+	Domain *theDomain=theModel->getDomainPtr();
+	ParameterIter &paramIter = theDomain->getParameters();
+
+	Parameter *theParam;
+	// De-activate all parameters
+	while ((theParam = paramIter()) != 0)
+	  theParam->activate(false);
+
+	// Now, compute sensitivity wrt each parameter
+	int numGrads = theDomain->getNumParameters();
+	paramIter = theDomain->getParameters();
+
+	while ((theParam = paramIter()) != 0) {
+
+	  // Activate this parameter
+	  theParam->activate(true);
+
+	  // Zero the RHS vector
+	  theSOE->zeroB();
+
+	  // Get the grad index for this parameter
+	  int gradIndex = theParam->getGradIndex();
+
+	  // Form the RHS
+	  this->formSensitivityRHS(gradIndex);
+
+	  // Solve for displacement sensitivity
+
+	  theSOE->solve();
+	  // Save sensitivity to nodes
+	  this->saveSensitivity( theSOE->getX(), gradIndex, numGrads );
+
+
+
+	  // Commit unconditional history variables (also for elastic problems; strain sens may be needed anyway)
+	  this->commitSensitivity(gradIndex, numGrads);
+
+	  // De-activate this parameter for next sensitivity calc
+	  theParam->activate(false);
+	//  opserr<<"HarmonicSteadyState::..........ComputeSensitivities. end"<<endln;
+	}
+
+	return 0;
+}

--- a/SRC/analysis/integrator/HarmonicSteadyState.cpp
+++ b/SRC/analysis/integrator/HarmonicSteadyState.cpp
@@ -18,21 +18,15 @@
 **                                                                    **
 ** ****************************************************************** */
 
-// $Revision: 1.6 $
-// $Date: 2007-04-02 23:42:26 $
-// $Source: /usr/local/cvs/OpenSees/SRC/analysis/integrator/HarmonicSteadyState.cpp,v $
-
-
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: 2021
 //
-// Written: fmk
-// Created: 07/98
-// Revision: A
+// based on LoadControl.cpp
+// written: fmk
 //
 // Description: This file contains the class definition for HarmonicSteadyState.
-// HarmonicSteadyState is an algorithmic class for performing a static analysis
-// using a load control integration scheme.
-//
-// What: "@(#) HarmonicSteadyState.h, revA"
+// HarmonicSteadyState is an algorithmic class for performing a quasi-static harmonic
+// steady-state analysis.
 
 #include "HarmonicSteadyState.h"
 #include <AnalysisModel.h>

--- a/SRC/analysis/integrator/HarmonicSteadyState.h
+++ b/SRC/analysis/integrator/HarmonicSteadyState.h
@@ -19,24 +19,18 @@
 **                                                                    **
 ** ****************************************************************** */
 
-// $Revision: 1.2 $
-// $Date: 2003-02-14 23:00:48 $
-// $Source: /usr/local/cvs/OpenSees/SRC/analysis/integrator/HarmonicSteadyState.h,v $
-
 #ifndef HARMONICSTEADYSTATE_H
 #define HARMONICSTEADYSTATE_H
 
-// File: ~/analysis/integrator/HarmonicSteadyState.h
+// Written: Seweryn Kokot, Opole University of Technology, Poland
+// Created: 2021
 //
-// Written: fmk
-// Created: 07/98
-// Revision: A
+// based on LoadControl.cpp
+// written: fmk
 //
 // Description: This file contains the class definition for HarmonicSteadyState.
-// HarmonicSteadyState is an algorithmic class for performing a static analysis
-// using a load control integration scheme.
-//
-// What: "@(#) HarmonicSteadyState.h, revA"
+// HarmonicSteadyState is an algorithmic class for performing a quasi-static harmonic
+// steady-state analysis.
 
 #include "StaticIntegrator.h"
 #include <classTags.h>

--- a/SRC/analysis/integrator/HarmonicSteadyState.h
+++ b/SRC/analysis/integrator/HarmonicSteadyState.h
@@ -45,7 +45,7 @@ class ReliabilityDomain;
 class HarmonicSteadyState : public StaticIntegrator
 {
   public:
-    HarmonicSteadyState(double deltaLambda, double loadCircFreq, int numIncr,
+    HarmonicSteadyState(double deltaLambda, double loadPeriod, int numIncr,
 			   double minLambda, double maxlambda,
 			   int classtag=INTEGRATOR_TAGS_HarmonicSteadyState);
 
@@ -80,7 +80,7 @@ protected:
 
   private:
     double deltaLambda;  // dlambda at step (i-1)
-    double loadCircFreq; // excitation circular frequency (p) in rad/s
+    double loadPeriod; // load period in seconds (p = 2pi/T)
 
     double specNumIncrStep, numIncrLastStep; // Jd & J(i-1)
     double dLambdaMin, dLambdaMax; // min & max values for dlambda at step (i)

--- a/SRC/analysis/integrator/HarmonicSteadyState.h
+++ b/SRC/analysis/integrator/HarmonicSteadyState.h
@@ -45,8 +45,8 @@ class ReliabilityDomain;
 class HarmonicSteadyState : public StaticIntegrator
 {
   public:
-    HarmonicSteadyState(double deltaLambda, int numIncr,
-			   double minLambda, double maxlambda, double loadCircFreq,
+    HarmonicSteadyState(double deltaLambda, double loadCircFreq, int numIncr,
+			   double minLambda, double maxlambda,
 			   int classtag=INTEGRATOR_TAGS_HarmonicSteadyState);
 
     ~HarmonicSteadyState();
@@ -80,10 +80,10 @@ protected:
 
   private:
     double deltaLambda;  // dlambda at step (i-1)
+    double loadCircFreq; // excitation circular frequency (p) in rad/s
 
     double specNumIncrStep, numIncrLastStep; // Jd & J(i-1)
     double dLambdaMin, dLambdaMax; // min & max values for dlambda at step (i)
-    double loadCircFreq; // excitation circular frequency (p) in rad/s
 
     // Adding sensitivity
     int gradNumber;

--- a/SRC/analysis/integrator/HarmonicSteadyState.h
+++ b/SRC/analysis/integrator/HarmonicSteadyState.h
@@ -1,0 +1,102 @@
+
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.2 $
+// $Date: 2003-02-14 23:00:48 $
+// $Source: /usr/local/cvs/OpenSees/SRC/analysis/integrator/HarmonicSteadyState.h,v $
+
+#ifndef HARMONICSTEADYSTATE_H
+#define HARMONICSTEADYSTATE_H
+
+// File: ~/analysis/integrator/HarmonicSteadyState.h
+//
+// Written: fmk
+// Created: 07/98
+// Revision: A
+//
+// Description: This file contains the class definition for HarmonicSteadyState.
+// HarmonicSteadyState is an algorithmic class for performing a static analysis
+// using a load control integration scheme.
+//
+// What: "@(#) HarmonicSteadyState.h, revA"
+
+#include "StaticIntegrator.h"
+#include <classTags.h>
+
+class LinearSOE;
+class AnalysisModel;
+class FE_Element;
+class Vector;
+class EquiSolnAlgo;
+class ReliabilityDomain;
+
+class HarmonicSteadyState : public StaticIntegrator
+{
+  public:
+    HarmonicSteadyState(double deltaLambda, int numIncr,
+			   double minLambda, double maxlambda, double loadCircFreq,
+			   int classtag=INTEGRATOR_TAGS_HarmonicSteadyState);
+
+    ~HarmonicSteadyState();
+
+    int newStep(void);
+    int update(const Vector &deltaU);
+    int setDeltaLambda(double newDeltaLambda);
+
+    // Public methods for Output
+    int sendSelf(int commitTag, Channel &theChannel);
+    int recvSelf(int commitTag, Channel &theChannel,
+			 FEM_ObjectBroker &theBroker);
+
+    void Print(OPS_Stream &s, int flag =0);
+
+    int formEleTangent(FE_Element *theEle);
+    int formEleResidual(FE_Element *theEle);
+
+    // Adding sensitivity
+    int formSensitivityRHS(int gradNum);
+    int formIndependentSensitivityRHS();
+    int saveSensitivity(const Vector &v, int gradNum, int numGrads);
+    int commitSensitivity(int gradNum, int numGrads);
+    int computeSensitivities(void);//Abbas
+    bool computeSensitivityAtEachIteration();
+
+
+    ///////////////////////
+
+protected:
+
+  private:
+    double deltaLambda;  // dlambda at step (i-1)
+
+    double specNumIncrStep, numIncrLastStep; // Jd & J(i-1)
+    double dLambdaMin, dLambdaMax; // min & max values for dlambda at step (i)
+    double loadCircFreq; // excitation circular frequency (p) in rad/s
+
+    // Adding sensitivity
+    int gradNumber;
+    int sensitivityFlag;
+   // EquiSolnAlgo *theAlgorithm;
+    ReliabilityDomain *theDomain;
+    ////////////////////
+};
+
+#endif

--- a/SRC/analysis/integrator/Makefile
+++ b/SRC/analysis/integrator/Makefile
@@ -60,7 +60,8 @@ OBJS       = AlphaOS.o \
 	TRBDF2.o \
     TRBDF3.o \
 	WilsonTheta.o \
-	GimmeMCK.o 
+	GimmeMCK.o \
+	HarmonicSteadyState.o
 
 all:         $(OBJS)
 

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -996,6 +996,7 @@
 #define INTEGRATOR_TAGS_GimmeMCK       	                57
 #define INTEGRATOR_TAGS_StagedLoadControl               58
 #define INTEGRATOR_TAGS_StagedNewmark                   59
+#define INTEGRATOR_TAGS_HarmonicSteadyState             60
 
 
 #define LinSOE_TAGS_FullGenLinSOE		1

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -70,6 +70,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <TransformationConstraintHandler.h>
 #include <Newmark.h>
 #include <GimmeMCK.h>
+#include <HarmonicSteadyState.h>
 #include <ProfileSPDLinSolver.h>
 #include <ProfileSPDLinDirectSolver.h>
 #include <ProfileSPDLinSOE.h>
@@ -1438,6 +1439,9 @@ int OPS_Integrator()
 
     } else if (strcmp(type,"MinUnbalDispNorm") == 0) {
 	si = (StaticIntegrator*)OPS_MinUnbalDispNorm();
+
+    } else if (strcmp(type,"HarmonicSteadyState") == 0 || strcmp(type,"HarmonicSteadyState") == 0) {
+	si = (StaticIntegrator*)OPS_HarmonicSteadyState();
 
     } else if (strcmp(type,"Newmark") == 0) {
 	ti = (TransientIntegrator*)OPS_Newmark();

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -1440,7 +1440,7 @@ int OPS_Integrator()
     } else if (strcmp(type,"MinUnbalDispNorm") == 0) {
 	si = (StaticIntegrator*)OPS_MinUnbalDispNorm();
 
-    } else if (strcmp(type,"HarmonicSteadyState") == 0 || strcmp(type,"HarmonicSteadyState") == 0) {
+    } else if (strcmp(type,"HarmonicSteadyState") == 0 || strcmp(type,"HarmonicSS") == 0) {
 	si = (StaticIntegrator*)OPS_HarmonicSteadyState();
 
     } else if (strcmp(type,"Newmark") == 0) {

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -456,6 +456,7 @@ void* OPS_LoadControlIntegrator();
 void* OPS_DisplacementControlIntegrator();
 void* OPS_Newmark();
 void* OPS_GimmeMCK();
+void* OPS_HarmonicSteadyState();
 void* OPS_ArcLength();
 void* OPS_ArcLength1();
 void* OPS_HSConstraint();

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -4472,7 +4472,7 @@ specifyIntegrator(ClientData clientData, Tcl_Interp *interp, int argc,
         theStaticAnalysis->setIntegrator(*theStaticIntegrator);
       }
 
-  else if (strcmp(argv[1],"HarmonicSteadyState") == 0 || strcmp(argv[1],"HarmonicSteadyState") == 0) {
+  else if (strcmp(argv[1],"HarmonicSteadyState") == 0 || strcmp(argv[1],"HarmonicSS") == 0) {
     theStaticIntegrator = (StaticIntegrator*)OPS_HarmonicSteadyState();
    }
 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -183,6 +183,7 @@ extern "C" int         OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp
 #include <DOF_Numberer.h>
 
 // integrators
+// #include <HarmonicSteadyState.h>
 #include <LoadControl.h>
 #include <StagedLoadControl.h>
 #include <ArcLength.h>
@@ -210,6 +211,7 @@ extern void *OPS_NewtonHallM(void);
 extern void *OPS_Newmark(void);
 extern void *OPS_StagedNewmark(void);
 extern void *OPS_GimmeMCK(void);
+extern void *OPS_HarmonicSteadyState(void);
 extern void *OPS_AlphaOS(void);
 extern void *OPS_AlphaOS_TP(void);
 extern void *OPS_AlphaOSGeneralized(void);
@@ -4469,7 +4471,11 @@ specifyIntegrator(ClientData clientData, Tcl_Interp *interp, int argc,
       if (theStaticAnalysis != 0)
         theStaticAnalysis->setIntegrator(*theStaticIntegrator);
       }
-  
+
+  else if (strcmp(argv[1],"HarmonicSteadyState") == 0 || strcmp(argv[1],"HarmonicSteadyState") == 0) {
+    theStaticIntegrator = (StaticIntegrator*)OPS_HarmonicSteadyState();
+   }
+
   else if (strcmp(argv[1],"ArcLength") == 0) {
       double arcLength;
       double alpha;


### PR DESCRIPTION
This PR implements the harmonic steady-state integrator as discussed in https://github.com/OpenSees/OpenSees/issues/498

The implementation is based on the LoadControl integration as a subclass of the StaticIntegrator, therfore the actual syntax of the 'HarmonicSteadyState' or 'HarmonicSS' is similar to the LoadControl integrator:

```
...
f = 148  # Hz
p = 2 * np.pi * f  # rad/s
# ops.integrator('LoadControl', 1.0)
ops.integrator('HarmonicSteadyState', 1.0, p)
```

where 'p' is the circular frequency in rad/s of the harmonic load F(t) = F0 * sin(p*t).

The following equation of motion
`
M a(t) + K u(t) = F0 * sin(p * t)`

is solved as a quasi-static problem

`(K - p^2 M) u0 = F0` or simply written as
`Kmod * u = F0` (as in statics `Ku = F`)

The F0 amplitude load distribution can be taken from the
loadPattern/load/eleLoad commands.