### PR TITLE
ElasticTimoshenkoBeam2d: bugfix for the local forces

### DIFF
--- a/SRC/element/elasticBeamColumn/ElasticTimoshenkoBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticTimoshenkoBeam2d.cpp
@@ -734,6 +734,8 @@ Response* ElasticTimoshenkoBeam2d::setResponse(const char **argv, int argc,
 
 int ElasticTimoshenkoBeam2d::getResponse (int responseID, Information &eleInfo)
 {
+    this->getResistingForce();
+
     switch (responseID) {
     case 1: // global forces
         return eleInfo.setVector(this->getResistingForce());

--- a/SRC/element/elasticBeamColumn/ElasticTimoshenkoBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticTimoshenkoBeam2d.cpp
@@ -734,13 +734,12 @@ Response* ElasticTimoshenkoBeam2d::setResponse(const char **argv, int argc,
 
 int ElasticTimoshenkoBeam2d::getResponse (int responseID, Information &eleInfo)
 {
-    this->getResistingForce();
-
     switch (responseID) {
     case 1: // global forces
         return eleInfo.setVector(this->getResistingForce());
     
     case 2: // local forces
+	    this->getResistingForce();
         theVector.Zero();
         // determine resisting forces in local system
         theVector = ql;


### PR DESCRIPTION
This simple PR fixes the bug related to the local forces (of the elastic Timoshenko element) which are not calculated correctly unless the `getResistingForce` function is executed. 

Without this bugfix the following command returns a list `ql` of zeros

```
localForces = ops.eleResponse(ele_tag, 'localForces')
print(f'localForces:\n{localForces}')
```