### PR TITLE
Typo and json print fixes for material wrappers

### DIFF
--- a/SRC/material/uniaxial/InitStrainMaterial.cpp
+++ b/SRC/material/uniaxial/InitStrainMaterial.cpp
@@ -290,6 +290,15 @@ InitStrainMaterial::recvSelf(int cTag, Channel &theChannel,
 void 
 InitStrainMaterial::Print(OPS_Stream &s, int flag)
 {
+    if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+        s << "InitStrainMaterial tag: " << this->getTag() << endln;
+        if (theMaterial)
+            s << "\tMaterial: " << theMaterial->getTag() << endln;
+        else
+            s << "\tMaterial is NULL" << endln;
+        s << "\tInitial strain: " << epsInit << endln;
+    }
+
 	if (flag == OPS_PRINT_PRINTMODEL_JSON) {
 		s << "\t\t\t{";
 		s << "\"name\": \"" << this->getTag() << "\", ";
@@ -299,13 +308,6 @@ InitStrainMaterial::Print(OPS_Stream &s, int flag)
 		else
 		  s << "\"Material\": " << "NULL" << ", ";
 		s << "\"initialStrain\": " << epsInit <<  "}";
-	} else {
-		s << "InitStrainMaterial tag: " << this->getTag() << endln;
-		if (theMaterial)
-		  s << "\tMaterial: " << theMaterial->getTag() << endln;
-		else
-		  s << "\tMaterial is NULL" << endln;
-		s << "\tinitital strain: " << epsInit << endln;
 	}
 }
 

--- a/SRC/material/uniaxial/InitStressMaterial.cpp
+++ b/SRC/material/uniaxial/InitStressMaterial.cpp
@@ -285,9 +285,21 @@ InitStressMaterial::recvSelf(int cTag, Channel &theChannel,
 void 
 InitStressMaterial::Print(OPS_Stream &s, int flag)
 {
-  s << "InitStressMaterial tag: " << this->getTag() << endln;
-  s << "\tMaterial: " << theMaterial->getTag() << endln;
-  s << "\tinitital strain: " << epsInit << endln;
+    if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+        s << "InitStressMaterial tag: " << this->getTag() << endln;
+        s << "\tMaterial: " << theMaterial->getTag() << endln;
+        s << "\tInitial stress: " << sigInit << endln;
+        s << "\tInitial strain: " << epsInit << endln;
+    }
+
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+        s << "\t\t\t{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"InitStressMaterial\", ";
+        s << "\"Material\": " << theMaterial->getTag() << ", ";
+        s << "\"initialStress\": " << sigInit << ", "; 
+        s << "\"initialStrain\": " << epsInit << "}";
+    }
 }
 
 int 


### PR DESCRIPTION
There was no JSON version of the print method for the InitStressMaterial wrapper, so I added it. I also fixed a typo in the InitStrainMaterial wrapper and restructured the print method to match other uniaxial materials.