### PR TITLE
SuperLU_DIST Precompile statement correction

### DIFF
--- a/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
@@ -40,7 +40,7 @@
 #include <superlu_ddefs.h>
 
 // SuperLU_DIST 'options' was redefined starting in Version 5.X.X
-#ifdef SUPERLU_DIST_MAIN_VERSION > 4
+#if defined(SUPERLU_DIST_MAJOR_VERSION) && SUPERLU_DIST_MAJOR_VERSION >= 5
     superlu_dist_options_t options;
 #else
     superlu_options_t options;


### PR DESCRIPTION
Changed to: `#if defined(SUPERLU_DIST_MAJOR_VERSION) && SUPERLU_DIST_MAJOR_VERSION >= 5`

Verified to compile on our HPC cluster now without the previously used patch file [`OpenSees-foss-fix_superlu_dist.patch`](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/o/OpenSees)

