### PR TITLE
Fixed a bug in OpenSeesUniaxialMaterialCommands.cpp

### DIFF
--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -936,7 +936,7 @@ int OPS_LimitCurve() {
     }
 
   } else if (strcmp(type, "ThreePoint") == 0) {
-    void* curve = OPS_RotationShearCurve();
+    void* curve = OPS_ThreePointCurve();
     if (curve != 0) {
       theCurve = (LimitCurve*)curve;
     } else {


### PR DESCRIPTION
Source code was not redirecting to the ThreePointCurve function for limitCurve('ThreePoint'). The issue is described [herein](https://github.com/zhuminjie/OpenSeesPy/issues/121) with an example.