### PR TITLE
Fixing the setResponse method in the NDMaterial base class

### DIFF
--- a/SRC/material/nD/NDMaterial.cpp
+++ b/SRC/material/nD/NDMaterial.cpp
@@ -300,12 +300,15 @@ NDMaterial::setResponse (const char **argv, int argc, OPS_Stream &output)
 	  const Matrix &res = this->getTangent();
 	  theResponse = new MaterialResponse(this, 4, this->getTangent());
   }
+
+  // Massimo Petracca - 28/12/2021:
+  // this should be handled by the PlaneStressUserMaterial... not here!
   //default damage output - added by V.K. Papanikolaou [AUTh] - start
-  else if (strcmp(argv[0], "Damage") == 0 || strcmp(argv[0], "damage") == 0) {
-      static Vector vec = Vector(3);
-      for (int i = 0; i < 3; i++) vec[i] = 0;
-      theResponse = new MaterialResponse(this, 5, vec);  // zero vector
-  }
+  //else if (strcmp(argv[0], "Damage") == 0 || strcmp(argv[0], "damage") == 0) {
+  //    static Vector vec = Vector(3);
+  //    for (int i = 0; i < 3; i++) vec[i] = 0;
+  //    theResponse = new MaterialResponse(this, 5, vec);  // zero vector
+  //}
   //default damage output - added by V.K. Papanikolaou [AUTh] - end 
 
   output.endTag(); // NdMaterialOutput
@@ -323,6 +326,12 @@ NDMaterial::getResponse (int responseID, Information &matInfo)
   case 2:
     return matInfo.setVector(this->getStrain());
     
+    // Massimo Petracca - 28/12/2021: adding missing responseID
+  case 3:
+      return matInfo.setVector(this->getTempAndElong());
+  case 4:
+      return matInfo.setMatrix(this->getTangent());
+
   default:
     return -1;
   }

--- a/SRC/material/nD/PlaneStressUserMaterial.cpp
+++ b/SRC/material/nD/PlaneStressUserMaterial.cpp
@@ -467,18 +467,31 @@ PlaneStressUserMaterial::recvSelf(int commitTag, Channel& theChannel, FEM_Object
   Response*
   PlaneStressUserMaterial::setResponse(const char** argv, int argc, OPS_Stream& output)
   {
-      Response* theResponse = 0;
-      const Vector& res = this->getCracking();
-      theResponse = new MaterialResponse(this, 1, res);
+      // Massimo Petracca - 28/12/2021:
+      // this should be handled by the PlaneStressUserMaterial... moved here from the NDMaterial
+      if ((argc == 1) && ((strcmp(argv[0], "Damage") == 0) || (strcmp(argv[0], "damage") == 0))) {
+          output.tag("NdMaterialOutput");
+          output.attr("matType", this->getClassType());
+          output.attr("matTag", this->getTag());
+          output.tag("ResponseType", "Crack1");
+          output.tag("ResponseType", "Crack2");
+          output.tag("ResponseType", "CAngle");
+          output.endTag();
+          static Vector vec(3);
+          // use a number not used in the NDMaterial..
+          // 5 is too likely to be used if someone will implement another response there.
+          return new MaterialResponse(this, 5555, vec);
+      }
 
-      return theResponse;
+      // otherwise call base class
+      return NDMaterial::setResponse(argv, argc, output);
   }
 
   int
   PlaneStressUserMaterial::getResponse(int responseID, Information & matInfo)
   {
       switch (responseID) {
-      case 1:
+      case 5555:
           return matInfo.setVector(this->getCracking());
 
       default:


### PR DESCRIPTION
@fmckenna @mhscott 
There were some inconsistencies in the setResponse / getResponse methods of the NDMaterial base class:

- The non-generic output "damage" is specific only for the PlaneStressUserMaterial, but was added here. I just moved it in the PlaneStressUserMaterial. Also because there was no getResponse counter-part.
- The responses at id 3 and 4 (getTempAndElong and getTangent) had no getResponse counter-part
- The PlaneStressUserMaterial was returning the crack output for any string passed by the user. Now it gives the crack only when "damage" is requested. Which I think is what @vpapanik meant to do.