### PR TITLE
Fix sprintf format in eleReponse (Tcl)

### DIFF
--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -6606,7 +6606,7 @@ eleResponse(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv
       int size = data->Size();
       char buffer[40];
       for (int i=0; i<size; i++) {
-	sprintf(buffer,"%f ",(*data)(i));
+	sprintf(buffer,"%35.20f",(*data)(i));
 	Tcl_AppendResult(interp, buffer, NULL);
       }
     }


### PR DESCRIPTION
@fmckenna  @mhscott 
The "eleResponse" in the Tcl interpreter is the only command that uses "%f" as format in sprintf. This translates in numbers such as 1.0e-7 printed as 0.000000.
I changed it to the format used in all other commands "%35.20f"