### PR TITLE
Fix "ascii art" drawing at the top of the files

### DIFF
--- a/SRC/material/uniaxial/GNGMaterial.cpp
+++ b/SRC/material/uniaxial/GNGMaterial.cpp
@@ -23,9 +23,9 @@
 // Jarrod Cook, University of Canterbury, Christchurch, New Zealand
 
 //	^
-//  |
+//      |
 //	|                ________(3)________
-//  |               /                  /
+//      |               /                  /
 //	F              /                  /
 //	O             /                  /
 //	R            /                  /

--- a/SRC/material/uniaxial/GNGMaterial.h
+++ b/SRC/material/uniaxial/GNGMaterial.h
@@ -23,9 +23,9 @@
 // Jarrod Cook, University of Canterbury, Christchurch, New Zealand
 
 //	^
-//  |
+//      |
 //	|                ________(3)________
-//  |               /                  /
+//      |               /                  /
 //	F              /                  /
 //	O             /                  /
 //	R            /                  /


### PR DESCRIPTION
This PR fixes two little mistakes in the drawing the author uses to explain the stress-strain diagram of this material. 