### PR TITLE
SurfaceLoad making matrices and vectors static

### DIFF
--- a/SRC/element/surfaceLoad/SurfaceLoad.cpp
+++ b/SRC/element/surfaceLoad/SurfaceLoad.cpp
@@ -47,6 +47,10 @@
 double SurfaceLoad :: oneOverRoot3 = 1.0/sqrt(3.0);
 double SurfaceLoad :: GsPts[4][2];
 
+Matrix SurfaceLoad::tangentStiffness(SL_NUM_DOF, SL_NUM_DOF);
+Vector SurfaceLoad::internalForces(SL_NUM_DOF);
+Vector SurfaceLoad::theVector(SL_NUM_DOF);
+
 #include <elementAPI.h>
 static int num_SurfaceLoad = 0;
 
@@ -96,8 +100,6 @@ OPS_SurfaceLoad(void)
 SurfaceLoad::SurfaceLoad(int tag, int Nd1, int Nd2, int Nd3, int Nd4, double pressure)
  :Element(tag,ELE_TAG_SurfaceLoad),     
    myExternalNodes(SL_NUM_NODE),
-   tangentStiffness(SL_NUM_DOF, SL_NUM_DOF),
-   internalForces(SL_NUM_DOF),
    g1(SL_NUM_NDF), 
    g2(SL_NUM_NDF),
    myNhat(SL_NUM_NDF), 
@@ -131,8 +133,6 @@ SurfaceLoad::SurfaceLoad(int tag, int Nd1, int Nd2, int Nd3, int Nd4, double pre
 SurfaceLoad::SurfaceLoad()
   :Element(0,ELE_TAG_SurfaceLoad),     
    	myExternalNodes(SL_NUM_NODE),
-   	tangentStiffness(SL_NUM_DOF, SL_NUM_DOF),
-   	internalForces(SL_NUM_DOF),
    	g1(SL_NUM_NDF), 
    	g2(SL_NUM_NDF),
    	myNhat(SL_NUM_NDF), 
@@ -354,16 +354,6 @@ SurfaceLoad::sendSelf(int commitTag, Channel &theChannel)
     return -2;
   }
 
-  res = theChannel.sendVector(dataTag, commitTag, internalForces);
-  if (res < 0) {
-    opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to send internalForces\n";
-    return -2;
-  }
-  res = theChannel.sendVector(dataTag, commitTag, theVector);
-  if (res < 0) {
-    opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to send theVector\n";
-    return -2;
-  }
   res = theChannel.sendVector(dataTag, commitTag, g1);
   if (res < 0) {
     opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to send g1\n";
@@ -438,16 +428,6 @@ SurfaceLoad::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theB
     return -2;
   }
 
-  res = theChannel.recvVector(dataTag, commitTag, internalForces);
-  if (res < 0) {
-    opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to receive internalForces\n";
-    return -2;
-  }
-  res = theChannel.recvVector(dataTag, commitTag, theVector);
-  if (res < 0) {
-    opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to receive theVector\n";
-    return -2;
-  }
   res = theChannel.recvVector(dataTag, commitTag, g1);
   if (res < 0) {
     opserr <<"WARNING SurfaceLoad::sendSelf() - " << this->getTag() << " failed to receive g1\n";

--- a/SRC/element/surfaceLoad/SurfaceLoad.h
+++ b/SRC/element/surfaceLoad/SurfaceLoad.h
@@ -35,15 +35,6 @@
 #include <NDMaterial.h>
 #include <ID.h>
 
-// number of nodes per element
-#define SL_NUM_NODE 4
-// d.o.f. per node
-#define SL_NUM_NDF  3
-// degrees of freedom per element
-#define SL_NUM_DOF  12
-// displacement degrees of freedom per element
-#define SL_NUM_DDOF  12
-
 class Domain;
 class Node;
 class Channel;
@@ -97,6 +88,11 @@ class SurfaceLoad : public Element
     
   private:
 
+  enum {SL_NUM_NODE = 4}; // number of nodes per element
+  enum {SL_NUM_NDF = 3}; // d.o.f. per node
+  enum {SL_NUM_DOF = 12}; // degrees of freedom per element
+  enum {SL_NUM_DDOF = 12}; // displacement degrees of freedom per element
+  
     // method to update base vectors g1 & g2
     int UpdateBase(double Xi, double Eta);
 

--- a/SRC/element/surfaceLoad/SurfaceLoad.h
+++ b/SRC/element/surfaceLoad/SurfaceLoad.h
@@ -97,9 +97,9 @@ class SurfaceLoad : public Element
     int UpdateBase(double Xi, double Eta);
 
     ID  myExternalNodes;      // contains the tags of the end nodes
-    Matrix tangentStiffness;  // Tangent Stiffness matrix
-    Vector internalForces;    // vector of Internal Forces
-    Vector theVector;         // vector to return the residual
+    static Matrix tangentStiffness;  // Tangent Stiffness matrix
+    static Vector internalForces;    // vector of Internal Forces
+    static Vector theVector;         // vector to return the residual
 
     double my_pressure;       // pressure applied to surface of element
 

--- a/SRC/element/surfaceLoad/TriSurfaceLoad.cpp
+++ b/SRC/element/surfaceLoad/TriSurfaceLoad.cpp
@@ -48,6 +48,8 @@ double TriSurfaceLoad::GsPts[1][1];
 Matrix TriSurfaceLoad::tangentStiffness(SL_NUM_DOF, SL_NUM_DOF);
 Matrix TriSurfaceLoad::mass(SL_NUM_DOF, SL_NUM_DOF);
 Matrix TriSurfaceLoad::damp(SL_NUM_DOF, SL_NUM_DOF);
+Vector TriSurfaceLoad::internalForces(SL_NUM_DOF);
+
 #include <elementAPI.h>
 static int num_TriSurfaceLoad = 0;
 
@@ -107,7 +109,6 @@ OPS_TriSurfaceLoad(void)
 TriSurfaceLoad::TriSurfaceLoad(int tag, int Nd1, int Nd2, int Nd3, double pressure,  double rhoH_)
  :Element(tag,ELE_TAG_TriSurfaceLoad),     
    myExternalNodes(SL_NUM_NODE),
-   internalForces(SL_NUM_DOF),
    g1(SL_NUM_NDF), 
    g2(SL_NUM_NDF),
    myNhat(SL_NUM_NDF), 
@@ -133,7 +134,6 @@ TriSurfaceLoad::TriSurfaceLoad(int tag, int Nd1, int Nd2, int Nd3, double pressu
 TriSurfaceLoad::TriSurfaceLoad()
   :Element(0,ELE_TAG_TriSurfaceLoad),     
    	myExternalNodes(SL_NUM_NODE),
-   	internalForces(SL_NUM_DOF),
    	g1(SL_NUM_NDF), 
    	g2(SL_NUM_NDF),
    	myNhat(SL_NUM_NDF), 
@@ -370,11 +370,6 @@ TriSurfaceLoad::sendSelf(int commitTag, Channel &theChannel)
     return -2;
   }
 
-  res = theChannel.sendVector(dataTag, commitTag, internalForces);
-  if (res < 0) {
-    opserr <<"WARNING TriSurfaceLoad::sendSelf() - " << this->getTag() << " failed to send internalForces\n";
-    return -2;
-  }
   res = theChannel.sendVector(dataTag, commitTag, g1);
   if (res < 0) {
     opserr <<"WARNING TriSurfaceLoad::sendSelf() - " << this->getTag() << " failed to send g1\n";
@@ -445,11 +440,6 @@ TriSurfaceLoad::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &t
     return -2;
   }
 
-  res = theChannel.recvVector(dataTag, commitTag, internalForces);
-  if (res < 0) {
-    opserr <<"WARNING TriSurfaceLoad::sendSelf() - " << this->getTag() << " failed to receive internalForces\n";
-    return -2;
-  }
   res = theChannel.recvVector(dataTag, commitTag, g1);
   if (res < 0) {
     opserr <<"WARNING TriSurfaceLoad::sendSelf() - " << this->getTag() << " failed to receive g1\n";

--- a/SRC/element/surfaceLoad/TriSurfaceLoad.h
+++ b/SRC/element/surfaceLoad/TriSurfaceLoad.h
@@ -34,15 +34,6 @@
 #include <NDMaterial.h>
 #include <ID.h>
 
-// number of nodes per element
-#define SL_NUM_NODE 3
-// d.o.f. per node
-#define SL_NUM_NDF  3
-// degrees of freedom per element
-#define SL_NUM_DOF  9
-// displacement degrees of freedom per element
-#define SL_NUM_DDOF  3
-
 class Domain;
 class Node;
 class Channel;
@@ -97,6 +88,11 @@ class TriSurfaceLoad : public Element
     
   private:
 
+  enum {SL_NUM_NODE = 3}; // number of nodes per element
+  enum {SL_NUM_NDF = 3}; // d.o.f. per node
+  enum {SL_NUM_DOF = 9}; // degrees of freedom per element
+  enum {SL_NUM_DDOF = 9}; // displacement degrees of freedom per element
+  
     // method to update base vectors g1 & g2
     int UpdateBase(double Xi, double Eta);
 

--- a/SRC/element/surfaceLoad/TriSurfaceLoad.h
+++ b/SRC/element/surfaceLoad/TriSurfaceLoad.h
@@ -100,7 +100,7 @@ class TriSurfaceLoad : public Element
     static Matrix tangentStiffness;  // Tangent Stiffness matrix
     static Matrix mass;  // mass matrix
     static Matrix damp;  // damping matrix
-    Vector internalForces;    // vector of Internal Forces
+    static Vector internalForces;    // vector of Internal Forces
 
     double my_pressure;       // pressure applied to surface of element
     double rhoH;              // A density per unit area to compute a mass matrix (lumped)


### PR DESCRIPTION
No need for each SurfaceLoad element to keep its own 12x12 matrix of zeros.... RAM killer