### PR TITLE
Changing modalDamping and modalDampingQ input behavior

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -2910,8 +2910,8 @@ int OPS_modalDamping()
 
     int numModes = OPS_GetNumRemainingInputArgs();
     if (numModes != 1 && numModes != numEigen) {
-      opserr << "WARNING modalDamping - same #damping factors as modes must be specified\n";
-      opserr << "                     - same damping ratio will be applied to all modes\n";
+      opserr << "WARNING modalDamping - fewer damping factors than modes were specified\n";
+      opserr << "                     - zero damping will be applied to un-specified modes\n";
     }
 
     double factor;
@@ -2921,14 +2921,16 @@ int OPS_modalDamping()
     //
     // read in values and set factors
     //
-    if (numModes == numEigen) {
-      for (int i = 0; i < numEigen; i++) {
+    if (numModes <= numEigen) {
+      for (int i = 0; i < numModes; i++) {
 	if (OPS_GetDoubleInput(&numdata, &factor) < 0) {
 	  opserr << "WARNING modalDamping - could not read factor for mode " << i+1 << endln;
 	  return -1;
 	}
 	modalDampingValues(i) = factor;
       }
+      for (int i = numModes; i < numEigen; i++)
+	modalDampingValues(i) = 0.0;
     } else {
       if (OPS_GetDoubleInput(&numdata, &factor) < 0) {
 	opserr << "WARNING modalDamping - could not read factor for all modes \n";

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -8733,40 +8733,42 @@ modalDamping(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **arg
   double factor;
   Vector modalDampingValues(numEigen);
 
-  if (numModes != 1 && numModes != numEigen) {
-    opserr << "WARNING modalDamping - same #damping factors as modes must be specified\n";
-    opserr << "                     - same damping ratio will be applied to all\n";
+  if (numModes != 1 && numModes < numEigen) {
+    opserr << "WARNING modalDamping - fewer damping factors than modes were specified\n";
+    opserr << "                     - zero damping will be applied to un-specified modes" << endln;
   }
+  if (numModes > numEigen) {
+    opserr << "WARNING modalDamping - more damping factors than modes were specifed\n";
+    opserr << "                     - ignoring additional damping factors" << endln;
+  }    
 
   // 
   // read in values and set factors
   //
 
-  if (numModes == numEigen) {
-
-    for (int i=0; i<numEigen; i++) {
+  if (numModes == 1) {
+    if (Tcl_GetDouble(interp, argv[1], &factor) != TCL_OK) {
+      opserr << "WARNING modalDamping - could not read factor for all modes \n";
+      return TCL_ERROR;	        
+    }        
+    
+    for (int i=0; i<numEigen; i++)
+      modalDampingValues[i] = factor;
+  }
+  else {
+    for (int i=0; i<numModes; i++) {
       if (Tcl_GetDouble(interp, argv[1+i], &factor) != TCL_OK) {
 	opserr << "WARNING modalDamping - could not read factor for model " << i+1 << endln;
 	return TCL_ERROR;	        
       }        
       modalDampingValues[i] = factor;    
     } 
-
-  } else {
-
-    if (Tcl_GetDouble(interp, argv[1], &factor) != TCL_OK) {
-      opserr << "WARNING modalDamping - could not read factor for all modes \n";
-      return TCL_ERROR;	        
-    }        
-
-    for (int i=0; i<numEigen; i++)
-      modalDampingValues[i] = factor;
+    for (int i = numModes; i < numEigen; i++)
+      modalDampingValues[i] = 0.0;
   }
-
+  
   // set factors in domain
   theDomain.setModalDampingFactors(&modalDampingValues, true);
-
-  //opserr << "modalDamping Factors: " << modalDampingValues;
 
   return TCL_OK;
 }
@@ -8775,12 +8777,12 @@ int
 modalDampingQ(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
 {
   if (argc < 2) { 
-    opserr << "WARNING modalDamping ?factor - not enough arguments to command\n";
+    opserr << "WARNING modalDampingQ ?factor - not enough arguments to command\n";
     return TCL_ERROR;
   }
 
   if (numEigen == 0 || theEigenSOE == 0) {
-    opserr << "WARNING - modalDamping - eigen command needs to be called first - NO MODAL DAMPING APPLIED\n ";
+    opserr << "WARNING - modalDampingQ - eigen command needs to be called first - NO MODAL DAMPING APPLIED\n ";
   }
 
 
@@ -8788,40 +8790,43 @@ modalDampingQ(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **ar
   double factor = 0;
   Vector modalDampingValues(numEigen);
 
-  if (numModes != 1 && numModes != numEigen) {
-    opserr << "WARNING modalDamping - same #damping factors as modes must be specified\n";
-    opserr << "                     - same damping ratio will be applied to all";
+  if (numModes != 1 && numModes < numEigen) {
+    opserr << "WARNING modalDampingQ - fewer damping factors than modes were specified\n";
+    opserr << "                      - zero damping will be applied to un-specified modes" << endln;
   }
+  if (numModes > numEigen) {
+    opserr << "WARNING modalDampingQ - more damping factors than modes were specifed\n";
+    opserr << "                      - ignoring additional damping factors" << endln;
+  }    
 
   // 
   // read in values and set factors
   //
 
-  if (numModes == numEigen) {
-
-    // read in all factors one at a time
-    for (int i=0; i<numEigen; i++) {
+  if (numModes == 1) {
+    if (Tcl_GetDouble(interp, argv[1], &factor) != TCL_OK) {
+      opserr << "WARNING modalDampingQ - could not read factor for all modes \n";
+      return TCL_ERROR;	        
+    }        
+    
+    for (int i=0; i<numEigen; i++)
+      modalDampingValues[i] = factor;
+  }
+  else {
+    for (int i=0; i<numModes; i++) {
       if (Tcl_GetDouble(interp, argv[1+i], &factor) != TCL_OK) {
-	opserr << "WARNING rayleigh alphaM? betaK? betaK0? betaKc? - could not read betaK? \n";
+	opserr << "WARNING modalDampingQ - could not read factor for model " << i+1 << endln;
 	return TCL_ERROR;	        
       }        
       modalDampingValues[i] = factor;    
     } 
-
-  } else {
-
-    //  read in one & set all factors to that value
-    if (Tcl_GetDouble(interp, argv[1], &factor) != TCL_OK) {
-      opserr << "WARNING rayleigh alphaM? betaK? betaK0? betaKc? - could not read betaK? \n";
-      return TCL_ERROR;	        
-    } 
-
-    for (int i=0; i<numEigen; i++)
-      modalDampingValues[i] = factor;
-  } 
+    for (int i = numModes; i < numEigen; i++)
+      modalDampingValues[i] = 0.0;
+  }
 
   // set factors in domain
   theDomain.setModalDampingFactors(&modalDampingValues, false);
+
   return TCL_OK;
 }
 


### PR DESCRIPTION
If Nmodes < Neigen, use zero damping for the "extra" modes instead of ignoring and using the same damping for all modes