### PR TITLE
Fixing a bug: setParameter backward compatibility issue after recent commit

### DIFF
--- a/SRC/domain/component/ElementStateParameter.cpp
+++ b/SRC/domain/component/ElementStateParameter.cpp
@@ -27,12 +27,12 @@
 #include <Channel.h>
 #include <Message.h>
 
-ElementStateParameter::ElementStateParameter(double value, 
+ElementStateParameter::ElementStateParameter(int tag, double value, 
 					     const char **Argv, 
 					     int Argc, 
 					     int Flag, 
 					     ID *theEle)
-  :Parameter(0,PARAMETER_TAG_ElementStateParameter),
+  :Parameter(tag,PARAMETER_TAG_ElementStateParameter),
    currentValue(value),
    flag(Flag),
    argc(Argc), fromFree(1)
@@ -149,13 +149,14 @@ ElementStateParameter::setDomain(Domain *theDomain)
 int 
 ElementStateParameter::sendSelf(int commitTag, Channel &theChannel)
 {
-  static ID iData(3);
+  static ID iData(4);
   iData(0) = flag;
   iData(1) = argc;
   if (theEleIDs != 0)
     iData(2) = theEleIDs->Size();
   else
     iData(2) = 0;
+  iData(3) = getTag();
 
   theChannel.sendID(commitTag, 0, iData);
 
@@ -183,12 +184,12 @@ ElementStateParameter::sendSelf(int commitTag, Channel &theChannel)
 int 
 ElementStateParameter::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
-  static ID iData(3);
+  static ID iData(4);
   theChannel.recvID(commitTag, 0, iData);
   flag = iData(0);
   argc = iData(1);
   int numEle = iData(2);
-
+  setTag(iData(3));
 
   static Vector dData(1);
   theChannel.recvVector(commitTag, 0, dData);

--- a/SRC/domain/component/ElementStateParameter.h
+++ b/SRC/domain/component/ElementStateParameter.h
@@ -33,7 +33,7 @@ class Domain;
 class ElementStateParameter : public Parameter
 {
  public:
-  ElementStateParameter(double value, 
+  ElementStateParameter(int tag, double value, 
 			const char **argv, 
 			int argc, 
 			int flag, 

--- a/SRC/interpreter/OpenSeesParameterCommands.cpp
+++ b/SRC/interpreter/OpenSeesParameterCommands.cpp
@@ -636,12 +636,23 @@ int OPS_setParameter() {
 
   if (argv.empty()) return 0;
 
-  ElementStateParameter theParameter(newValue, &argv[0], (int)argv.size(),
+  Domain* theDomain = OPS_GetDomain();
+  if (theDomain == 0) return 0;
+
+  int tempParamId = 0;
+  Parameter* tempParam;
+  ParameterIter& tempParamIter = theDomain->getParameters();
+  while ((tempParam = tempParamIter()) != 0) {
+      if (tempParam->getTag() > tempParamId)
+          tempParamId = tempParam->getTag();
+  }
+  ++tempParamId;
+  ElementStateParameter theParameter(tempParamId, newValue, &argv[0], (int)argv.size(),
                                      flag, &eleIDs);
 
-  Domain *theDomain = OPS_GetDomain();
-  if (theDomain == 0) return 0;
+  
   theDomain->addParameter(&theParameter);
+  theDomain->removeParameter(tempParamId);
 
   return 0;
 }

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -10551,9 +10551,17 @@ setParameter(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **arg
       argLoc += 3;
     }
 
-    ElementStateParameter theParameter(newValue, &argv[argLoc], argc-argLoc, flag, &eleIDs);
-
+    int tempParamId = 0;
+    Parameter* tempParam;
+    ParameterIter& tempParamIter = theDomain.getParameters();
+    while ((tempParam = tempParamIter()) != 0) {
+        if (tempParam->getTag() > tempParamId)
+            tempParamId = tempParam->getTag();
+    }
+    ++tempParamId;
+    ElementStateParameter theParameter(tempParamId, newValue, &argv[argLoc], argc-argLoc, flag, &eleIDs);
     theDomain.addParameter(&theParameter);
+    theDomain.removeParameter(tempParamId);
   }
 
   return TCL_OK;


### PR DESCRIPTION
@mhscott here's the PR related to the issue #1072 

After the recent commit https://github.com/OpenSees/OpenSees/commit/b15a2e575f9442e0f5f57bca32f92d858547f288, the ElementStateParameter was added to the domain the first time with a tag = 0.

The second time "setParameter" is called, it will be ignored because a parameter with tag = 0 already exists.
However, it also generated a seg-fault in the wipeModel, because the ElementStateParameter was added to the domain, but in the setParameter command, the ElementStateParameter is passed as a pointer to a temporary.

Now it is fixed (in both Python and Tcl) just by:

1. generating a temporary TAG for the new parameter
2. removing the parameter before exiting the command.

To do so, however, I had to do a minor change to the ElementStateParameter class, because it did not accept a tag in the constructor