### PR TITLE
Mac Build Workflow

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.11"
-        
+
     - name: Install conan
       run: python3 -m pip install conan==1.60.0
 
@@ -63,7 +63,35 @@ jobs:
 #        - name: Verification OpenSeesPyMP
 #          run: |
 #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
-
+  build-mac:
+    name: Mac Build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with: python-version: "3.11"
+      - name: Install Library
+        run: |
+         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+         brew install hdf5
+         brew install open-mpi
+         brew install scalapack
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DMUMPS_DIR=$PWD/../../mumps/build -DOPENMPI=TRUE -DSCALAPACK_LIBRARIES=/usr/local/Cellar/scalapack/2.2.0_1/lib/libscalapack.dylib
+          cmake --build . --config Release --target OpenSees
+          cmake --build . --config Release --target OpenSeesPy
+          mv ./OpenSeesPy.dylib ./opensees.so
+      - name: Verification OpenSeesPySP
+        run: |
+          cd ./EXAMPLES/ExamplePython/
+          export PYTHONPATH="../../build/"
+          python3 -c "import sys; print(sys.path)"
+          python3 example_variable_analysis.py
 # Not building on Windows until we can figure out how to use Fortran
 # with Github Actions
     #  build-win32:
@@ -73,7 +101,7 @@ jobs:
     #    - name: Checkout sources
     #      uses: actions/checkout@v2
     #      with: {ref: cmake-build}
-    #    
+    #
     #    - name: Install Conan
     #      uses: turtlebrowser/get-conan@main
     #

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,8 +6,7 @@ env:
 
 on:
   push:
-    branches: [master]
-
+  workflow-dispatch:
   pull_request:
     branches: [master]
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   push:
-  workflow-dispatch:
+  workflow_dispatch:
   pull_request:
     branches: [master]
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,7 +6,8 @@ env:
 
 on:
   push:
-  workflow_dispatch:
+    branches: [master]
+
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
Hello. I'm glad to see Ubuntu build workflow working well. I'd like to add a Mac build workflow. People building OpenSees on Mac might be a few, but I'm certain that the workflow will be helpful for them and ensure that OpenSees will be successfully built on Mac after new features added.
P.S. I think build workflow for Windows might be desired and installing Intel Fortran is a key to enable that. I found that awvwgk/setup-fortran would be helpful for us. They've already made a Github Actions enabling installation of Intel oneAPI HPC toolkit to windows runner on Github Actions. The remained problems are that they are not motivated for 1. integration with VS and 2. installing all of components we need and Intel oneAPI Base toolkit. Those mean that we need to add some modification to their repository. I hope this information will be useful to those who want to implement windows build workflow. 