### PR TITLE
Implement `sendSelf` and `recvSelf` for `Pinching4`

### DIFF
--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -144,6 +144,7 @@
 #include "Hertzdamp.h"
 #include "JankowskiImpact.h"
 #include "ViscoelasticGap.h"
+#include "Pinching4Material.h"
 
 // Sections
 #include "ElasticSection2d.h"
@@ -1571,6 +1572,9 @@ FEM_ObjectBrokerAllClasses::getNewUniaxialMaterial(int classTag)
 
 	case MAT_TAG_GMG_CyclicReinforcedConcrete:
 		return new GMG_CyclicReinforcedConcrete();
+
+	case MAT_TAG_Pinching4:
+		return new Pinching4Material();
 
 
 	default:

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -48,6 +48,9 @@
 #include <Information.h>
 #include <Parameter.h>
 
+#include <Channel.h>
+
+
 void* OPS_Pinching4Material()
 {
     int numdata = OPS_GetNumRemainingInputArgs();
@@ -560,13 +563,259 @@ UniaxialMaterial* Pinching4Material::getCopy(void)
 
 int Pinching4Material::sendSelf(int commitTag, Channel &theChannel)
 {
-	return -1;
+
+    // Instantiate a Vector to store the relevant class attributes
+    static Vector data(120);
+
+    // Fill the Vector with class attributes.
+    data(0) = this->getTag();
+	int indx = 0;
+
+	// Backbone parameters
+	data(indx++) = stress1p;
+	data(indx++) = strain1p;
+	data(indx++) = stress2p;
+	data(indx++) = strain2p;
+	data(indx++) = stress3p;
+	data(indx++) = strain3p;
+	data(indx++) = stress4p;
+	data(indx++) = strain4p;
+	data(indx++) = stress1n;
+	data(indx++) = strain1n;
+	data(indx++) = stress2n;
+	data(indx++) = strain2n;
+	data(indx++) = stress3n;
+	data(indx++) = strain3n;
+	data(indx++) = stress4n;
+	data(indx++) = strain4n;
+
+	// material tag
+	data(indx++) = tagMat;
+
+	// Damage parameters
+	data(indx++) = gammaK1;
+	data(indx++) = gammaK2;
+	data(indx++) = gammaK3;
+	data(indx++) = gammaK4;
+	data(indx++) = gammaKLimit;
+	data(indx++) = gammaD1;
+	data(indx++) = gammaD2;
+	data(indx++) = gammaD3;
+	data(indx++) = gammaD4;
+	data(indx++) = gammaDLimit;
+	data(indx++) = gammaF1;
+	data(indx++) = gammaF2;
+	data(indx++) = gammaF3;
+	data(indx++) = gammaF4;
+	data(indx++) = gammaFLimit;
+	data(indx++) = gammaE;
+	data(indx++) = TnCycle;
+	data(indx++) = CnCycle;
+	data(indx++) = DmgCyc;
+
+	// unloading-reloading parameters
+	data(indx++) = rDispP;
+	data(indx++) = rForceP;
+	data(indx++) = uForceP;
+	data(indx++) = rDispN;
+	data(indx++) = rForceN;
+	data(indx++) = uForceN;
+
+	// Converged Material History parameters
+	data(indx++) = Cstate;
+	data(indx++) = Cstrain;
+	data(indx++) = Cstress;
+	data(indx++) = CstrainRate;
+	data(indx++) = lowCstateStrain;
+	data(indx++) = lowCstateStress;
+	data(indx++) = hghCstateStrain;
+	data(indx++) = hghCstateStress;
+	data(indx++) = CminStrainDmnd;
+	data(indx++) = CmaxStrainDmnd;
+	data(indx++) = Cenergy;
+	data(indx++) = CgammaK;
+	data(indx++) = CgammaD;
+	data(indx++) = CgammaF;
+	data(indx++) = gammaKUsed;
+	data(indx++) = gammaFUsed;
+
+	// strength and stiffness parameters
+	data(indx++) = kElasticPos;
+	data(indx++) = kElasticNeg;
+	data(indx++) = kElasticPosDamgd;
+	data(indx++) = kElasticNegDamgd;
+	data(indx++) = uMaxDamgd;
+	data(indx++) = uMinDamgd;
+
+	// energy parameters
+	data(indx++) = energyCapacity;
+	data(indx++) = kunload;
+	data(indx++) = elasticStrainEnergy;
+
+	// Vector-type variable contents
+	for (int k = 0; k<6; k++){
+	  data(indx++) = envlpPosStress[k];
+	  data(indx++) = envlpPosStrain[k];
+	  data(indx++) = envlpNegStress[k];
+	  data(indx++) = envlpNegStrain[k];          
+	  data(indx++) = envlpPosDamgdStress[k];
+	  data(indx++) = envlpNegDamgdStress[k];
+	}
+	for (int k = 0; k<4; k++){
+	  data(indx++) = state3Stress[k];
+	  data(indx++) = state3Strain[k];
+	  data(indx++) = state4Stress[k];
+	  data(indx++) = state4Strain[k];
+	}
+
+	// Send the data vector
+    int res = theChannel.sendVector(this->getDbTag(), commitTag, data);
+    if (res < 0) 
+    {
+        opserr << "Pinching4Material::sendSelf() - failed to send data\n";
+        return res;
+    }
+
+    return res;
 }
 
-int Pinching4Material::recvSelf(int commitTag, Channel &theChannel,
-							   FEM_ObjectBroker & theBroker)
+int Pinching4Material::recvSelf(
+    int commitTag, Channel &theChannel,
+	FEM_ObjectBroker & theBroker)
 {
-	return -1;
+
+	// Instantiate a Vector to store the relevant class attributes
+    static Vector data(120);
+
+    int res = theChannel.recvVector(this->getDbTag(), commitTag, data);
+    if (res < 0) 
+    {
+        opserr << "Pinching4Material::recvSelf() - failed to receive data\n";
+        return res;
+    }
+
+    // Assign the received values to the class attributes
+
+    this->setTag((int)data(0));
+
+	int indx = 0;
+	
+	// Backbone parameters
+	stress1p = data(indx++);
+	strain1p = data(indx++);
+	stress2p = data(indx++);
+	strain2p = data(indx++);
+	stress3p = data(indx++);
+	strain3p = data(indx++);
+	stress4p = data(indx++);
+	strain4p = data(indx++);
+	stress1n = data(indx++);
+	strain1n = data(indx++);
+	stress2n = data(indx++);
+	strain2n = data(indx++);
+	stress3n = data(indx++);
+	strain3n = data(indx++);
+	stress4n = data(indx++);
+	strain4n = data(indx++);
+
+	// material tag
+	tagMat = (int)data(indx++);
+
+	// Damage parameters
+	gammaK1 = data(indx++);
+	gammaK2 = data(indx++);
+	gammaK3 = data(indx++);
+	gammaK4 = data(indx++);
+	gammaKLimit = data(indx++);
+	gammaD1 = data(indx++);
+	gammaD2 = data(indx++);
+	gammaD3 = data(indx++);
+	gammaD4 = data(indx++);
+	gammaDLimit = data(indx++);
+	gammaF1 = data(indx++);
+	gammaF2 = data(indx++);
+	gammaF3 = data(indx++);
+	gammaF4 = data(indx++);
+	gammaFLimit = data(indx++);
+	gammaE = data(indx++);
+	TnCycle = data(indx++);
+	CnCycle = data(indx++);
+	DmgCyc = (int)data(indx++);
+
+	// unloading-reloading parameters
+	rDispP = data(indx++);
+	rForceP = data(indx++);
+	uForceP = data(indx++);
+	rDispN = data(indx++);
+	rForceN = data(indx++);
+	uForceN = data(indx++);
+
+	// Converged Material History parameters
+	Cstate = (int)data(indx++);
+	Cstrain = data(indx++);
+	Cstress = data(indx++);
+	CstrainRate = data(indx++);
+	lowCstateStrain = data(indx++);
+	lowCstateStress = data(indx++);
+	hghCstateStrain = data(indx++);
+	hghCstateStress = data(indx++);
+	CminStrainDmnd = data(indx++);
+	CmaxStrainDmnd = data(indx++);
+	Cenergy = data(indx++);
+	CgammaK = data(indx++);
+	CgammaD = data(indx++);
+	CgammaF = data(indx++);
+	gammaKUsed = data(indx++);
+	gammaFUsed = data(indx++);
+
+	// strength and stiffness parameters
+	kElasticPos = data(indx++);
+	kElasticNeg = data(indx++);
+	kElasticPosDamgd = data(indx++);
+	kElasticNegDamgd = data(indx++);
+	uMaxDamgd = data(indx++);
+	uMinDamgd = data(indx++);
+
+	// energy parameters
+	energyCapacity = data(indx++);
+	kunload = data(indx++);
+	elasticStrainEnergy = data(indx++);
+
+	// Vector-type variable contents
+	for (int k = 0; k<6; k++){
+	  envlpPosStress[k] = data(indx++);
+	  envlpPosStrain[k] = data(indx++);
+	  envlpNegStress[k] = data(indx++);
+	  envlpNegStrain[k] = data(indx++);
+	  envlpPosDamgdStress[k] = data(indx++);
+	  envlpNegDamgdStress[k] = data(indx++);
+	}
+	for (int k = 0; k<4; k++){
+	  state3Stress[k] = data(indx++);
+	  state3Strain[k] = data(indx++);
+	  state4Stress[k] = data(indx++);
+	  state4Strain[k] = data(indx++);
+	}
+
+	// Set trial variables to the last converged values
+	Tstress = Cstress;
+	Tstrain = Cstrain;
+	Ttangent = 0.0;
+	Tstate = Cstate;
+	dstrain = 0.0;
+	TstrainRate = CstrainRate;
+	lowTstateStrain = lowCstateStrain;
+	lowTstateStress = lowCstateStress;
+	hghTstateStrain = hghCstateStrain;
+	hghTstateStress = hghCstateStress;
+	TminStrainDmnd = CminStrainDmnd;
+	TmaxStrainDmnd = CmaxStrainDmnd;
+	Tenergy = Cenergy;
+	TgammaK = CgammaK;
+	TgammaD = CgammaD;
+	TgammaF = CgammaF;
+	
+    return res;
 }
 
 void Pinching4Material::Print(OPS_Stream &s, int flag)

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -186,10 +186,6 @@ Pinching4Material::Pinching4Material(int tag,
 	energyCapacity = 0.0; kunload = 0.0; elasticStrainEnergy = 0.0;
 
 
-#ifdef _G3DEBUG
-	fg = new FileStream();
-	fg->setFile("PinchDamage.out", APPEND);
-#endif
 	// set envelope slopes
 	this->SetEnvelope();
 
@@ -273,9 +269,7 @@ Pinching4Material::Pinching4Material():
 
 Pinching4Material::~Pinching4Material()
 {
-#ifdef _G3DEBUG
-	fg->close();
-#endif
+
 }
 
 int Pinching4Material::setTrialStrain(double strain, double CstrainRate)
@@ -408,9 +402,6 @@ int Pinching4Material::commitState(void)  {
 
 	CnCycle = TnCycle; // number of cycles of loading
 
-#ifdef _G3DEBUG
-	(*fg) << tagMat << "  " << CgammaF << "  " << CgammaK << "  " << CgammaD << endln;
-#endif
 	return 0;
 }
 

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -565,7 +565,7 @@ int Pinching4Material::sendSelf(int commitTag, Channel &theChannel)
 {
 
     // Instantiate a Vector to store the relevant class attributes
-    static Vector data(120);
+    static Vector data(119);
 
     // Fill the Vector with class attributes.
     data(0) = this->getTag();
@@ -588,9 +588,6 @@ int Pinching4Material::sendSelf(int commitTag, Channel &theChannel)
 	data(indx++) = strain3n;
 	data(indx++) = stress4n;
 	data(indx++) = strain4n;
-
-	// material tag
-	data(indx++) = tagMat;
 
 	// Damage parameters
 	data(indx++) = gammaK1;
@@ -685,7 +682,7 @@ int Pinching4Material::recvSelf(
 {
 
 	// Instantiate a Vector to store the relevant class attributes
-    static Vector data(120);
+    static Vector data(119);
 
     int res = theChannel.recvVector(this->getDbTag(), commitTag, data);
     if (res < 0) 
@@ -717,9 +714,6 @@ int Pinching4Material::recvSelf(
 	strain3n = data(indx++);
 	stress4n = data(indx++);
 	strain4n = data(indx++);
-
-	// material tag
-	tagMat = (int)data(indx++);
 
 	// Damage parameters
 	gammaK1 = data(indx++);

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -559,8 +559,9 @@ int Pinching4Material::sendSelf(int commitTag, Channel &theChannel)
     static Vector data(119);
 
     // Fill the Vector with class attributes.
-    data(0) = this->getTag();
-	int indx = 1;
+	int indx = 0;
+
+	data(indx++) = this->getTag();
 
 	// Backbone parameters
 	data(indx++) = stress1p;
@@ -684,9 +685,9 @@ int Pinching4Material::recvSelf(
 
     // Assign the received values to the class attributes
 
-    this->setTag((int)data(0));
+	int indx = 0;
 
-	int indx = 1;
+	this->setTag((int)data(indx++));
 	
 	// Backbone parameters
 	stress1p = data(indx++);

--- a/SRC/material/uniaxial/Pinching4Material.cpp
+++ b/SRC/material/uniaxial/Pinching4Material.cpp
@@ -569,7 +569,7 @@ int Pinching4Material::sendSelf(int commitTag, Channel &theChannel)
 
     // Fill the Vector with class attributes.
     data(0) = this->getTag();
-	int indx = 0;
+	int indx = 1;
 
 	// Backbone parameters
 	data(indx++) = stress1p;
@@ -698,7 +698,7 @@ int Pinching4Material::recvSelf(
 
     this->setTag((int)data(0));
 
-	int indx = 0;
+	int indx = 1;
 	
 	// Backbone parameters
 	stress1p = data(indx++);

--- a/SRC/material/uniaxial/Pinching4Material.h
+++ b/SRC/material/uniaxial/Pinching4Material.h
@@ -190,9 +190,6 @@ private:
 	double Envlp4Stress(Vector , Vector , double);
 	void updateDmg(double, double);
 
-#ifdef _G3DEBUG
-	FileStream* fg;
-#endif
 
 };
 #endif

--- a/SRC/material/uniaxial/Pinching4Material.h
+++ b/SRC/material/uniaxial/Pinching4Material.h
@@ -105,10 +105,7 @@ private:
 		Vector envlpPosStress; Vector envlpPosStrain; 
 		Vector envlpNegStress; Vector envlpNegStrain;
 
-		int tagMat;  // material tag
-
 	// Damage parameters
-
 	double gammaK1; double gammaK2; double gammaK3; double gammaK4; double gammaKLimit;
 	double gammaD1; double gammaD2; double gammaD3; double gammaD4; double gammaDLimit;
 	double gammaF1; double gammaF2; double gammaF3; double gammaF4; double gammaFLimit;

--- a/SRC/material/uniaxial/Pinching4Material.h
+++ b/SRC/material/uniaxial/Pinching4Material.h
@@ -162,7 +162,7 @@ private:
 	double TgammaD;
 	double TgammaF;
 
-	// strength and stiffness parameters;
+	// strength and stiffness parameters
 	double kElasticPos;
 	double kElasticNeg;
 	double kElasticPosDamgd;


### PR DESCRIPTION
This PR implements the `sendSelf` and `recvSelf` methods of the `Pinching4` material.
As an initial attempt, I tried emulating the syntax in `ElasticMultiLinear` and `ElasticPowerFunc`, where `theChannel.<send/recv>Vector` is called repeatedly with different arguments, but I wasn't able to retrieve the correct vector values in `recvSelf` with this approach. The proposed implementation simply aggregates the individual values of the `Vector`-typed attributes inside a larger vector, skipping trial attributes.
I would be happy to also commit the `Tcl` script I used while debugging if that would be helpful. 