### PR TITLE
Error handling with responseSpectrum command

### DIFF
--- a/SRC/analysis/analysis/ResponseSpectrumAnalysis.cpp
+++ b/SRC/analysis/analysis/ResponseSpectrumAnalysis.cpp
@@ -86,7 +86,12 @@ OPS_ResponseSpectrumAnalysis(void)
 	double scale = 1.0;
 
 	// make sure eigenvalue and modal properties have been called before
-	const auto& modal_props = theAnalysisModel->getDomainPtr()->getModalProperties();
+	//const auto& modal_props = theAnalysisModel->getDomainPtr()->getModalProperties();
+	DomainModalProperties modal_props;
+	if (theAnalysisModel->getDomainPtr()->getModalProperties(modal_props) < 0) {
+	  opserr << "OPS_ResponseSpectrumAnalysis - eigen and modalProperties have not been called" << endln;
+	  return -1;
+	}
 	int ndf = modal_props.totalMass().Size();
 
 	// parse
@@ -190,7 +195,12 @@ void ResponseSpectrumAnalysis::analyze()
 	Domain* domain = m_model->getDomainPtr();
 
 	// get the modal properties
-	const DomainModalProperties& mp = domain->getModalProperties();
+	//const DomainModalProperties& mp = domain->getModalProperties();
+	DomainModalProperties mp;
+	if (domain->getModalProperties(mp) < 0) {
+	  opserr << "ResponseSpectrumAnalysis::analyze() - failed to get modal properties" << endln;
+	  return;
+	}
 
 	// size info
 	int num_eigen = domain->getEigenvalues().Size();
@@ -227,7 +237,12 @@ void ResponseSpectrumAnalysis::analyze(int mode_id)
 	Domain* domain = m_model->getDomainPtr();
 
 	// get the modal properties
-	const DomainModalProperties& mp = domain->getModalProperties();
+	//const DomainModalProperties& mp = domain->getModalProperties();
+	DomainModalProperties mp;
+	if (domain->getModalProperties(mp) < 0) {
+	  opserr << "ResponseSpectrumAnalysis::analyze(mode_id) - failed to get modal properties" << endln;
+	  return;
+	}
 
 	// size info
 	int num_eigen = domain->getEigenvalues().Size();
@@ -257,8 +272,13 @@ void ResponseSpectrumAnalysis::check()
 	Domain* domain = m_model->getDomainPtr();
 
 	// get the modal properties
-	const DomainModalProperties& mp = domain->getModalProperties();
-
+	//const DomainModalProperties& mp = domain->getModalProperties();
+	DomainModalProperties mp;
+	if (domain->getModalProperties(mp) < 0) {
+	  opserr << "ResponseSpectrumAnalysis::check() - failed to get modal properties" << endln;
+	  return;
+	}
+	
 	// number of eigen-modes
 	int num_eigen = domain->getEigenvalues().Size();
 	if (num_eigen < 1)
@@ -320,8 +340,13 @@ void ResponseSpectrumAnalysis::solveMode()
 	Domain* domain = m_model->getDomainPtr();
 
 	// get the modal properties
-	const DomainModalProperties& mp = domain->getModalProperties();
-
+	//const DomainModalProperties& mp = domain->getModalProperties();
+	DomainModalProperties mp;
+	if (domain->getModalProperties(mp) < 0) {
+	  opserr << "ResponseSpectrumAnalysis::solveMode() - failed to get modal properties" << endln;
+	  return;
+	}
+	
 	// size info
 	int ndf = mp.totalMass().Size();
 

--- a/SRC/domain/domain/Domain.cpp
+++ b/SRC/domain/domain/Domain.cpp
@@ -2225,13 +2225,16 @@ void Domain::unsetModalProperties(void)
     }
 }
 
-const DomainModalProperties& Domain::getModalProperties(void) const
+int Domain::getModalProperties(DomainModalProperties &dmp) const
 {
     if (theModalProperties == 0) {
-        opserr << "Domain::getModalProperties - DomainModalProperties were never set\n";
-        exit(-1);
+      opserr << "Domain::getModalProperties - DomainModalProperties were never set" << endln;
+      return -1;
     }
-    return *theModalProperties;
+    else {
+      dmp = *theModalProperties;
+      return 0;
+    }
 }
 
 int

--- a/SRC/domain/domain/Domain.h
+++ b/SRC/domain/domain/Domain.h
@@ -201,7 +201,7 @@ class Domain
     virtual double getTimeEigenvaluesSet(void);
     void setModalProperties(const DomainModalProperties& dmp);
     void unsetModalProperties(void);
-    const DomainModalProperties& getModalProperties(void) const;
+    int getModalProperties(DomainModalProperties & dmp) const;
     int setModalDampingFactors(Vector *, bool inclModalMatrix = false);
     const Vector *getModalDampingFactors(void);
     bool inclModalDampingMatrix(void);


### PR DESCRIPTION
Sudden termination (dead kernels) via exit(-1) if modalProperties has not been called prior to responseSpectrum.
Modified the Domain::getModalProperties() method to return 0 (success) or -1 (error).
Tested on simple OpenSeesPy example and no weird side effects.
We'll wait for @MassimoPetracca's approval to merge.