### PR TITLE
Added missing TzSimple2 and PySimple2 to OpenSeesPy.

### DIFF
--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -409,6 +409,10 @@ static int setUpUniaxialMaterials(void) {
   uniaxialMaterialsMap.insert(
       std::make_pair("QzSimple1", &OPS_QzSimple1));
   uniaxialMaterialsMap.insert(
+      std::make_pair("PySimple2", &OPS_PySimple2));
+  uniaxialMaterialsMap.insert(
+      std::make_pair("TzSimple2", &OPS_TzSimple2));
+  uniaxialMaterialsMap.insert(
       std::make_pair("QzSimple2", &OPS_QzSimple2));
   uniaxialMaterialsMap.insert(
       std::make_pair("PyLiq1", &OPS_PyLiq1));


### PR DESCRIPTION
Two materials were missing that are used for SSI.

Test script:

import opensees as opy
opy.wipe()
opy.model('basic', '-ndm', 2, '-ndf', 3)
opy.uniaxialMaterial('PySimple2', 1, 1, 1.0, 1.0, 1.0, 0.0)
opy.uniaxialMaterial('TzSimple1', 2, 1, 1.0, 1.0, 0.0)
