### PR TITLE
cmp - fix cmake for renamed `MetisWrapper.*`

### DIFF
--- a/SRC/graph/partitioner/CMakeLists.txt
+++ b/SRC/graph/partitioner/CMakeLists.txt
@@ -6,8 +6,8 @@
 #==============================================================================
 target_sources(graph
     PRIVATE
-      Metis.cpp
+      MetisWrapper.cpp
     PUBLIC
-      Metis.h
+      MetisWrapper.h
       GraphPartitioner.h
 )


### PR DESCRIPTION
Pull request #772 renamed `SRC/graph/partitioner/Metis.*`, breaking the CMake build. This fixes that.