### PR TITLE
Fixing sendSelf / recvSelf method in some objects

### DIFF
--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -179,6 +179,7 @@
 #include "PlateFiberMaterial.h"
 #include "OrthotropicMaterial.h"
 #include "PlaneStressRebarMaterial.h"
+#include "PlaneStressLayeredMaterial.h"
 //start Yuli Huang & Xinzheng L
 #include "PlateRebarMaterial.h"
 #include "PlateFromPlaneStressMaterial.h"
@@ -1628,6 +1629,9 @@ FEM_ObjectBrokerAllClasses::getNewNDMaterial(int classTag)
 
   case ND_TAG_PlaneStressRebarMaterial:
     return new PlaneStressRebarMaterial();
+
+  case ND_TAG_PlaneStressLayeredMaterial:
+    return new PlaneStressLayeredMaterial();
 
   //start Yuli Huang & Xinzheng 
   case ND_TAG_PlateRebarMaterial:

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -157,6 +157,7 @@
 #include "ElasticPlateSection.h"
 #include "ElasticMembranePlateSection.h"
 #include "MembranePlateFiberSection.h"
+#include "DoubleMembranePlateFiberSection.h"
 #include "Bidirectional.h"
 #include "LayeredShellFiberSection.h" // Yuli Huang & Xinzheng Lu 
 
@@ -1557,6 +1558,9 @@ FEM_ObjectBrokerAllClasses::getNewSection(int classTag)
 
 	case SEC_TAG_MembranePlateFiberSection:
 		return new MembranePlateFiberSection();
+
+	case SEC_TAG_DoubleMembranePlateFiberSection:
+		return new DoubleMembranePlateFiberSection();
 
 	//start Yuli Huang & Xinzheng Lu LayeredShellFiberSection
         case SEC_TAG_LayeredShellFiberSection:

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -174,9 +174,11 @@
 #include "J2BeamFiber3d.h"
 #include "J2AxiSymm.h"
 #include "J2ThreeDimensional.h"
+#include "PlaneStrainMaterial.h"
 #include "PlaneStressMaterial.h"
 #include "PlateFiberMaterial.h"
 #include "OrthotropicMaterial.h"
+#include "PlaneStressRebarMaterial.h"
 //start Yuli Huang & Xinzheng L
 #include "PlateRebarMaterial.h"
 #include "PlateFromPlaneStressMaterial.h"
@@ -1618,8 +1620,14 @@ FEM_ObjectBrokerAllClasses::getNewNDMaterial(int classTag)
   case ND_TAG_PlaneStressMaterial:
     return new PlaneStressMaterial();
 
+  case ND_TAG_PlaneStrainMaterial:
+    return new PlaneStrainMaterial();
+
   case ND_TAG_OrthotropicMaterial:
     return new OrthotropicMaterial();
+
+  case ND_TAG_PlaneStressRebarMaterial:
+    return new PlaneStressRebarMaterial();
 
   //start Yuli Huang & Xinzheng 
   case ND_TAG_PlateRebarMaterial:

--- a/SRC/element/shell/ASDShellQ4.h
+++ b/SRC/element/shell/ASDShellQ4.h
@@ -167,7 +167,7 @@ private:
 
     // nodal ids
     ID m_node_ids = ID(4);
-    Node* nodePointers[4];      //pointers to four nodes -ambaker1
+    Node* nodePointers[4] = { nullptr, nullptr, nullptr, nullptr }; //pointers to four nodes -ambaker1
 
     // coordinate transformation
     ASDShellQ4Transformation* m_transformation = nullptr;
@@ -193,6 +193,9 @@ private:
     Matrix m_KQQ_inv = Matrix(4, 4);
     Matrix m_KQU = Matrix(4, 24); // L = G'*C*B
     Matrix m_KUQ = Matrix(24, 4); // L^T = B'*C'*G
+
+    // initialization flag
+    bool m_initialized = false;
 };
 
 #endif // ASDShellQ4_h

--- a/SRC/element/shell/ASDShellQ4CorotationalTransformation.h
+++ b/SRC/element/shell/ASDShellQ4CorotationalTransformation.h
@@ -119,11 +119,15 @@ public:
         }
     }
 
-    virtual void setDomain(Domain* domain, const ID& node_ids)
+    virtual void setDomain(Domain* domain, const ID& node_ids, bool initialized)
     {
         // call base class setDomain to
         // get nodes and save initial displacements and rotations
-        ASDShellQ4Transformation::setDomain(domain, node_ids);
+        ASDShellQ4Transformation::setDomain(domain, node_ids, initialized);
+
+        // quick return
+        if (domain == nullptr || initialized)
+            return;
 
         // init state variables
         revertToStart();

--- a/SRC/element/shell/ASDShellQ4CorotationalTransformation.h
+++ b/SRC/element/shell/ASDShellQ4CorotationalTransformation.h
@@ -450,7 +450,8 @@ public:
 
         // 9*4 -> 9 quaternions +
         auto lamq = [&v, &pos](QuaternionType& x) {
-            x = QuaternionType(v(pos++), v(pos++), v(pos++), v(pos++));
+            x = QuaternionType(v(pos), v(pos+1), v(pos+2), v(pos+3));
+            pos += 4;
         };
         lamq(m_Q0);
         for (int i = 0; i < 4; i++)

--- a/SRC/element/shell/ASDShellQ4Transformation.h
+++ b/SRC/element/shell/ASDShellQ4Transformation.h
@@ -100,14 +100,14 @@ public:
         }
 
         // get nodes and save initial displacements and rotations
-        if (!initialized) {
-            for (size_t i = 0; i < 4; i++) {
-                m_nodes[i] = domain->getNode(node_ids(i));
-                if (m_nodes[i] == nullptr) {
-                    opserr << "ASDShellQ4Transformation::setDomain - no node " << node_ids(i)
-                        << " exists in the model\n";
-                    exit(-1);
-                }
+        for (size_t i = 0; i < 4; i++) {
+            m_nodes[i] = domain->getNode(node_ids(i));
+            if (m_nodes[i] == nullptr) {
+                opserr << "ASDShellQ4Transformation::setDomain - no node " << node_ids(i)
+                    << " exists in the model\n";
+                exit(-1);
+            }
+            if (!initialized) {
                 const Vector& iU = m_nodes[i]->getTrialDisp();
                 if (iU.Size() != 6) {
                     opserr << "ASDShellQ4Transformation::setDomain - node " << node_ids(i)

--- a/SRC/element/shell/ASDShellQ4Transformation.h
+++ b/SRC/element/shell/ASDShellQ4Transformation.h
@@ -89,25 +89,35 @@ public:
     {
     }
 
-    virtual void setDomain(Domain* domain, const ID& node_ids)
+    virtual void setDomain(Domain* domain, const ID& node_ids, bool initialized)
     {
+        // if domain is null
+        if (domain == nullptr) {
+            for (size_t i = 0; i < 4; i++) {
+                m_nodes[i] = nullptr;
+            }
+            return;
+        }
+
         // get nodes and save initial displacements and rotations
-        for (size_t i = 0; i < 4; i++) {
-            m_nodes[i] = domain->getNode(node_ids(i));
-            if (m_nodes[i] == nullptr) {
-                opserr << "ASDShellQ4Transformation::setDomain - no node " << node_ids(i)
-                    << " exists in the model\n";
-                exit(-1);
+        if (!initialized) {
+            for (size_t i = 0; i < 4; i++) {
+                m_nodes[i] = domain->getNode(node_ids(i));
+                if (m_nodes[i] == nullptr) {
+                    opserr << "ASDShellQ4Transformation::setDomain - no node " << node_ids(i)
+                        << " exists in the model\n";
+                    exit(-1);
+                }
+                const Vector& iU = m_nodes[i]->getTrialDisp();
+                if (iU.Size() != 6) {
+                    opserr << "ASDShellQ4Transformation::setDomain - node " << node_ids(i)
+                        << " has " << iU.Size() << " DOFs, while 6 are expected\n";
+                    exit(-1);
+                }
+                size_t index = i * 6;
+                for (size_t j = 0; j < 6; j++)
+                    m_U0(index + j) = iU(j);
             }
-            const Vector& iU = m_nodes[i]->getTrialDisp();
-            if (iU.Size() != 6) {
-                opserr << "ASDShellQ4Transformation::setDomain - node " << node_ids(i)
-                    << " has " << iU.Size() << " DOFs, while 6 are expected\n";
-                exit(-1);
-            }
-            size_t index = i * 6;
-            for (size_t j = 0; j < 6; j++)
-                m_U0(index + j) = iU(j);
         }
     }
 

--- a/SRC/element/shell/ShellMITC4.h
+++ b/SRC/element/shell/ShellMITC4.h
@@ -193,6 +193,11 @@ class ShellMITC4 : public Element {
     Vector *load;
     Matrix *Ki;
     double init_disp[4][6];
+
+    // Massimo Petracca 2022.
+    // initialization flag: we need this to avoid re-computing
+    // initial displacements if setDomain is called after a recvSelf!
+    bool m_initialzed = false;
 } ; 
 
 

--- a/SRC/element/triangle/Tri31.cpp
+++ b/SRC/element/triangle/Tri31.cpp
@@ -1058,7 +1058,7 @@ Tri31::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 			theMaterial[i]->setDbTag(matDbTag);
 			res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
 			if (res < 0) {
-				opserr << "NLBeamColumn3d::recvSelf() - material " << i << "failed to recv itself\n";
+				opserr << "Tri31::recvSelf() - material " << i << " failed to recv itself\n";
 				return res;
 			}
 		}

--- a/SRC/material/nD/OrthotropicMaterial.h
+++ b/SRC/material/nD/OrthotropicMaterial.h
@@ -49,6 +49,9 @@ public:
 	OrthotropicMaterial();
 	~OrthotropicMaterial();
 
+	// info
+	const char* getClassType(void) const { return "OrthotropicMaterial"; };
+
 	// density
 	double getRho(void);
 

--- a/SRC/material/nD/PlaneStrainMaterial.cpp
+++ b/SRC/material/nD/PlaneStrainMaterial.cpp
@@ -361,7 +361,7 @@ PlaneStrainMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
   theMaterial->setDbTag(idData(2));
 
   // recv a vector containing strains and set the strains
-  static Vector vecData(9);
+  static Vector vecData(3);
   res = theChannel.recvVector(this->getDbTag(), commitTag, vecData);
   if (res < 0) {
       opserr << "PlaneStrainMaterial::recvSelf() - failed to recv vector data\n";

--- a/SRC/material/nD/PlaneStrainMaterial.cpp
+++ b/SRC/material/nD/PlaneStrainMaterial.cpp
@@ -74,6 +74,7 @@ Matrix  PlaneStrainMaterial::tangent(3,3) ;
 //null constructor
 PlaneStrainMaterial::PlaneStrainMaterial( ) : 
 NDMaterial(0, ND_TAG_PlaneStrainMaterial ), 
+theMaterial(nullptr),
 strain(3) 
 { }
 
@@ -310,6 +311,18 @@ PlaneStrainMaterial::sendSelf(int commitTag, Channel &theChannel)
     return res;
   }
 
+  // put the strains in a vector and send it
+  static Vector vecData(3);
+  vecData(0) = strain(0);
+  vecData(1) = strain(1);
+  vecData(2) = strain(2);
+
+  res = theChannel.sendVector(this->getDbTag(), commitTag, vecData);
+  if (res < 0) {
+      opserr << "PlaneStrainMaterial::sendSelf() - failed to send vector data\n";
+      return res;
+  }
+
   // now send the materials data
   res = theMaterial->sendSelf(commitTag, theChannel);
   if (res < 0) 
@@ -327,7 +340,7 @@ PlaneStrainMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
   static ID idData(3);
   res = theChannel.recvID(this->getDbTag(), commitTag, idData);
   if (res < 0) {
-    opserr << "PlaneStrainMaterial::sendSelf() - failed to send id data\n";
+    opserr << "PlaneStrainMaterial::recvSelf() - failed to recv id data\n";
     return res;
   }
 
@@ -347,10 +360,21 @@ PlaneStrainMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBrok
   }
   theMaterial->setDbTag(idData(2));
 
+  // recv a vector containing strains and set the strains
+  static Vector vecData(9);
+  res = theChannel.recvVector(this->getDbTag(), commitTag, vecData);
+  if (res < 0) {
+      opserr << "PlaneStrainMaterial::recvSelf() - failed to recv vector data\n";
+      return res;
+  }
+  strain(0) = vecData(0);
+  strain(1) = vecData(1);
+  strain(2) = vecData(2);
+
   // now receive the materials data
   res = theMaterial->recvSelf(commitTag, theChannel, theBroker);
   if (res < 0) 
-    opserr << "PlaneStrainMaterial::sendSelf() - failed to send vector material\n";
+    opserr << "PlaneStrainMaterial::recvSelf() - failed to recv vector material\n";
   
   return res;
 }

--- a/SRC/material/nD/PlateFromPlaneStressMaterial.cpp
+++ b/SRC/material/nD/PlateFromPlaneStressMaterial.cpp
@@ -358,7 +358,7 @@ PlateFromPlaneStressMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_O
 
   this->setTag(idData(0));
   int matClassTag = idData(1);
-  if (theMat->getClassTag() != matClassTag) {
+  if (theMat == nullptr || theMat->getClassTag() != matClassTag) {
     if (theMat != 0) delete theMat;
     theMat = theBroker.getNewNDMaterial(matClassTag);
     if (theMat == 0) {

--- a/SRC/material/nD/PlateFromPlaneStressMaterial.cpp
+++ b/SRC/material/nD/PlateFromPlaneStressMaterial.cpp
@@ -86,7 +86,7 @@ void* OPS_PlateFromPlaneStressMaterial()
 //null constructor
 PlateFromPlaneStressMaterial::PlateFromPlaneStressMaterial( ) : 
 NDMaterial(0, ND_TAG_PlateFromPlaneStressMaterial ), 
-strain(5) 
+theMat(nullptr), strain(5), gmod(0.0)
 { }
 
 

--- a/SRC/material/nD/PlateRebarMaterial.cpp
+++ b/SRC/material/nD/PlateRebarMaterial.cpp
@@ -45,7 +45,7 @@ Matrix  PlateRebarMaterial::tangent(5,5) ;
 //null constructor
 PlateRebarMaterial::PlateRebarMaterial( ) : 
 NDMaterial(0, ND_TAG_PlateRebarMaterial ), 
-strain(5) 
+theMat(nullptr), angle(0.0), c(0.0), s(0.0), strain(5) 
 { }
 
 void* OPS_PlateRebarMaterial()
@@ -331,7 +331,7 @@ PlateRebarMaterial::sendSelf(int commitTag, Channel &theChannel)
 
   res = theChannel.sendID(dataTag, commitTag, idData);
   if (res < 0) {
-    opserr << "PlateRebarMaterial::sendSelf() - failed to send data" << endln;
+    opserr << "PlateRebarMaterial::sendSelf() - failed to send ID" << endln;
     return res;
   }
 
@@ -340,14 +340,14 @@ PlateRebarMaterial::sendSelf(int commitTag, Channel &theChannel)
 
   res = theChannel.sendVector(dataTag, commitTag, vecData);
   if (res < 0) {
-    opserr << "PlateRebarMaterial::sendSelf() - failed to send data" << endln;
+    opserr << "PlateRebarMaterial::sendSelf() - failed to send Vector" << endln;
     return res;
   }
 
   // now send the materials data
   res += theMat->sendSelf(commitTag, theChannel);
   if (res < 0) 
-    opserr << "PlateRebarMaterial::sendSelf() - failed to send material1" << endln;
+    opserr << "PlateRebarMaterial::sendSelf() - failed to send material" << endln;
 
   return res;
 }
@@ -363,13 +363,13 @@ PlateRebarMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroke
   static ID idData(3);
   res = theChannel.recvID(dataTag, commitTag, idData);
   if (res < 0) {
-    opserr << "PlateRebarMaterial::sendSelf() - failed to receive id data" << endln;
+    opserr << "PlateRebarMaterial::sendSelf() - failed to receive ID" << endln;
     return res;
   }
 
   this->setTag(idData(0));
   int matClassTag = idData(1);
-  if (theMat->getClassTag() != matClassTag) {
+  if (theMat == nullptr || theMat->getClassTag() != matClassTag) {
     if (theMat != 0) delete theMat;
     theMat = theBroker.getNewUniaxialMaterial(matClassTag);
     if (theMat == 0) {
@@ -382,7 +382,7 @@ PlateRebarMaterial::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroke
   static Vector vecData(1);
   res = theChannel.recvVector(dataTag, commitTag, vecData);
   if (res < 0) {
-    opserr << "PlateRebarMaterial::sendSelf() - failed to receive vector data" << endln;
+    opserr << "PlateRebarMaterial::sendSelf() - failed to receive Vector" << endln;
     return res;
   }
   angle = vecData(0);


### PR DESCRIPTION
@mhscott @jaabell 

Following the suggestion given by @mhscott here [an-openseesspecial-request](https://portwooddigital.com/2022/08/21/an-openseesspecial-request/), I started checking materials, sections, and elements' behavior in the sendSelf/recvSelf methods.

In this PR I started with shell elements, shell sections, and material wrappers. In future PRs I'll periodically check other objects.

Some recurring issues I found are (it might be useful for others):

- In elements (like shells) that compute the initial displacement in the setDomain method, we need to make sure there is an "is_initialized" flag, otherwise, the setDomain method called after the recvSelf will erroneously override the initial displacement.
- Many objects do not initialize pointers to NULL in the default (empty) constructor. This will lead to false-checks in statements like (if(theMat) theMat->doSomething()) in the recvSelf method
- arrays (allocated with new[]) are sometimes deleted with delete instead of delete[]
