### PR TITLE
ComponentElement2D JSON output.

### DIFF
--- a/SRC/element/componentElement/ComponentElement2d.cpp
+++ b/SRC/element/componentElement/ComponentElement2d.cpp
@@ -875,6 +875,15 @@ ComponentElement2d::Print(OPS_Stream &s, int flag)
       s << "\"A\": " << A << ", ";
       s << "\"Iz\": " << I << ", ";
       s << "\"massperlength\": " << rho << ", ";
+      s << "\"materials\": [" ;
+      if (end1Hinge) 
+        s << "\"" << end1Hinge->getTag() << "\", ";
+      else
+        s << "null, ";
+      if (end2Hinge) 
+        s << "\"" << end2Hinge->getTag() << "\"], ";
+      else
+        s << "null], ";
       s << "\"crdTransformation\": \"" << theCoordTransf->getTag() << "\"}";
   }
 }


### PR DESCRIPTION
The JSON output for `ComponentElement2D` has been updated to include a `"materials"` field
which holds the tags of it's constitutive materials. The field name was chosen to match that of the zero-length elements.