### PR TITLE
Compatibility improvements for Tcl

### DIFF
--- a/SRC/modelbuilder/tcl/TclModelBuilder.cpp
+++ b/SRC/modelbuilder/tcl/TclModelBuilder.cpp
@@ -513,6 +513,9 @@ TclModelBuilder::TclModelBuilder(Domain &theDomain, Tcl_Interp *interp, int NDM,
   Tcl_CreateCommand(interp, "load", TclCommand_addNodalLoad,
 		    (ClientData)NULL, NULL);
 
+  Tcl_CreateCommand(interp, "nodeLoad", TclCommand_addNodalLoad,
+			(ClientData)NULL, NULL); // alias added to prevent confusion with Tcl load command
+
   Tcl_CreateCommand(interp, "eleLoad", TclCommand_addElementalLoad,
 		    (ClientData)NULL, NULL);
 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -1467,6 +1467,11 @@ wipeModel(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
 
   // the domain deletes the record objects, 
   // just have to delete the private array
+  
+  // restore original "load" command.
+  Tcl_Eval(interp, "interp alias {} load {} oldload");
+  Tcl_ResetResult(interp);
+
   return TCL_OK;  
 }
 

--- a/SRC/tcl/tclMain.cpp
+++ b/SRC/tcl/tclMain.cpp
@@ -257,8 +257,8 @@ g3TclMain(int argc, char **argv, Tcl_AppInitProc * appInitProc, int rank, int np
     Tcl_FindExecutable(argv[0]);
 
     interp = Tcl_CreateInterp();
-    Tcl_Eval(interp, "rename load import;");
-	Tcl_Eval(interp, "interp alias {} load {} import;");
+    Tcl_Eval(interp, "rename load oldload");
+	Tcl_Eval(interp, "interp alias {} load {} oldload");
 
     numParam = OpenSeesParseArgv(argc, argv);
 


### PR DESCRIPTION
The Tcl load command is now renamed to "oldload" instead of "import". The "import" command has special meaning for some Tcl packages.
https://core.tcl-lang.org/tcllib/doc/tcllib-1-20/embedded/md/index.md#import

Additionally, to better support compatibility with the Tcl load command, the "wipe" command now restores the Tcl load command, and an alternate alias, "nodeLoad" is provided.

This maintains backwards compatibility, and allows for binary files (e.g. some Tcl packages) to be loaded in between OpenSees analyses.