### PR TITLE
Remove additional material creation statements.

### DIFF
--- a/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
+++ b/SRC/material/uniaxial/TclModelBuilderUniaxialMaterialCommand.cpp
@@ -182,7 +182,6 @@ extern void *OPS_BoucWenOriginal(void);
 extern void *OPS_GNGMaterial(void);
 extern void *OPS_OOHystereticMaterial(void);
 extern void *OPS_ElasticPowerFunc(void);
-extern void *OPS_UVCuniaxial(void);
 extern void *OPS_DegradingPinchedBW(void);
 extern void* OPS_BoucWenInfill(void);  // S. Sirotti  18-January-2022  e-mail: stefano.sirotti@unimore.it
 extern void *OPS_SLModel(void);
@@ -605,13 +604,6 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
       void* theMat = OPS_ElasticPowerFunc();
       if (theMat != 0)
         theMaterial = (UniaxialMaterial*)theMat;
-      else
-        return TCL_ERROR;
-    }
-    if (strcmp(argv[1], "UVCuniaxial") == 0) {
-      void *theMat = OPS_UVCuniaxial();
-      if (theMat != 0)
-        theMaterial = (UniaxialMaterial *)theMat;
       else
         return TCL_ERROR;
     }
@@ -1196,13 +1188,6 @@ TclModelBuilderUniaxialMaterialCommand (ClientData clientData, Tcl_Interp *inter
 	theMaterial = (UniaxialMaterial *)theMat;
       else 
 	return TCL_ERROR;
-    }
-    if (strcmp(argv[1], "UVCuniaxial") == 0) {
-      void* theMat = OPS_UVCuniaxial();
-      if (theMat != 0)
-        theMaterial = (UniaxialMaterial*)theMat;
-      else
-        return TCL_ERROR;
     }
     if (strcmp(argv[1],"Pinching4") == 0) {
 		if (argc != 42 && argc != 31 ) {


### PR DESCRIPTION
Seems like the TCL interpreter commands for uvcUniaxial were duplicated twice (three total). This commit removes the two extra. The original still exists on line 378 in the updated file.