### PR TITLE
Fixing Visual Studio Compilation due to DuctileFracture uniaxial material

### DIFF
--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -2448,13 +2448,6 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
     }
   }
 
-  	else if (strcmp(argv[1], "DuctileFracture") == 0) {
-		void *theMat = OPS_DuctileFracture();
-		if (theMat != 0) 
-			theMaterial = (UniaxialMaterial *)theMat;
-		else 
-			return TCL_ERROR;
-	}
     
     else if (strcmp(argv[1],"Concrete01WithSITC") == 0) {
       if (argc < 7) {
@@ -2923,6 +2916,13 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
     }								// END Salvatore Sessa 14-Jan-2021 Mail: salvatore.sessa2@unina.it
     if (strcmp(argv[1], "DowelType") == 0) {
         void* theMat = OPS_DowelType();
+        if (theMat != 0)
+            theMaterial = (UniaxialMaterial*)theMat;
+        else
+            return TCL_ERROR;
+    }
+    if (strcmp(argv[1], "DuctileFracture") == 0) {
+        void* theMat = OPS_DuctileFracture();
         if (theMat != 0)
             theMaterial = (UniaxialMaterial*)theMat;
         else

--- a/Win32/proj/material/material.vcxproj
+++ b/Win32/proj/material/material.vcxproj
@@ -268,6 +268,7 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelECThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMP.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMPF.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\DuctileFracture.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.cpp" />
@@ -686,6 +687,7 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelECThermal.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMP.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMPF.h" />
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\DuctileFracture.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.h" />

--- a/Win32/proj/material/material.vcxproj.filters
+++ b/Win32/proj/material/material.vcxproj.filters
@@ -343,6 +343,9 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMP.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\uniaxial\DuctileFracture.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\TclModelBuilderUniaxialMaterialCommand.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
@@ -1586,6 +1589,9 @@
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMP.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\DuctileFracture.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\TriMatrix.h">

--- a/Win64/proj/material/material.vcxproj.filters
+++ b/Win64/proj/material/material.vcxproj.filters
@@ -1798,6 +1798,9 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\DowelType.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\DuctileFracture.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\nD\AcousticMedium.h">
       <Filter>nD</Filter>
     </ClInclude>


### PR DESCRIPTION
@fmckenna @mhscott 
This PR fixes a compilation error in Visual Studio.
The new DuctileFracture uniaxial material was called in the TclModelBuilderUniaxialMaterialCommand.cpp inside an **else if** block which caused a compilation error due to an excessive number of **else if** blocks.

I simply moved it at the end using a separated **if** block