### PR TITLE
Add recorder of Fracture Index to MVLEM  element

### DIFF
--- a/SRC/element/mvlem/MVLEM.cpp
+++ b/SRC/element/mvlem/MVLEM.cpp
@@ -1420,6 +1420,14 @@ Response *MVLEM::setResponse(const char **argv, int argc, OPS_Stream &s)
 		return theResponse = new ElementResponse(this, 6, Vector(2));
 	}
 
+	// Steel Fracture Index (KZ - 05/13/21)
+	else if (strcmp(argv[0], "Steel_Fracture_Index") == 0 || strcmp(argv[0], "steel_fracture_index") == 0) {
+
+		s.tag("ResponseType", "damage");
+
+		return theResponse = new ElementResponse(this, 7, Vector(m));
+	}
+
 	s.endTag();
 
 	return 0;
@@ -1447,6 +1455,9 @@ MVLEM::getResponse(int responseID, Information &eleInfo)
 
 	case 6:  // Shear Force-Deformtion
 		return eleInfo.setVector(this->getShearFD()); 
+
+	case 7:  // Steel Fracture Index (KZ - 05/13/21)
+		return eleInfo.setVector(this->getSteelFractureIndex());
 
 	default:
 
@@ -1554,4 +1565,21 @@ MVLEM::setupMacroFibers()
   NodeMass = density * A * h / 2;
 
   return 0;
+}
+
+
+// Get Steel Fracture Index (KZ - 05/13/21)
+Vector MVLEM::getSteelFractureIndex(void)
+{
+	Vector steelFractureIndex(m);
+
+	for (int i = 0; i<m; i++) {
+		Information matInfo(0.0);
+		if (theMaterialsSteel[i]->getResponse(5, matInfo) == 0) {
+			const Vector &dataFI = matInfo.getData();
+			steelFractureIndex(i) = dataFI(0);
+		}
+	}
+
+	return steelFractureIndex;
 }

--- a/SRC/element/mvlem/MVLEM.h
+++ b/SRC/element/mvlem/MVLEM.h
@@ -99,7 +99,8 @@ class MVLEM : public Element {
   Vector getStressSteel(void);
   Vector getShearFD(void);
   int setupMacroFibers();
-  
+  Vector getSteelFractureIndex(void);
+
   // private attributes - a copy for each object of the class
   ID  externalNodes;          			// contains the id's of end nodes
   Matrix trans;							// hold the transformation matrix, could use a Vector


### PR DESCRIPTION
Add recorder to MVLEM element. The new recorder obtains the Fracture Index produced by the DuctileFracture uniaxial material (Reinforcing Ductile Fracture Model developed by Kuanshi Zhong). The DuctileFracture material enables the user to simulate bar rupture explicitly, the material produces a Fracture Index history which can be recorded with this update when combined with the MVLEM element. The update allows calling the recorder just like any MVLEM recorder for a fiber using the DuctileFracture material.