### PR TITLE
Adding option to suppress warnings about default analysis options

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -547,7 +547,7 @@ OpenSeesCommands::setAlgorithm(EquiSolnAlgo* algorithm)
 }
 
 void
-OpenSeesCommands::setStaticAnalysis()
+OpenSeesCommands::setStaticAnalysis(bool suppress)
 {
     // delete the old analysis
     if (theStaticAnalysis != 0) {
@@ -567,29 +567,39 @@ OpenSeesCommands::setStaticAnalysis()
 	theTest = new CTestNormUnbalance(1.0e-6,25,0);
     }
     if (theAlgorithm == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Static - no Algorithm yet specified, \n";
 	opserr << " NewtonRaphson default will be used\n";
+      }
 	theAlgorithm = new NewtonRaphson(*theTest);
     }
     if (theHandler == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Static - no ConstraintHandler yet specified, \n";
 	opserr << " PlainHandler default will be used\n";
+      }
 	theHandler = new PlainHandler();
     }
     if (theNumberer == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Static - no Numberer specified, \n";
 	opserr << " RCM default will be used\n";
+      }
 	RCM* theRCM = new RCM(false);
 	theNumberer = new DOF_Numberer(*theRCM);
     }
     if (theStaticIntegrator == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Static - no Integrator specified, \n";
 	opserr << " StaticIntegrator default will be used\n";
+      }
     setIntegrator(new LoadControl(1, 1, 1, 1), false);
     }
     if (theSOE == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Static - no LinearSOE specified, \n";
 	opserr << " ProfileSPDLinSOE default will be used\n";
+      }
 	ProfileSPDLinSolver *theSolver;
 	theSolver = new ProfileSPDLinDirectSolver();
 	theSOE = new ProfileSPDLinSOE(*theSolver);
@@ -616,7 +626,7 @@ OpenSeesCommands::setStaticAnalysis()
 }
 
 int
-OpenSeesCommands::setPFEMAnalysis()
+OpenSeesCommands::setPFEMAnalysis(bool suppress)
 {
     // delete the old analysis
     if (theStaticAnalysis != 0) {
@@ -704,7 +714,7 @@ OpenSeesCommands::setPFEMAnalysis()
 }
 
 void
-OpenSeesCommands::setVariableAnalysis()
+OpenSeesCommands::setVariableAnalysis(bool suppress)
 {
     // delete the old analysis
     if (theStaticAnalysis != 0) {
@@ -727,33 +737,43 @@ OpenSeesCommands::setVariableAnalysis()
     }
 
     if (theAlgorithm == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis VariableTransient - no Algorithm yet specified, \n";
 	opserr << " NewtonRaphson default will be used\n";
+      }
 	theAlgorithm = new NewtonRaphson(*theTest);
     }
 
     if (theHandler == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis VariableTransient dt tFinal - no ConstraintHandler\n";
 	opserr << " yet specified, PlainHandler default will be used\n";
+      }
 	theHandler = new PlainHandler();
     }
 
     if (theNumberer == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis VariableTransient dt tFinal - no Numberer specified, \n";
 	opserr << " RCM default will be used\n";
+      }
 	RCM *theRCM = new RCM(false);
 	theNumberer = new DOF_Numberer(*theRCM);
     }
 
     if (theTransientIntegrator == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis VariableTransient dt tFinal - no Integrator specified, \n";
 	opserr << " Newmark(.5,.25) default will be used\n";
+      }
         setIntegrator(new Newmark(0.5, 0.25), true);
     }
 
     if (theSOE == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis VariableTransient dt tFinal - no LinearSOE specified, \n";
 	opserr << " ProfileSPDLinSOE default will be used\n";
+      }
 	ProfileSPDLinSolver *theSolver;
 	theSolver = new ProfileSPDLinDirectSolver();
 	theSOE = new ProfileSPDLinSOE(*theSolver);
@@ -779,7 +799,7 @@ OpenSeesCommands::setVariableAnalysis()
 }
 
 void
-OpenSeesCommands::setTransientAnalysis()
+OpenSeesCommands::setTransientAnalysis(bool suppress)
 {
     // delete the old analysis
     if (theStaticAnalysis != 0) {
@@ -799,29 +819,39 @@ OpenSeesCommands::setTransientAnalysis()
 	theTest = new CTestNormUnbalance(1.0e-6,25,0);
     }
     if (theAlgorithm == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Transient - no Algorithm yet specified, \n";
 	opserr << " NewtonRaphson default will be used\n";
+      }
 	theAlgorithm = new NewtonRaphson(*theTest);
     }
     if (theHandler == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Transient - no ConstraintHandler yet specified, \n";
 	opserr << " PlainHandler default will be used\n";
+      }
 	theHandler = new PlainHandler();
     }
     if (theNumberer == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Transient - no Numberer specified, \n";
 	opserr << " RCM default will be used\n";
+      }
 	RCM* theRCM = new RCM(false);
 	theNumberer = new DOF_Numberer(*theRCM);
     }
     if (theTransientIntegrator == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Transient - no Integrator specified, \n";
 	opserr << " TransientIntegrator default will be used\n";
+      }
     setIntegrator(new Newmark(0.5,0.25), true);
     }
     if (theSOE == 0) {
+      if (!suppress) {
 	opserr << "WARNING analysis Transient - no LinearSOE specified, \n";
 	opserr << " ProfileSPDLinSOE default will be used\n";
+      }
 	ProfileSPDLinSolver *theSolver;
 	theSolver = new ProfileSPDLinDirectSolver();
 	theSOE = new ProfileSPDLinSOE(*theSolver);
@@ -1685,19 +1715,25 @@ int OPS_Analysis()
     }
 
     const char* type = OPS_GetString();
-
+    bool suppressWarnings = false;
+    if (OPS_GetNumRemainingInputArgs() > 0) {
+      const char* opt = OPS_GetString();
+      if (strcmp(opt,"-noWarnings") == 0)
+	suppressWarnings = true;
+    }
+    
     // create analysis
     if (strcmp(type, "Static") == 0) {
 	if (cmds != 0) {
-	    cmds->setStaticAnalysis();
+	    cmds->setStaticAnalysis(suppressWarnings);
 	}
     } else if (strcmp(type, "Transient") == 0) {
 	if (cmds != 0) {
-	    cmds->setTransientAnalysis();
+	    cmds->setTransientAnalysis(suppressWarnings);
 	}
     } else if (strcmp(type, "PFEM") == 0) {
 	if (cmds != 0) {
-	    if (cmds->setPFEMAnalysis() < 0) {
+	    if (cmds->setPFEMAnalysis(suppressWarnings) < 0) {
 		return -1;
 	    }
 	}
@@ -1705,7 +1741,7 @@ int OPS_Analysis()
 	       (strcmp(type,"TransientWithVariableTimeStep") == 0) ||
 	       (strcmp(type,"VariableTransient") == 0)) {
 	if (cmds != 0) {
-	    cmds->setVariableAnalysis();
+	    cmds->setVariableAnalysis(suppressWarnings);
 	}
 
     } else {

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -106,17 +106,17 @@ public:
     void setCTest(ConvergenceTest* test);
     ConvergenceTest* getCTest() {return theTest;}
 
-    void setStaticAnalysis();
+    void setStaticAnalysis(bool suppress);
     StaticAnalysis* getStaticAnalysis() {return theStaticAnalysis;}
 
-    int setPFEMAnalysis();
+    int setPFEMAnalysis(bool suppress);
     PFEMAnalysis* getPFEMAnalysis() {return thePFEMAnalysis;}
 
-    void setVariableAnalysis();
+    void setVariableAnalysis(bool suppress);
     VariableTimeStepDirectIntegrationAnalysis*
     getVariableAnalysis() {return theVariableTimeStepTransientAnalysis;}
 
-    void setTransientAnalysis();
+    void setTransientAnalysis(bool suppress);
     DirectIntegrationAnalysis* getTransientAnalysis() {return theTransientAnalysis;}
 
     void setNumEigen(int num) {numEigen = num;}


### PR DESCRIPTION
For when you're running analyses in a loop and don't want to type out constraints, numberer, integrator, etc. and don't want to see warnings all the time