### PR TITLE
Added OpenSeesPy to CMake build process

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -33,6 +33,30 @@ jobs:
         #- name: Verification
         #  run: |
         #    cd ./EXAMPLES/verification/ && ../../build/OpenSeesTcl runVerificationSuite.tcl
+    - name: Build OpenSeesPy
+      run: |
+        cd ./build
+        cmake ..
+        make -j 4
+        make OpenSeesPy
+        mkdir fake_folder
+    - name: Rename OpenSeesPy
+      run: |
+        cd ./build
+        mv lib/OpenSeesPy.so lib/opensees.so
+
+# Simple sanity test
+    - name: Verification OpenSeesPySP
+      run: |
+        cd ./build
+        cd ../examples_py
+        export PYTHONPATH="../build/lib/"
+        python -c "import sys; print(sys.path)"
+        python example_variable_analysis.py
+#        # Simple MP sanity test
+#        - name: Verification OpenSeesPyMP
+#          run: |
+#            mpiexec -np 2 python ../examples_py/example_mpi_paralleltruss_explicit.py
 
 # Not building on Windows until we can figure out how to use Fortran
 # with Github Actions

--- a/examples_py/example_mpi_paralleltruss_explicit.py
+++ b/examples_py/example_mpi_paralleltruss_explicit.py
@@ -2,9 +2,9 @@
 import opensees as ops
 
 pid = ops.getPID()
-print(pid)
+print('pid: ', pid)
 np = ops.getNP()
-print(np)
+print('np: ', np)
 ops.start()
 a = open('nps.txt', 'w')
 a.write(str(np))

--- a/examples_py/example_variable_analysis.py
+++ b/examples_py/example_variable_analysis.py
@@ -1,5 +1,6 @@
 import sys
 sys.path.insert(0, '../SRC/interpreter/')
+# sys.path.insert(0, '../build/lib/')
 import opensees as ops
 
 


### PR DESCRIPTION
This adds only 10 seconds to the build process and allows the OpenSeesPy package to be checked.

Note: I can't get it to build the parallel version. Locally I compile with mpicc and mpicxx but these are not allowed in the conan compiler settings and I don't know how to add them.