### PR TITLE
BugFix getResponse in PlaneStressUserMaterial

### DIFF
--- a/SRC/material/nD/PlaneStressUserMaterial.cpp
+++ b/SRC/material/nD/PlaneStressUserMaterial.cpp
@@ -495,7 +495,7 @@ PlaneStressUserMaterial::recvSelf(int commitTag, Channel& theChannel, FEM_Object
           return matInfo.setVector(this->getCracking());
 
       default:
-          return -1;
+          return NDMaterial::getResponse(responseID, matInfo);
       }
   }
   //set/getResponse - added by V.K. Papanikolaou [AUTh] - end


### PR DESCRIPTION
@fmckenna @mhscott @jaabell a small bugfix for PlaneStressUserMaterial not forwarding the getResponse method to the base class