### PR TITLE
Make updates to build_cmake.yml workflow

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -17,9 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+        
     - name: Install conan
-      run: python3 -m pip install conan==1.54.0
+      run: python3 -m pip install conan==1.60.0
 
     - name: Detect Conan Defaults
       run: |


### PR DESCRIPTION
Update build_cmake.yml.

To fix the error 'relocation R_X86_64_PC32 against symbol `_Py_TrueStruct' can not be used when making a shared object; recompile with -fPIC' #1110

Adds specific Python configuration, which points to a an environment libpython3.10.a, rather than the default /usr/lib/x86_64-linux-gnu/libpython3.10.a

```
- uses: actions/setup-python@v4
      with:
        python-version: "3.11"
```

Update conan version to 1.60.0, to fix the NMakeToolChain error. The `conan.tools.microsoft import` line changed 

```
ERROR: tcl/8.6.11: Cannot load recipe.
Error loading conanfile at '/home/runner/.conan/data/tcl/8.6.11/_/_/export/conanfile.py': Unable to load conanfile in /home/runner/.conan/data/tcl/8.6.11/_/_/export/conanfile.py
  File "/usr/lib/python3.10/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 719, in _load
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 8[83](https://github.com/mckee107/OpenSees/actions/runs/5578192140/jobs/10192053886#step:5:84), in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/.conan/data/tcl/8.6.11/_/_/export/conanfile.py", line 6, in <module>
    from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, msvc_runtime_flag, NMakeToolchain
ImportError: cannot import name 'NMakeToolchain' from 'conan.tools.microsoft' (/home/runner/.local/lib/python3.10/site-packages/conan/tools/microsoft/__init__.py)
```