### PR TITLE
Update Response Spectrum Analysis to use also Lists as input for Tn and Sa

### DIFF
--- a/SRC/analysis/analysis/ResponseSpectrumAnalysis.cpp
+++ b/SRC/analysis/analysis/ResponseSpectrumAnalysis.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>
+#include <string>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -51,6 +52,45 @@
 #define NOMINMAX
 #endif
 #endif
+
+namespace {
+
+	bool string_to_list_of_doubles(const std::string& text, char sep, std::vector<double>& out) {
+		auto to_double = [](const std::string & text, double& num) -> bool {
+			num = 0.0;
+			try {
+				num = std::stod(text);
+				return true;
+			}
+			catch (...) {
+				return false;
+			}
+		};
+		if (out.size() > 0) out.clear();
+		std::size_t start = 0, end = 0;
+		double value;
+		while (true) {
+			end = text.find(sep, start);
+			if (end == std::string::npos) {
+				if (start < text.size()) {
+					if (!to_double(text.substr(start), value))
+						return false;
+					out.push_back(value);
+				}
+				break;
+			}
+			std::string subs = text.substr(start, end - start);
+			if (subs.size() > 0) {
+				if (!to_double(subs, value))
+					return false;
+				out.push_back(value);
+			}
+			start = end + 1;
+		}
+		return true;
+	}
+
+}
 
 int
 OPS_ResponseSpectrumAnalysis(void)
@@ -79,6 +119,10 @@ OPS_ResponseSpectrumAnalysis(void)
 	TimeSeries* ts = nullptr;
 	int dir = 1;
 	double scale = 1.0;
+	std::vector<double> Tn;
+	std::vector<double> Sa;
+	int mode_id = 0;
+	bool single_mode = false;
 
 	// make sure eigenvalue and modal properties have been called before
 	DomainModalProperties modal_props;
@@ -92,20 +136,52 @@ OPS_ResponseSpectrumAnalysis(void)
 	int nargs = OPS_GetNumRemainingInputArgs();
 	if (nargs < 2) {
 		opserr << "ResponseSpectrumAnalysis $tsTag $dir <-scale $scale> <-damp $damp>\n"
+			<< "or\n"
+			<< "ResponseSpectrumAnalysis $dir -Tn $TnValues -Sa $SaValues <-scale $scale> <-damp $damp>\n"
 			"Error: at least 2 arguments should be provided.\n";
 		return -1;
 	}
+
+	// search for -Tn -Sa, if both found we use them as lists
+	// otherwise we fallback to the old implementation of the timeSeries
+	bool found_Tn = false;
+	bool found_Sa = false;
+	while (OPS_GetNumRemainingInputArgs() > 0) {
+		const char* arg = OPS_GetString();
+		if (!found_Tn && strcmp(arg, "-Tn") == 0)
+			found_Tn = true;
+		if (!found_Sa && strcmp(arg, "-Sa") == 0)
+			found_Sa = true;
+	}
+	bool use_lists = found_Tn && found_Sa;
+	if (found_Tn && !found_Sa) {
+		opserr << "ResponseSpectrumAnalysis Error: found -Tn but not -Sa, please specify both of them or use a timeSeries\n";
+		return -1;
+	}
+	if (found_Sa && !found_Tn) {
+		opserr << "ResponseSpectrumAnalysis Error: found -Sa but not -Tn, please specify both of them or use a timeSeries\n";
+		return -1;
+	}
+	OPS_ResetCurrentInputArg(-nargs);
+
+	// num data
 	int numData = 1;
-	int tstag;
-	if (OPS_GetInt(&numData, &tstag) < 0) {
-		opserr << "ResponseSpectrumAnalysis Error: Failed to get timeSeries tag.\n";
-		return -1;
+
+	// get time series
+	if (!use_lists) {
+		int tstag;
+		if (OPS_GetInt(&numData, &tstag) < 0) {
+			opserr << "ResponseSpectrumAnalysis Error: Failed to get timeSeries tag.\n";
+			return -1;
+		}
+		ts = OPS_getTimeSeries(tstag);
+		if (ts == nullptr) {
+			opserr << "ResponseSpectrumAnalysis Error: Failed to get timeSeries with tag = " << tstag << ".\n";
+			return -1;
+		}
 	}
-	ts = OPS_getTimeSeries(tstag);
-	if (ts == nullptr) {
-		opserr << "ResponseSpectrumAnalysis Error: Failed to get timeSeries with tag = " << tstag << ".\n";
-		return -1;
-	}
+
+	// get direction
 	if (OPS_GetInt(&numData, &dir) < 0) {
 		opserr << "ResponseSpectrumAnalysis Error: Failed to get direction.\n";
 		return -1;
@@ -116,19 +192,14 @@ OPS_ResponseSpectrumAnalysis(void)
 	}
 
 	// parse optional data
-	nargs = OPS_GetNumRemainingInputArgs();
-	int loc = 0;
-	int mode_id = 0;
-	bool single_mode = false;
-	while (loc < nargs) {
+	while (OPS_GetNumRemainingInputArgs() > 0) {
 		const char* value = OPS_GetString();
 		if (strcmp(value, "-scale") == 0) {
-			if (loc < nargs - 1) {
+			if (OPS_GetNumRemainingInputArgs() > 0) {
 				if (OPS_GetDouble(&numData, &scale) < 0) {
 					opserr << "ResponseSpectrumAnalysis Error: Failed to get scale factor.\n";
 					return -1;
 				}
-				++loc;
 			}
 			else {
 				opserr << "ResponseSpectrumAnalysis Error: scale factor requested but not provided.\n";
@@ -136,26 +207,92 @@ OPS_ResponseSpectrumAnalysis(void)
 			}
 		}
 		else if (strcmp(value, "-mode") == 0) {
-			if (loc < nargs - 1) {
+			if (OPS_GetNumRemainingInputArgs() > 0) {
 				if (OPS_GetInt(&numData, &mode_id) < 0) {
 					opserr << "ResponseSpectrumAnalysis Error: Failed to get the mode_id.\n";
 					return -1;
 				}
 				--mode_id; // make it 0-based
 				single_mode = true;
-				++loc;
 			}
 			else {
 				opserr << "ResponseSpectrumAnalysis Error: mode_id requested but not provided.\n";
 				return -1;
 			}
 		}
-		++loc;
+		else if (strcmp(value, "-Tn") == 0) {
+			// first try expanded list like {*}$the_list,
+			// also used in python like *the_list
+			Tn.clear();
+			while (OPS_GetNumRemainingInputArgs() > 0) { 
+				double item;
+				if (OPS_GetDoubleInput(&numData, &item) < 0) {
+					break;
+				}
+				Tn.push_back(item);
+			}
+			// try Tcl list (it's a string after all...)
+			if (Tn.size() == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+				std::string list_string = OPS_GetString();
+				if (!string_to_list_of_doubles(list_string, ' ', Tn)) {
+					opserr << "ResponseSpectrumAnalysis Error: cannot part the Tn list.\n";
+					return -1;
+				}
+			}
+		}
+		else if (strcmp(value, "-Sa") == 0) {
+			// first try expanded list like {*}$the_list,
+			// also used in python like *the_list
+			Sa.clear();
+			while (OPS_GetNumRemainingInputArgs() > 0) {
+				double item;
+				if (OPS_GetDoubleInput(&numData, &item) < 0) {
+					break;
+				}
+				Sa.push_back(item);
+			}
+			// try Tcl list (it's a string after all...)
+			if (Sa.size() == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+				std::string list_string = OPS_GetString();
+				if (!string_to_list_of_doubles(list_string, ' ', Sa)) {
+					opserr << "ResponseSpectrumAnalysis Error: cannot part the Sa list.\n";
+					return -1;
+				}
+			}
+		}
+	}
+
+	// check Tn and Sa vectors
+	if (use_lists) {
+		if (Tn.size() != Sa.size()) {
+			opserr << "ResponseSpectrumAnalysis Error: Sa and Tn lists must have the same length\n";
+			return -1;
+		}
+		if (Tn.size() == 0) {
+			opserr << "ResponseSpectrumAnalysis Error: Sa and Tn lists cannot be empty\n";
+			return -1;
+		}
+		for (std::size_t i = 0; i < Tn.size(); ++i) {
+			if (Tn[i] < 0.0) {
+				opserr << "ResponseSpectrumAnalysis Error: Tn values must be positive (found " << Tn[i] << ")\n";
+				return -1;
+			}
+			if (i > 0 && Tn[i] <= Tn[i-1]) {
+				opserr << "ResponseSpectrumAnalysis Error: Tn values must be monotonically increasing (found " << Tn[i] << " after " << Tn[i-1] << ")\n";
+				return -1;
+			}
+		}
+		for (double item : Sa) {
+			if (item < 0.0) {
+				opserr << "ResponseSpectrumAnalysis Error: Sa values must be positive (found " << item << ")\n";
+				return -1;
+			}
+		}
 	}
 
 	// ok, create the response spectrum analysis and run it here... 
 	// no need to store it
-	ResponseSpectrumAnalysis rsa(theAnalysisModel, ts, dir, scale);
+	ResponseSpectrumAnalysis rsa(theAnalysisModel, ts, Tn, Sa, dir, scale);
 	int result;
 	if (single_mode)
 		result = rsa.analyze(mode_id);
@@ -168,11 +305,15 @@ OPS_ResponseSpectrumAnalysis(void)
 ResponseSpectrumAnalysis::ResponseSpectrumAnalysis(
 	AnalysisModel* theModel,
 	TimeSeries* theFunction,
+	const std::vector<double>& Tn,
+	const std::vector<double>& Sa,
 	int theDirection,
 	double scale
 )
 	: m_model(theModel)
 	, m_function(theFunction)
+	, m_Tn(Tn)
+	, m_Sa(Sa)
 	, m_direction(theDirection)
 	, m_scale(scale)
 	, m_current_mode(0)
@@ -379,7 +520,7 @@ int ResponseSpectrumAnalysis::solveMode()
 	double omega = std::sqrt(lambda);
 	double freq = omega / 2.0 / M_PI;
 	double period = 1.0 / freq;
-	double mga = m_function->getFactor(period);
+	double mga = getSa(period);
 	double Vscale = mp.eigenVectorScaleFactors()(m_current_mode);
 	double MPF = mp.modalParticipationFactors()(m_current_mode, exdof);
 
@@ -416,5 +557,39 @@ int ResponseSpectrumAnalysis::solveMode()
 	}
 
 	return 0;
+}
+
+double ResponseSpectrumAnalysis::getSa(double T) const
+{
+	// use the time series if provided
+	if (m_function) 
+		return m_function->getFactor(T);
+	// otherwise use the vectors
+	std::size_t n = m_Tn.size();
+	// check empty
+	if (n < 1)
+		return 0.0;
+	// check constant
+	if (n == 1)
+		return m_Sa[0];
+	// check bounds
+	if (T <= m_Tn.front())
+		return m_Sa.front();
+	if (T >= m_Tn.back())
+		return m_Sa.back();
+	// interpolate
+	for (std::size_t i = 1; i < n; ++i) {
+		double t1 = m_Tn[i];
+		if (T <= t1) {
+			double t0 = m_Tn[i - 1];
+			double s1 = m_Sa[i];
+			double s0 = m_Sa[i - 1];
+			double dT = t1 - t0;
+			double dS = s1 - s0;
+			double scale = dT > 0.0 ? (T - t0) / dT : 0.5;
+			return s0 + scale * dS;
+		}
+	}
+	return m_Sa.back();
 }
 

--- a/SRC/analysis/analysis/ResponseSpectrumAnalysis.h
+++ b/SRC/analysis/analysis/ResponseSpectrumAnalysis.h
@@ -48,14 +48,14 @@ public:
 	~ResponseSpectrumAnalysis();
 
 public:
-	void analyze();
-	void analyze(int mode_id);
+	int analyze();
+	int analyze(int mode_id);
 
 private:
-	void check();
-	void beginMode();
-	void endMode();
-	void solveMode();
+	int check();
+	int beginMode();
+	int endMode();
+	int solveMode();
 
 private:
 	// the model

--- a/SRC/analysis/analysis/ResponseSpectrumAnalysis.h
+++ b/SRC/analysis/analysis/ResponseSpectrumAnalysis.h
@@ -33,6 +33,7 @@
 #ifndef ResponseSpectrumAnalysis_h
 #define ResponseSpectrumAnalysis_h
 
+#include <vector>
 class AnalysisModel;
 class TimeSeries;
 
@@ -42,6 +43,8 @@ public:
 	ResponseSpectrumAnalysis(
 		AnalysisModel* theModel,
 		TimeSeries* theFunction,
+		const std::vector<double>& Tn,
+		const std::vector<double>& Sa,
 		int theDirection,
 		double scale
 	);
@@ -56,12 +59,15 @@ private:
 	int beginMode();
 	int endMode();
 	int solveMode();
+	double getSa(double T) const;
 
 private:
 	// the model
 	AnalysisModel* m_model;
 	// the response spectrum function
 	TimeSeries* m_function;
+	std::vector<double> m_Tn;
+	std::vector<double> m_Sa;
 	// the direction 1 to 3 (for 2D models) or 1 to 6 (for 3D models)
 	int m_direction;
 	// the scale factor for the computed displacement field

--- a/SRC/domain/domain/DomainModalProperties.cpp
+++ b/SRC/domain/domain/DomainModalProperties.cpp
@@ -714,7 +714,7 @@ bool DomainModalProperties::compute(Domain* domain)
             }
         }
     };
-    if (ndf == 3 == ndf == 6) {
+    if (ndf == 3 || ndf == 6) {
         compute_extra_rotary_mass(ML);
         compute_extra_rotary_mass(MLfree);
     }

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -581,7 +581,7 @@ static PyObject* Py_ops_modalProperties(PyObject* self, PyObject* args)
     return wrapper->getResults();
 }
 
-static PyObject* Py_ops_responseSpectrum(PyObject* self, PyObject* args)
+static PyObject* Py_ops_responseSpectrumAnalysis(PyObject* self, PyObject* args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
     if (OPS_ResponseSpectrumAnalysis() < 0) {
@@ -2771,7 +2771,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("nodeReaction", &Py_ops_nodeReaction);
     addCommand("eigen", &Py_ops_eigen);
     addCommand("modalProperties", &Py_ops_modalProperties);
-    addCommand("responseSpectrum", &Py_ops_responseSpectrum);
+    addCommand("responseSpectrumAnalysis", &Py_ops_responseSpectrumAnalysis);
     addCommand("nDMaterial", &Py_ops_nDMaterial);
     addCommand("block2D", &Py_ops_block2d);
     addCommand("block3D", &Py_ops_block3d);

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -908,7 +908,7 @@ int OpenSeesAppInit(Tcl_Interp *interp) {
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);       
     Tcl_CreateCommand(interp, "modalProperties", &modalProperties,
         (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
-    Tcl_CreateCommand(interp, "responseSpectrum", &responseSpectrum,
+    Tcl_CreateCommand(interp, "responseSpectrumAnalysis", &responseSpectrumAnalysis,
         (ClientData)NULL, (Tcl_CmdDeleteProc*)NULL);
     Tcl_CreateCommand(interp, "video", &videoPlayer, 
 		      (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL);       
@@ -5762,7 +5762,7 @@ modalProperties(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** 
 }
 
 int
-responseSpectrum(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
+responseSpectrumAnalysis(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv)
 {
     OPS_ResetInputNoBuilder(clientData, interp, 1, argc, argv, &theDomain);
     if (OPS_ResponseSpectrumAnalysis() < 0)

--- a/SRC/tcl/commands.h
+++ b/SRC/tcl/commands.h
@@ -133,7 +133,7 @@ int
 modalProperties(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
 
 int
-responseSpectrum(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
+responseSpectrumAnalysis(ClientData clientData, Tcl_Interp* interp, int argc, TCL_Char** argv);
 
 int 
 videoPlayer(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv);


### PR DESCRIPTION
@mhscott Here's the PR for improving the RSA command as discussed in #1008 .

- I removed all `exit(-1)` in favor of a returned (int) error code.
- I fixed a small bug introduced in domainModalProperties while allowing ndm=1
- changed the name from **responseSpectrum** to **responseSpectrumAnalysis**
- the command can now accept a timeSeries (as before) for the Tn/Sa pairs, or lists for Tn and Sa. In Tcl it can be both `-Tn $Tn -Sa $Sa` or `-Tn {*}$Tn -Sa {*}$Sa`, in Python it can be `'-Tn', *Tn, '-Sa', *Sa`

I will update the documentation soon