### PR TITLE
Units  warning in limitCurve functions

### DIFF
--- a/SRC/material/uniaxial/limitState/limitCurve/RotationShearCurve.cpp
+++ b/SRC/material/uniaxial/limitState/limitCurve/RotationShearCurve.cpp
@@ -57,6 +57,7 @@ static int shearCurveCount = 0;
 void *
 OPS_RotationShearCurve(void)
 {
+  opserr << "WARNING RotationShearCurve regarding units of input parameters \n-- Check for units in line 482 of this code --\n double Vc = 0.8*Ag*(6*sqrt(fc*1000)/Mratio*sqrt(1+Nu/(6*sqrt(fc*1000)*Ag)))/1000; //(kips)\n Source Code Link -- https://github.com/L-iqra/OpenSees-source/edit/master/SRC/material/uniaxial/limitState/limitCurve/RotationShearCurve.cpp";
   if (shearCurveCount == 0) {
     //opserr << "RotationShearCurve limit curve - Written by MRL UT Austin Copyright 2012 -  Use at your Own Peril \n";
     shearCurveCount++;

--- a/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.cpp
+++ b/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.cpp
@@ -44,7 +44,7 @@
 #include <elementAPI.h>
 
 void* OPS_ShearCurve()
-{
+{   opserr << "Warning : Check units requirement in ShearCurve.h : fc to be entered in ps. Source code:https://github.com/L-iqra/OpenSees-source/edit/master/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.h"
     if (OPS_GetNumRemainingInputArgs() < 12) {
 	opserr << "WARNING insufficient arguments\n";
 	//	    printCommand(argc,argv); // Commented out by Terje

--- a/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.cpp
+++ b/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.cpp
@@ -44,7 +44,7 @@
 #include <elementAPI.h>
 
 void* OPS_ShearCurve()
-{   opserr << "Warning : Check units requirement in ShearCurve.h : fc to be entered in ps. Source code:https://github.com/L-iqra/OpenSees-source/edit/master/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.h"
+{   opserr << "Warning : Check units requirement in ShearCurve.h : fc to be entered in ps. Source code:https://github.com/L-iqra/OpenSees-source/edit/master/SRC/material/uniaxial/limitState/limitCurve/ShearCurve.h";
     if (OPS_GetNumRemainingInputArgs() < 12) {
 	opserr << "WARNING insufficient arguments\n";
 	//	    printCommand(argc,argv); // Commented out by Terje


### PR DESCRIPTION
In the source code/files of ShearCurve.cpp, ShearCurve.h, RotationShearCurve.h, and RotationShearCurve.cpp, the units explicitly mentioned are psi and kips. However, the demonstration manual states that these functions can take input in both psi and MPa units. 

Link to [source codes](https://github.com/OpenSees/OpenSees/tree/master/SRC/material/uniaxial/limitState/limitCurve)
Link to [manual](https://opensees.berkeley.edu/wiki/images/5/57/LimitStateMaterialManual.pdf))

The users are advised to be cautious while using these functions.

@mhscott @fmckenna Can you please check this and make appropriate changes in the code ?