### PR TITLE
Increase the FourNodeTetrahedron stiffness accuracy

### DIFF
--- a/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
+++ b/SRC/element/tetrahedron/FourNodeTetrahedron.cpp
@@ -197,7 +197,7 @@ const double  FourNodeTetrahedron::one_over_root3 = 1.0 / root3 ;
 
 const double  FourNodeTetrahedron::sg[] = { 0.25 } ;
 
-const double  FourNodeTetrahedron::wg[] = { 0.16667 } ;
+const double  FourNodeTetrahedron::wg[] = { 0.166666666666666667 } ;
 
   
 static Matrix B(NumStressComponents,NumDOFsPerNode) ;


### PR DESCRIPTION
Hello,

This PR increases the four node tetrahedron stiffness calculation accuracy. 

For an example single tetrahedron element the exact stiffness matrix is: 
```

Kexact:
[[ 149.  108.   24.   -1.    6.   12.  -54.  -48.    0.  -94.  -66.  -36.]
 [ 108.  344.   54.  -24.  104.   42.  -24. -216.  -12.  -60. -232.  -84.]
 [  24.   54.  113.    0.   30.   35.    0.  -24.  -54.  -24.  -60.  -94.]
 [  -1.  -24.    0.   29.  -18.  -12.  -18.   24.    0.  -10.   18.   12.]
 [   6.  104.   30.  -18.   44.   18.   12.  -72.  -12.    0.  -76.  -36.]
 [  12.   42.   35.  -12.   18.   29.    0.  -24.  -18.    0.  -36.  -46.]
 [ -54.  -24.    0.  -18.   12.    0.   36.    0.    0.   36.   12.    0.]
 [ -48. -216.  -24.   24.  -72.  -24.    0.  144.    0.   24.  144.   48.]
 [   0.  -12.  -54.    0.  -12.  -18.    0.    0.   36.    0.   24.   36.]
 [ -94.  -60.  -24.  -10.    0.    0.   36.   24.    0.   68.   36.   24.]
 [ -66. -232.  -60.   18.  -76.  -36.   12.  144.   24.   36.  164.   72.]
 [ -36.  -84.  -94.   12.  -36.  -46.    0.   48.   36.   24.   72.  104.]]
```

while OpenSees (without the PR fix) returns the following matrix:

```
K:
[[ 149.003  108.002   24.      -1.       6.      12.     -54.001  -48.001    0.     -94.002  -66.001  -36.001]
 [ 108.002  344.007   54.001  -24.     104.002   42.001  -24.    -216.004  -12.     -60.001 -232.005  -84.002]
 [  24.      54.001  113.002    0.      30.001   35.001    0.     -24.     -54.001  -24.     -60.001  -94.002]
 [  -1.     -24.       0.      29.001  -18.     -12.     -18.      24.       0.     -10.      18.      12.   ]
 [   6.     104.002   30.001  -18.      44.001   18.      12.     -72.001  -12.       0.     -76.002  -36.001]
 [  12.      42.001   35.001  -12.      18.      29.001    0.     -24.     -18.       0.     -36.001  -46.001]
 [ -54.001  -24.       0.     -18.      12.       0.      36.001    0.       0.      36.001   12.       0.   ]
 [ -48.001 -216.004  -24.      24.     -72.001  -24.       0.     144.003    0.      24.     144.003   48.001]
 [   0.     -12.     -54.001    0.     -12.     -18.       0.       0.      36.001    0.      24.      36.001]
 [ -94.002  -60.001  -24.     -10.       0.       0.      36.001   24.       0.      68.001   36.001   24.   ]
 [ -66.001 -232.005  -60.001   18.     -76.002  -36.001   12.     144.003   24.      36.001  164.003   72.001]
 [ -36.001  -84.002  -94.002   12.     -36.001  -46.001    0.      48.001   36.001   24.      72.001  104.002]]
```
