### PR TITLE
Alias for Tcl load command

### DIFF
--- a/SRC/tcl/tclMain.cpp
+++ b/SRC/tcl/tclMain.cpp
@@ -258,6 +258,7 @@ g3TclMain(int argc, char **argv, Tcl_AppInitProc * appInitProc, int rank, int np
 
     interp = Tcl_CreateInterp();
     Tcl_Eval(interp, "rename load import;");
+	Tcl_Eval(interp, "interp alias {} load {} import;");
 
     numParam = OpenSeesParseArgv(argc, argv);
 


### PR DESCRIPTION
The issue #656 was resolved by renaming "load" to "import" at the Tcl app initialization, which prevents the functionality of the Tcl "load" command from being eliminated when "model" is called. 
This commit extends the fix, by adding an alias "load" to "import", so that Tcl packages can be loaded in normally before calling "model". 