### PR TITLE
Check for MPI only for OpenSeesMP and OpenSeesSP targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,11 @@ endif()
 
 find_package (Python COMPONENTS Interpreter Development)
 
+if((TARGET OpenSeesMP) OR (TARGET OpenSeesSP))
+  find_package(MPI)
+endif()
 
-find_package(MPI)
+
 find_package(MKL)
 
 #set (LAPACK_FOUND FALSE)


### PR DESCRIPTION
On Linux, when using CMake, if I have the MPI compilers it will set `MPI_FOUND` to `True` which in turn enables looking for Mumps even if my compilation target is `OpenSees` or `OpenSeesPy`. 

So this PR restricts looking for MPI only when the target is `OpenSeesMP` or `OpenSeesSP`.