### PR TITLE
Fix typos in `EXAMPLES/`

### DIFF
--- a/EXAMPLES/DatastarExamples/Example1.tcl
+++ b/EXAMPLES/DatastarExamples/Example1.tcl
@@ -67,7 +67,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/DeveloperTestScripts/ZeroLengthImpact3D_test.tcl
+++ b/EXAMPLES/DeveloperTestScripts/ZeroLengthImpact3D_test.tcl
@@ -100,10 +100,10 @@ uniaxialMaterial Elastic 6 1.0e-5;
 uniaxialMaterial Elastic 7 1.0e-5;
 
 #element zeroLength $eleTag $iNode $jNode -mat $matTag1 $matTag2 ... -dir $dir1 $dir2 ... <-orient $x1 $x2 $x3 $yp1 $yp2 $yp3> <-doRayleigh $rFlag>
-element zeroLength 141 11 21 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergance of Newton-Raphson method 
-element zeroLength 142 12 22 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergance of Newton-Raphson method 
-element zeroLength 144 14 24 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergance of Newton-Raphson method 
-element zeroLength 145 15 25 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergance of Newton-Raphson method 
+element zeroLength 141 11 21 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergence of Newton-Raphson method 
+element zeroLength 142 12 22 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergence of Newton-Raphson method 
+element zeroLength 144 14 24 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergence of Newton-Raphson method 
+element zeroLength 145 15 25 -mat 6 7 6 -dir 1 2 3; # springs with very low stiffness for convergence of Newton-Raphson method 
 
 puts "model is built";
 

--- a/EXAMPLES/Example1/main.cpp
+++ b/EXAMPLES/Example1/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
     
     TimeSeries *theSeries = new LinearSeries();
     
-    // construct a load pattren using constructor:
+    // construct a load pattern using constructor:
     //		LoadPattern(tag)
     // and then set it's TimeSeries and add it to the domain
     

--- a/EXAMPLES/ExamplePython/Example3.1.py
+++ b/EXAMPLES/ExamplePython/Example3.1.py
@@ -98,7 +98,7 @@ beamIntegration("Lobatto", 1, 1, np)
 #                       tag 
 geomTransf("PDelta", 1)
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                   tag ndI ndJ transfTag integrationTag
 eleType = "forceBeamColumn"
 element(eleType, 1, 1, 3, 1, 1)

--- a/EXAMPLES/ExamplePython/Example3.2.py
+++ b/EXAMPLES/ExamplePython/Example3.2.py
@@ -99,7 +99,7 @@ beamIntegration("Lobatto", 1, 1, np)
 #                       tag 
 geomTransf("PDelta", 1)
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                   tag ndI ndJ transfTag integrationTag
 eleType = "forceBeamColumn"
 element(eleType, 1, 1, 3, 1, 1)

--- a/EXAMPLES/ExamplePython/Example7.1.py
+++ b/EXAMPLES/ExamplePython/Example7.1.py
@@ -100,7 +100,7 @@ algorithm("Newton")
 # DOF numberer
 numberer("RCM")
 
-# Cosntraint handler
+# Constraint handler
 constraints("Plain") 
 
 # System of equations solver

--- a/EXAMPLES/ExamplePython/Example8.1.py
+++ b/EXAMPLES/ExamplePython/Example8.1.py
@@ -101,7 +101,7 @@ algorithm("Newton")
 # DOF numberer
 numberer("RCM")
 
-# Cosntraint handler
+# Constraint handler
 constraints("Plain")
 
 # System of equations solver

--- a/EXAMPLES/ExamplePython/bending_quad9n.py
+++ b/EXAMPLES/ExamplePython/bending_quad9n.py
@@ -47,6 +47,6 @@ ops.printModel()
 # verification:
 # tip vertical displacement (node 2 and 3) = 0.0075
 # bottom Gauss Point stress_xx = 46475.8
-# bottom extrem stress_xx (extrapolated) = 60000.0
+# bottom extreme stress_xx (extrapolated) = 60000.0
 
 exit()

--- a/EXAMPLES/ExampleScripts/ArcLength01.tcl
+++ b/EXAMPLES/ExampleScripts/ArcLength01.tcl
@@ -107,7 +107,7 @@ geomTransf Linear 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                           tag ndI ndJ nsecs secID transfTag
 set eleType nonlinearBeamColumn
 set eleType forceBeamColumn

--- a/EXAMPLES/ExampleScripts/ArcLength02.tcl
+++ b/EXAMPLES/ExampleScripts/ArcLength02.tcl
@@ -124,7 +124,7 @@ while {$ok == 0 && $currentDisp < $maxU} {
 
         # if the analysis fails try initial tangent iteration
         if {$ok != 0} {
-            puts "regular newton failed .. lets try an initail stiffness for this step"
+            puts "regular newton failed .. lets try an initial stiffness for this step"
             test NormDispIncr 1.0e-12  1000 0
             algorithm ModifiedNewton -initial
             set ok [analyze 1]

--- a/EXAMPLES/ExampleScripts/Cube_tcl/TriSimu_Sand.tcl
+++ b/EXAMPLES/ExampleScripts/Cube_tcl/TriSimu_Sand.tcl
@@ -54,9 +54,9 @@ source IsotropicCompression_Analysis.tcl
 #===========================================================
 # Apply friction(fixing the top and bottom plates with soil)
 #================================================================
-# You can test the differece between full frition or no friction 
-# on the top and bottom platens by comment or de-comment the 
-# following command
+# You can test the difference between full friction or no 
+# friction on the top and bottom plates by commenting or 
+# uncommenting the following command:
 source Apply_FrictionBC.tcl
 
 

--- a/EXAMPLES/ExampleScripts/DynamicShell.tcl
+++ b/EXAMPLES/ExampleScripts/DynamicShell.tcl
@@ -60,7 +60,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     
     # if the analysis fails try initial tangent iteration
     if {$ok != 0} {
-	puts "regular newton failed .. lets try an initail stiffness for this step"
+	puts "regular newton failed .. lets try an initial stiffness for this step"
 	test NormDispIncr 1.0e-12  100 0
 	algorithm ModifiedNewton -initial
 	set ok [analyze 1 .01]

--- a/EXAMPLES/ExampleScripts/DynamicShell2.tcl
+++ b/EXAMPLES/ExampleScripts/DynamicShell2.tcl
@@ -63,7 +63,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     
     # if the analysis fails try initial tangent iteration
     if {$ok != 0} {
-	puts "regular newton failed .. lets try an initail stiffness for this step"
+	puts "regular newton failed .. lets try an initial stiffness for this step"
 	test NormDispIncr 1.0e-12  100 0
 	algorithm ModifiedNewton -initial
 	set ok [analyze 1 .01]

--- a/EXAMPLES/ExampleScripts/Example3.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example3.1.tcl
@@ -107,7 +107,7 @@ geomTransf Corotational 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #               e            tag ndI ndJ nsecs secID transfTag
 set eleType forceBeamColumn
 element $eleType  1   1   3   $np    1       1 

--- a/EXAMPLES/ExampleScripts/Example3.2.tcl
+++ b/EXAMPLES/ExampleScripts/Example3.2.tcl
@@ -119,7 +119,7 @@ if {$ok != 0} {
 
 	# if the analysis fails try initial tangent iteration
 	if {$ok != 0} {
-	    puts "regular newton failed .. lets try an initail stiffness for this step"
+	    puts "regular newton failed .. lets try an initial stiffness for this step"
 	    test NormUnbalance 1.0  1000 5
 	    algorithm ModifiedNewton -initial
 	    set ok [analyze 1]

--- a/EXAMPLES/ExampleScripts/Example3.3.tcl
+++ b/EXAMPLES/ExampleScripts/Example3.3.tcl
@@ -151,7 +151,7 @@ while {$ok == 0 && $tCurrent < $tFinal} {
     
     # if the analysis fails try initial tangent iteration
     if {$ok != 0} {
-	puts "regular newton failed .. lets try an initail stiffness for this step"
+	puts "regular newton failed .. lets try an initial stiffness for this step"
 	test NormDispIncr 1.0e-12  100 0
 	algorithm ModifiedNewton -initial
 	set ok [analyze 1 .01]

--- a/EXAMPLES/ExampleScripts/Example6.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example6.1.tcl
@@ -79,7 +79,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/ExampleScripts/Example7.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example7.1.tcl
@@ -58,7 +58,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/ExampleScripts/Example8.1.tcl
+++ b/EXAMPLES/ExampleScripts/Example8.1.tcl
@@ -65,7 +65,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/ExampleScripts/Frame.tcl
+++ b/EXAMPLES/ExampleScripts/Frame.tcl
@@ -39,7 +39,7 @@ uniaxialMaterial Steel01  3  $fy $E 0.01
 # Define cross-section for nonlinear columns
 # ------------------------------------------
 
-# set some paramaters
+# set some parameters
 set colWidth 15
 set colDepth 24 
 
@@ -80,7 +80,7 @@ geomTransf Corotational 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #               e            tag ndI ndJ nsecs secID transfTag
 set eleType dispBeamColumn
 element $eleType  1   1   3   $np    1       1 
@@ -90,7 +90,7 @@ element $eleType  6   4   6   $np    1       1
 element $eleType  8   5   7   $np    1       1 
 element $eleType  9   6   8   $np    1       1 
 
-# Define beam elment
+# Define beam element
 # -----------------------------
 
 # Geometry of column elements

--- a/EXAMPLES/ExampleScripts/RCFrame1.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrame1.tcl
@@ -142,7 +142,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Transformation
 
 # System of equations solver
@@ -199,7 +199,7 @@ while {$ok == 0 && $currentDisp < $maxU} {
     
     # if the analysis fails try initial tangent iteration
     if {$ok != 0} {
-	puts "regular newton failed .. lets try an initail stiffness for this step"
+	puts "regular newton failed .. lets try an initial stiffness for this step"
 	test NormDispIncr 1.0e-12  2000 1
 	algorithm ModifiedNewton -initial
 	set ok [analyze 1]

--- a/EXAMPLES/ExampleScripts/RCFrame2.tcl
+++ b/EXAMPLES/ExampleScripts/RCFrame2.tcl
@@ -153,7 +153,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain
 
 # System of equations solver

--- a/EXAMPLES/ExampleScripts/Rigid.tcl
+++ b/EXAMPLES/ExampleScripts/Rigid.tcl
@@ -95,7 +95,7 @@ foreach rigidConstraint {no yes} {
 	    set np 5
 	    
 
-	    # Create the coulumns using Beam-column elements
+	    # Create the columns using Beam-column elements
 	    #               e            tag ndI ndJ nsecs secID transfTag
 	    element $eleType  1   1   3   $np    1       1 
 	    element $eleType  2   2   4   $np    1       1 

--- a/EXAMPLES/ExampleScripts/SPtcl/Plug_In_PileElements.tcl
+++ b/EXAMPLES/ExampleScripts/SPtcl/Plug_In_PileElements.tcl
@@ -46,5 +46,5 @@ for {set i 0} {$i < $num_of_pile_element} {incr i} {
   }   
 
 }
-puts "Finished Pluging in pile elements..."
+puts "Finished Plugging in pile elements..."
 close $els_in_pile

--- a/EXAMPLES/ExampleScripts/Test-BoucWenInfill.tcl
+++ b/EXAMPLES/ExampleScripts/Test-BoucWenInfill.tcl
@@ -61,7 +61,7 @@ uniaxialMaterial Steel02  3   $fy  $E  0.1     15  0.925  0.15;
 uniaxialMaterial BoucWenInfill       4    7416   0.003  0.295   0.2   1.5  153  1.8627  0.023    0.0011  0.001   0.17  5.8   0.21   1.0e-05     1000000 
 
 # #########################################################################################################
-# set some paramaters for COLUMNS sections
+# set some parameters for COLUMNS sections
 set colWidth 350.0
 set colDepth 350.0
 
@@ -107,7 +107,7 @@ uniaxialMaterial Elastic 51 $GAcol
 section Aggregator     10    51 Vy      51 Vz    50 T      -section 1 
 #______________________
 # ##############################################
-# set some paramaters for BEAM sections
+# set some parameters for BEAM sections
 set beaWidth 350.0
 set beaDepth 350.0
 

--- a/EXAMPLES/ExampleScripts/TimeSeriesTest.tcl
+++ b/EXAMPLES/ExampleScripts/TimeSeriesTest.tcl
@@ -47,7 +47,7 @@ foreach seriesCommand $seriesCommands {
     set A 1.0;
     set m 1.0;
     
-    #derived quantaties                                                             
+    #derived quantities                                                             
     set PI 3.14159
 
     set fStruct [expr 1.0/$periodStruct]

--- a/EXAMPLES/ExampleScripts/bending_quad9n.tcl
+++ b/EXAMPLES/ExampleScripts/bending_quad9n.tcl
@@ -43,6 +43,6 @@ print
 # verification:
 # tip vertical displacement (node 2 and 3) = 0.0075
 # bottom Gauss Point stress_xx = 46475.8
-# bottom extrem stress_xx (extrapolated) = 60000.0
+# bottom extreme stress_xx (extrapolated) = 60000.0
 
 exit

--- a/EXAMPLES/ExampleScripts/patchtri31p.tcl
+++ b/EXAMPLES/ExampleScripts/patchtri31p.tcl
@@ -67,7 +67,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/ExamplesForTesting/MY0a.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0a.ops
@@ -13,7 +13,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   1      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  0      ;# mass density
 set press   -80.    ;# isotropic consolidation pressure on quad element(s)
 set loadInc  0.45    ;# load increment per step for monotonic loading option

--- a/EXAMPLES/ExamplesForTesting/MY0b.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0b.ops
@@ -13,7 +13,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   2      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  0      ;# mass density
 set press   -80.    ;# isotropic consolidation pressure on quad element(s)
 set loadInc  0.45    ;# load increment per step for monotonic loading option

--- a/EXAMPLES/ExamplesForTesting/MY0c.ops
+++ b/EXAMPLES/ExamplesForTesting/MY0c.ops
@@ -13,7 +13,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   3      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  0      ;# mass density
 set press   -80.    ;# isotropic consolidation pressure on quad element(s)
 set loadInc  0.45    ;# load increment per step for monotonic loading option

--- a/EXAMPLES/ExamplesForTesting/MY1a.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1a.ops
@@ -14,7 +14,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   1      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  2      ;# mass density
 set press   -36.    ;# isotropic consolidation pressure on quad element(s)
 set loadFac  20      ;# load multiplier 

--- a/EXAMPLES/ExamplesForTesting/MY1b.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1b.ops
@@ -14,7 +14,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   2      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  2      ;# mass density
 set press   -36.    ;# isotropic consolidation pressure on quad element(s)
 set loadFac  20      ;# load multiplier 

--- a/EXAMPLES/ExamplesForTesting/MY1c.ops
+++ b/EXAMPLES/ExamplesForTesting/MY1c.ops
@@ -14,7 +14,7 @@ puts "\n PLEASE SEND QUESTIONS TO zhyang@ucsd.edu (Zhaohui Yang) \n"
 #some user defined variables
 # 
 set matOpt   3      ;# 1 = drained, pressure depend;  2 = undrained, pressure depend; 
-                    ;# 3 = undrained, pressure independ; 4 = elastic 
+                    ;# 3 = undrained, pressure independent; 4 = elastic 
 set massDen  2      ;# mass density
 set press   -36.    ;# isotropic consolidation pressure on quad element(s)
 set loadFac  20      ;# load multiplier 

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.1.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.1.ops
@@ -105,7 +105,7 @@ geomTransf Linear 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                           tag ndI ndJ nsecs secID transfTag
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.2.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.2.ops
@@ -114,7 +114,7 @@ geomTransf Linear 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                           tag ndI ndJ nsecs secID transfTag
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1

--- a/EXAMPLES/ExamplesForTesting/Test.Example3.3.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.Example3.3.ops
@@ -113,7 +113,7 @@ geomTransf Linear 1
 # Number of integration points along length of element
 set np 5
 
-# Create the coulumns using Beam-column elements
+# Create the columns using Beam-column elements
 #                           tag ndI ndJ nsecs secID transfTag
 element nonlinearBeamColumn  1   1   3   $np    1       1
 element nonlinearBeamColumn  2   2   4   $np    1       1
@@ -335,7 +335,7 @@ if {$ok != 0} {
 
 	# if the analysis fails try initial tangent iteration
 	if {$ok != 0} {
-	    puts "regular newton failed .. lets try an initail stiffness for this step"
+	    puts "regular newton failed .. lets try an initial stiffness for this step"
 	    test NormDispIncr 1.0e-12  100 1
 	    algorithm Newton -initial
 	    set ok [analyze 1 .01]

--- a/EXAMPLES/ExamplesForTesting/Test.RCFrame1.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.RCFrame1.ops
@@ -138,7 +138,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Transformation
 
 # System of equations solver

--- a/EXAMPLES/ExamplesForTesting/Test.RCFrame2.ops
+++ b/EXAMPLES/ExamplesForTesting/Test.RCFrame2.ops
@@ -153,7 +153,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain
 
 # System of equations solver

--- a/EXAMPLES/LargeSP/Example.tcl
+++ b/EXAMPLES/LargeSP/Example.tcl
@@ -65,7 +65,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/ShadowTruss/ClientMain.cpp
+++ b/EXAMPLES/ShadowTruss/ClientMain.cpp
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
     
     TimeSeries *theSeries = new LinearSeries();
     
-    // construct a load pattren using constructor:
+    // construct a load pattern using constructor:
     //		LoadPattern(tag)
     // and then set it's TimeSeries and add it to the domain
 

--- a/EXAMPLES/SmallMP/analysis.tcl
+++ b/EXAMPLES/SmallMP/analysis.tcl
@@ -36,7 +36,7 @@ proc doDynamic {dT nPts} {
 	
 	# if the analysis fails try initial tangent iteration
 	if {$ok != 0} {
-	    puts "regular newton failed .. lets try an initail stiffness for this step"
+	    puts "regular newton failed .. lets try an initial stiffness for this step"
 	    test NormDispIncr 1.0e-12  100 0
 	    algorithm ModifiedNewton -initial
 	    set ok [analyze 1 $dT]

--- a/EXAMPLES/TeraGridExamples/Example1.tcl
+++ b/EXAMPLES/TeraGridExamples/Example1.tcl
@@ -67,7 +67,7 @@ algorithm Newton
 # DOF numberer
 numberer RCM
 
-# Cosntraint handler
+# Constraint handler
 constraints Plain 
 
 # System of equations solver

--- a/EXAMPLES/TeraGridExamples/analysis.tcl
+++ b/EXAMPLES/TeraGridExamples/analysis.tcl
@@ -36,7 +36,7 @@ proc doDynamic {dT nPts} {
 	
 	# if the analysis fails try initial tangent iteration
 	if {$ok != 0} {
-	    puts "regular newton failed .. lets try an initail stiffness for this step"
+	    puts "regular newton failed .. lets try an initial stiffness for this step"
 	    test NormDispIncr 1.0e-12  100 0
 	    algorithm ModifiedNewton -initial
 	    set ok [analyze 1 $dT]

--- a/EXAMPLES/verification/EigenFrame.tcl
+++ b/EXAMPLES/verification/EigenFrame.tcl
@@ -3,7 +3,7 @@
 #   and again by Peterson in 1981
 
 #REFERENCES: 
-# 1) Bathe, K.J and Wilson, E.L.Large Eigenvalue Problems in Synamic Analysis, ASCE,
+# 1) Bathe, K.J and Wilson, E.L.Large Eigenvalue Problems in Dynamic Analysis, ASCE,
 # Journal of Eng. Mech.. Division, 98(6), 1471-1485, 
 # 2) Peterson, F.E. EASE2, Elastic Analysis for Structural Engineering, Example Problem Manual, 
 # Engineering Analysis Corporation, Berkeley, CA 1981.

--- a/EXAMPLES/verification/PortalFrame2d.tcl
+++ b/EXAMPLES/verification/PortalFrame2d.tcl
@@ -1,5 +1,5 @@
 
-# Two dimenional Frame: Eigenvalue & Static Loads
+# Two dimensional Frame: Eigenvalue & Static Loads
 
 
 # REFERENCES:

--- a/EXAMPLES/verification/sdofTransient.tcl
+++ b/EXAMPLES/verification/sdofTransient.tcl
@@ -70,7 +70,7 @@ set tFinal [expr 2.251*$periodForce]
 set periodStruct 0.8
 set K 2.0
 
-# derived quantaties
+# derived quantities
 set w [expr 2.0 * $PI / $periodForce]
 set wn [expr 2.0 * $PI / $periodStruct]
 
@@ -174,7 +174,7 @@ puts "\n\n   - Earthquake Response (Section 6.4)\n"
 set tol 3.0e-2; 
 set results {2.67 5.97 7.47 9.91 7.47 5.37}
 
-# read earthquake record, setting dt and nPts variables with data in te file elCentro.at2
+# read earthquake record, setting dt and nPts variables with data in the file elCentro.at2
 source ReadRecord.tcl
 ReadRecord elCentro.at2 elCentro.dat dt nPts
 


### PR DESCRIPTION
Found using `codespell`