### PR TITLE
Fixing setResponse methods in all shell sections

### DIFF
--- a/SRC/material/section/DoubleMembranePlateFiberSection.cpp
+++ b/SRC/material/section/DoubleMembranePlateFiberSection.cpp
@@ -846,29 +846,33 @@ DoubleMembranePlateFiberSection::setResponse(const char **argv, int argc,
 {
   Response *theResponse =0;
 
-  if (argc > 2 || strcmp(argv[0],"fiber") == 0) {
+  if (argc > 2 && (strcmp(argv[0], "fiber") == 0 || strcmp(argv[0], "Fiber") == 0)) {
     
     int passarg = 2;
     int key = atoi(argv[1]);    
     
     if (key > 0 && key <= 2*numFibers) {
-      double fiber_thickness = 0.5 * h * wg[key - 1];
-      double fiber_location = 0.5 * (d + h) + (0.5 * h) * sg[key - 1];
-      if (key >= numFibers)
+      int quadrature_id = key - 1;
+      if (key > numFibers)
+          quadrature_id -= numFibers;
+      double fiber_thickness = 0.5 * h * wg[quadrature_id];
+      double fiber_location = 0.5 * (d + h) + (0.5 * h) * sg[quadrature_id];
+      if (key > numFibers)
           fiber_location = -fiber_location;
       output.tag("FiberOutput");
       output.attr("number", key);
-      output.attr("zLoc", 0.5 * h * sg[key - 1]);
+      output.attr("zLoc", fiber_location);
       output.attr("thickness", fiber_thickness);
       theResponse =  theFibers[key-1]->setResponse(&argv[passarg], argc-passarg, output);
       output.endTag();
     }
-
-    return theResponse;
   }
 
   // If not a fiber response, call the base class method
-  return SectionForceDeformation::setResponse(argv, argc, output);
+  if (theResponse == 0)
+      return SectionForceDeformation::setResponse(argv, argc, output);
+
+  return theResponse;
 }
 
 

--- a/SRC/material/section/DoubleMembranePlateFiberSection.cpp
+++ b/SRC/material/section/DoubleMembranePlateFiberSection.cpp
@@ -179,7 +179,19 @@ int DoubleMembranePlateFiberSection::getOrder( ) const
 //send back order of strainResultant in vector form
 const ID& DoubleMembranePlateFiberSection::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 
@@ -839,8 +851,17 @@ DoubleMembranePlateFiberSection::setResponse(const char **argv, int argc,
     int passarg = 2;
     int key = atoi(argv[1]);    
     
-    if (key > 0 && key <= numFibers) {
+    if (key > 0 && key <= 2*numFibers) {
+      double fiber_thickness = 0.5 * h * wg[key - 1];
+      double fiber_location = 0.5 * (d + h) + (0.5 * h) * sg[key - 1];
+      if (key >= numFibers)
+          fiber_location = -fiber_location;
+      output.tag("FiberOutput");
+      output.attr("number", key);
+      output.attr("zLoc", 0.5 * h * sg[key - 1]);
+      output.attr("thickness", fiber_thickness);
       theResponse =  theFibers[key-1]->setResponse(&argv[passarg], argc-passarg, output);
+      output.endTag();
     }
 
     return theResponse;

--- a/SRC/material/section/ElasticMembranePlateSection.cpp
+++ b/SRC/material/section/ElasticMembranePlateSection.cpp
@@ -139,7 +139,19 @@ int ElasticMembranePlateSection::getOrder( ) const
 //send back order of strain in vector form
 const ID& ElasticMembranePlateSection::getType( )
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 

--- a/SRC/material/section/ElasticPlateSection.cpp
+++ b/SRC/material/section/ElasticPlateSection.cpp
@@ -125,7 +125,16 @@ int ElasticPlateSection::getOrder( ) const
 //send back order of strain in vector form
 const ID& ElasticPlateSection::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_MXX;
+        array(1) = SECTION_RESPONSE_MYY;
+        array(2) = SECTION_RESPONSE_MXY;
+        array(3) = SECTION_RESPONSE_VXZ;
+        array(4) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 

--- a/SRC/material/section/LayeredShellFiberSection.cpp
+++ b/SRC/material/section/LayeredShellFiberSection.cpp
@@ -240,7 +240,19 @@ int LayeredShellFiberSection::getOrder( ) const
 //send back order of strainResultant in vector form
 const ID& LayeredShellFiberSection::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 

--- a/SRC/material/section/LayeredShellFiberSectionThermal.cpp
+++ b/SRC/material/section/LayeredShellFiberSectionThermal.cpp
@@ -140,7 +140,19 @@ int LayeredShellFiberSectionThermal::getOrder( ) const
 //send back order of strainResultant in vector form
 const ID& LayeredShellFiberSectionThermal::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 

--- a/SRC/material/section/MembranePlateFiberSection.cpp
+++ b/SRC/material/section/MembranePlateFiberSection.cpp
@@ -169,7 +169,19 @@ int MembranePlateFiberSection::getOrder( ) const
 //send back order of strainResultant in vector form
 const ID& MembranePlateFiberSection::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 
@@ -660,7 +672,12 @@ MembranePlateFiberSection::setResponse(const char **argv, int argc,
     int key = atoi(argv[1]);    
     
     if (key > 0 && key <= numFibers) {
+      output.tag("FiberOutput");
+      output.attr("number", key);
+      output.attr("zLoc", 0.5 * h * sg[key - 1]);
+      output.attr("thickness", 0.5 * h * wg[key - 1]);
       theResponse = theFibers[key-1]->setResponse(&argv[passarg], argc-passarg, output);
+      output.endTag();
     }
 
   }

--- a/SRC/material/section/MembranePlateFiberSectionThermal.cpp
+++ b/SRC/material/section/MembranePlateFiberSectionThermal.cpp
@@ -149,7 +149,19 @@ int MembranePlateFiberSectionThermal::getOrder( ) const
 //send back order of strainResultant in vector form
 const ID& MembranePlateFiberSectionThermal::getType( ) 
 {
-  return array ;
+    static bool initialized = false;
+    if (!initialized) {
+        array(0) = SECTION_RESPONSE_FXX;
+        array(1) = SECTION_RESPONSE_FYY;
+        array(2) = SECTION_RESPONSE_FXY;
+        array(3) = SECTION_RESPONSE_MXX;
+        array(4) = SECTION_RESPONSE_MYY;
+        array(5) = SECTION_RESPONSE_MXY;
+        array(6) = SECTION_RESPONSE_VXZ;
+        array(7) = SECTION_RESPONSE_VYZ;
+        initialized = true;
+    }
+    return array;
 }
 
 
@@ -746,6 +758,8 @@ MembranePlateFiberSectionThermal::setResponse(const char **argv, int argc,
       
       output.tag("FiberOutput");
       output.attr("number",pointNum);
+      output.attr("zLoc", 0.5 * h * sg[pointNum - 1]);
+      output.attr("thickness", 0.5 * h * wg[pointNum - 1]);
       
       theResponse = theFibers[pointNum-1]->setResponse(&argv[2], argc-2, output);
       

--- a/SRC/material/section/SectionForceDeformation.cpp
+++ b/SRC/material/section/SectionForceDeformation.cpp
@@ -213,6 +213,30 @@ SectionForceDeformation::setResponse(const char **argv, int argc,
       case SECTION_RESPONSE_T:
 	output.tag("ResponseType","theta");
 	break;
+      case SECTION_RESPONSE_FXX:
+          output.tag("ResponseType", "epsXX");
+          break;
+      case SECTION_RESPONSE_FYY:
+          output.tag("ResponseType", "epsYY");
+          break;
+      case SECTION_RESPONSE_FXY:
+          output.tag("ResponseType", "epsXY");
+          break;
+      case SECTION_RESPONSE_MXX:
+          output.tag("ResponseType", "kappaXX");
+          break;
+      case SECTION_RESPONSE_MYY:
+          output.tag("ResponseType", "kappaYY");
+          break;
+      case SECTION_RESPONSE_MXY:
+          output.tag("ResponseType", "kappaXY");
+          break;
+      case SECTION_RESPONSE_VXZ:
+          output.tag("ResponseType", "gammaXZ");
+          break;
+      case SECTION_RESPONSE_VYZ:
+          output.tag("ResponseType", "gammaYZ");
+          break;
       default:
 	output.tag("ResponseType","Unknown");
       }
@@ -242,6 +266,30 @@ SectionForceDeformation::setResponse(const char **argv, int argc,
       case SECTION_RESPONSE_T:
 	output.tag("ResponseType","T");
 	break;
+      case SECTION_RESPONSE_FXX:
+          output.tag("ResponseType", "Fxx");
+          break;
+      case SECTION_RESPONSE_FYY:
+          output.tag("ResponseType", "Fyy");
+          break;
+      case SECTION_RESPONSE_FXY:
+          output.tag("ResponseType", "Fxy");
+          break;
+      case SECTION_RESPONSE_MXX:
+          output.tag("ResponseType", "Mxx");
+          break;
+      case SECTION_RESPONSE_MYY:
+          output.tag("ResponseType", "Myy");
+          break;
+      case SECTION_RESPONSE_MXY:
+          output.tag("ResponseType", "Mxy");
+          break;
+      case SECTION_RESPONSE_VXZ:
+          output.tag("ResponseType", "Vxz");
+          break;
+      case SECTION_RESPONSE_VYZ:
+          output.tag("ResponseType", "Vyz");
+          break;
       default:
 	output.tag("ResponseType","Unknown");
       }
@@ -271,6 +319,30 @@ SectionForceDeformation::setResponse(const char **argv, int argc,
       case SECTION_RESPONSE_T:
 	output.tag("ResponseType","theta");
 	break;
+      case SECTION_RESPONSE_FXX:
+          output.tag("ResponseType", "epsXX");
+          break;
+      case SECTION_RESPONSE_FYY:
+          output.tag("ResponseType", "epsYY");
+          break;
+      case SECTION_RESPONSE_FXY:
+          output.tag("ResponseType", "epsXY");
+          break;
+      case SECTION_RESPONSE_MXX:
+          output.tag("ResponseType", "kappaXX");
+          break;
+      case SECTION_RESPONSE_MYY:
+          output.tag("ResponseType", "kappaYY");
+          break;
+      case SECTION_RESPONSE_MXY:
+          output.tag("ResponseType", "kappaXY");
+          break;
+      case SECTION_RESPONSE_VXZ:
+          output.tag("ResponseType", "gammaXZ");
+          break;
+      case SECTION_RESPONSE_VYZ:
+          output.tag("ResponseType", "gammaYZ");
+          break;
       default:
 	output.tag("ResponseType","Unknown");
       }
@@ -296,6 +368,30 @@ SectionForceDeformation::setResponse(const char **argv, int argc,
       case SECTION_RESPONSE_T:
 	output.tag("ResponseType","T");
 	break;
+      case SECTION_RESPONSE_FXX:
+          output.tag("ResponseType", "Fxx");
+          break;
+      case SECTION_RESPONSE_FYY:
+          output.tag("ResponseType", "Fyy");
+          break;
+      case SECTION_RESPONSE_FXY:
+          output.tag("ResponseType", "Fxy");
+          break;
+      case SECTION_RESPONSE_MXX:
+          output.tag("ResponseType", "Mxx");
+          break;
+      case SECTION_RESPONSE_MYY:
+          output.tag("ResponseType", "Myy");
+          break;
+      case SECTION_RESPONSE_MXY:
+          output.tag("ResponseType", "Mxy");
+          break;
+      case SECTION_RESPONSE_VXZ:
+          output.tag("ResponseType", "Vxz");
+          break;
+      case SECTION_RESPONSE_VYZ:
+          output.tag("ResponseType", "Vyz");
+          break;
       default:
 	output.tag("ResponseType","Unknown");
       }

--- a/SRC/material/section/SectionForceDeformation.h
+++ b/SRC/material/section/SectionForceDeformation.h
@@ -58,6 +58,17 @@ class Response;
 #define SECTION_RESPONSE_B              9 // Bi-moment (FiberSectionWarping3d)
 #define SECTION_RESPONSE_W             10 // (FiberSectionWarping3d)
 
+// section responses for shells
+#define SECTION_RESPONSE_FXX 11 // membrane xx
+#define SECTION_RESPONSE_FYY 12 // membrane yy
+#define SECTION_RESPONSE_FXY 13 // membrane xy
+#define SECTION_RESPONSE_MXX 14 // bending xx
+#define SECTION_RESPONSE_MYY 15 // bending yy
+#define SECTION_RESPONSE_MXY 16 // bending xy
+#define SECTION_RESPONSE_VXZ 17 // bending yy
+#define SECTION_RESPONSE_VYZ 18 // bending xy
+
+
 class SectionForceDeformation : public Material
 {
  public:


### PR DESCRIPTION
Dear @mhscott , 
as discussed in this issue #695 , due to a recent clean-up of shell cross sections, the common responses such as stress and strain are handled by the base class SectionForceDeformation.
However, SectionForceDeformation recognizes only responses of beam elements, thus the XML tags of the components of shell elements are now all "UnknownStress".

This PR:

- Defines the following macros for responses of shell sections in SectionForceDeformation.h: 
```cpp
#define SECTION_RESPONSE_FXX 11 // membrane xx
#define SECTION_RESPONSE_FYY 12 // membrane yy
#define SECTION_RESPONSE_FXY 13 // membrane xy
#define SECTION_RESPONSE_MXX 14 // bending xx
#define SECTION_RESPONSE_MYY 15 // bending yy
#define SECTION_RESPONSE_MXY 16 // bending xy
#define SECTION_RESPONSE_VXZ 17 // bending yy
#define SECTION_RESPONSE_VYZ 18 // bending xy
```
- Implements the proper getType() methods in all shell sections to match those values
- The MembranePlateFiberSection now opens XML tags consistently with the LayeredShellSection for fiber response
- In the DoubleMembranePlateFiberSection there was a small bug ("or" instead of "and") in the if-statement for fiber results
- In the DoubleMembranePlateFiberSection the fiber output was given only for the first 5 fibers. Now all 10 fibers are handled