### PR TITLE
Update PathSeries.cpp

### DIFF
--- a/SRC/domain/pattern/PathSeries.cpp
+++ b/SRC/domain/pattern/PathSeries.cpp
@@ -354,8 +354,8 @@ PathSeries::getFactor(double pseudoTime)
 
   // determine indexes into the data array whose boundary holds the time
   double incr = (pseudoTime-startTime)/pathTimeIncr; 
-  int incr1 = floor(incr);
-  int incr2 = incr1+1;
+  long long incr1 = floor(incr);
+  long long incr2 = incr1+1;
   int size = thePath->Size();
 
   if (incr2 >= size) {


### PR DESCRIPTION
Change incr1 and incr2 to llong integers. Fixes segmentation fault from overloading int variable type in very long transient analyses.