### PR TITLE
UniaxialMaterial IMKPeakOriented IMKPinching minor fix

### DIFF
--- a/SRC/material/uniaxial/IMKPeakOriented.cpp
+++ b/SRC/material/uniaxial/IMKPeakOriented.cpp
@@ -715,7 +715,6 @@ int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
     data(51) = posKp;
     data(62) = posKpc;
 // 3 State Variables 63-65
-    // data(63) = U;
     data(64) = Ui;
     data(65) = Fi;
 // 2 Stiffness 66 67

--- a/SRC/material/uniaxial/IMKPeakOriented.cpp
+++ b/SRC/material/uniaxial/IMKPeakOriented.cpp
@@ -69,8 +69,7 @@ OPS_IMKPeakOriented()
 
 
     // Parsing was successful, allocate the material
-    theMaterial = new IMKPeakOriented(iData[0],
-        dData[0],
+    theMaterial = new IMKPeakOriented(iData[0], dData[0],
         dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
         dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
         dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
@@ -118,8 +117,7 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     //state determination algorithm: defines the current force and tangent stiffness
     const double Ui_1 = Ui;
     const double Fi_1 = Fi;
-    U = strain; //set trial displacement
-    Ui = U;
+    Ui = strain; //set trial displacement
     const double dU = Ui - Ui_1;    // Incremental deformation at current step
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -167,7 +165,7 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN NEW EXCURSION /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        if (Branch == 1 && Fi_1*Fi <= 0.0) {
+        if (Branch == 1 && Fi_1 * Fi <= 0.0) {
     /////////////////// UPDATE BACKBONE CURVE /////////////////////////////////////////////////
             const double Ei = max(0.0, engAcml - engDspt);
             betaS = pow((Ei / (engRefS - engAcml)), c_S);
@@ -219,9 +217,9 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
                 negUglobal *= (1 + betaA * D_neg); // Accelerated Reloading Stiffness
                 negUy = negFy / Ke;
             // Capping Point
-                const double FyProj = negFy - negKp*negUy;
+                const double FyProj = negFy - negKp * negUy;
                 negUcap = negKp <= negKpc ? 0 : (FcapProj - FyProj) / (negKp - negKpc);
-                negFcap = FyProj + negKp*negUcap;
+                negFcap = FyProj + negKp * negUcap;
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (negUy < negUglobal) {           // Elastic Branch
@@ -366,12 +364,12 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     // CHECK FOR FAILURE
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        const bool	FailPp = ( posFglobal == 0 );
-        const bool	FailPn = ( negFglobal == 0 );
-        const bool	FailDp = ( dU > 0 && Ui >=  posUu_0 );
-        const bool	FailDn = ( dU < 0 && Ui <= -negUu_0 );
-        const bool	FailRp = ( Branch == 7 && Fi <= 0);
-        const bool	FailRn = ( Branch == 17 && Fi >= 0);
+        const bool FailPp = ( posFglobal == 0 );
+        const bool FailPn = ( negFglobal == 0 );
+        const bool FailDp = ( dU > 0 && Ui >=  posUu_0 );
+        const bool FailDn = ( dU < 0 && Ui <= -negUu_0 );
+        const bool FailRp = ( Branch == 7 && Fi <= 0);
+        const bool FailRn = ( Branch == 17 && Fi >= 0);
         if (FailS || FailC || FailA || FailK || FailPp || FailPn || FailRp || FailRn || FailDp || FailDn) {
             Fi = 0;
             Failure_Flag = true;
@@ -381,7 +379,7 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
 
         KgetTangent = (Fi - Fi_1) / dU;
     }
-    if (KgetTangent==0) {
+    if (KgetTangent == 0) {
         KgetTangent = 1e-6;
     }
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -413,7 +411,7 @@ double IMKPeakOriented::getInitialTangent(void)
 double IMKPeakOriented::getStrain(void)
 {
     //cout << " getStrain" << endln;
-    return (U);
+    return (Ui);
 }
 
 int IMKPeakOriented::commitState(void)
@@ -448,7 +446,6 @@ int IMKPeakOriented::commitState(void)
     cNegKp = negKp;
     cNegKpc = negKpc;
 // 3 State
-    cU = U;
     cUi = Ui;
     cFi = Fi;
 // 2 Stiffness
@@ -494,7 +491,6 @@ int IMKPeakOriented::revertToLastCommit(void)
     negKp = cNegKp;
     negKpc = cNegKpc;
 // 3 State Variables
-    U = cU;
     Ui = cUi;
     Fi = cFi;
 // 2 Stiffness
@@ -556,7 +552,6 @@ int IMKPeakOriented::revertToStart(void)
     negKpc = cNegKpc = -negKpc_0;
     negUres = cNegUres = (negFres - negFcap) / negKpc + negUcap;
 // 3 State Values
-    U = cU = 0;
     Ui = cUi = 0;
     Fi = cFi = 0;
 // 2 Stiffness
@@ -567,7 +562,7 @@ int IMKPeakOriented::revertToStart(void)
     engAcml = cEngAcml = 0.0;
     engDspt = cEngDspt = 0.0;
 // 2 Flag
-    Failure_Flag= cFailure_Flag = false;
+    Failure_Flag = cFailure_Flag = false;
     Branch = cBranch = 0;
     return 0;
 }
@@ -608,7 +603,6 @@ IMKPeakOriented::getCopy(void)
     theCopy->negKp = negKp;
     theCopy->negKpc = negKpc;
 // 3 State Values
-    theCopy->U = U;
     theCopy->Ui = Ui;
     theCopy->Fi = Fi;
 // 2 Stiffness
@@ -647,7 +641,6 @@ IMKPeakOriented::getCopy(void)
     theCopy->cNegKp = cNegKp;
     theCopy->cNegKpc = cNegKpc;
 // 3 State
-    theCopy->cU = cU;
     theCopy->cUi = cUi;
     theCopy->cFi = cFi;
 // 2 Stiffness
@@ -722,7 +715,7 @@ int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
     data(51) = posKp;
     data(62) = posKpc;
 // 3 State Variables 63-65
-    data(63) = U;
+    // data(63) = U;
     data(64) = Ui;
     data(65) = Fi;
 // 2 Stiffness 66 67
@@ -761,7 +754,6 @@ int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
     data(111) = cPosKp;
     data(112) = cPosKpc;
 // 3 State Variables 113-115
-    data(113) = cU;
     data(114) = cUi;
     data(115) = cFi;
 // 2 Stiffness 116 117
@@ -858,7 +850,6 @@ int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &t
         posKp = data(61);
         posKpc = data(62);
     // 3 State Variables
-        U = data(63);
         Ui = data(64);
         Fi = data(65);
     // 2 Stiffness
@@ -897,7 +888,6 @@ int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &t
         cPosKp = data(111);
         cPosKpc = data(112);
     // 3 State Variables
-        cU = data(113);
         cUi = data(114);
         cFi = data(115);
     // 2 Stiffness

--- a/SRC/material/uniaxial/IMKPeakOriented.cpp
+++ b/SRC/material/uniaxial/IMKPeakOriented.cpp
@@ -41,7 +41,7 @@ OPS_IMKPeakOriented()
 {
     if (numIMKPeakOrientedMaterials == 0) {
         numIMKPeakOrientedMaterials++;
-        opserr << "IMK with Peak-Oriented Response - Code by AE_KI (Nov22)\n";
+        opserr << "IMK with Peak-Oriented Response - Code by AE_KI (Sep23)\n";
     }
 
     // Pointer to a uniaxial material that will be returned
@@ -49,17 +49,17 @@ OPS_IMKPeakOriented()
 
     int    iData[1];
     double dData[23];
-    int numData = 1;
+    int numInt = 1;
 
-    if (OPS_GetIntInput(&numData, iData) != 0) {
+    if (OPS_GetIntInput(&numInt, iData) != 0) {
         opserr << "WARNING invalid uniaxialMaterial IMKPeakOriented tag" << endln;
         return 0;
     }
 
-    numData = 23;
+    int numDouble = 23;
 
 
-    if (OPS_GetDoubleInput(&numData, dData) != 0) {
+    if (OPS_GetDoubleInput(&numDouble, dData) != 0) {
         opserr << "Invalid Args want: uniaxialMaterial IMKPeakOriented tag? Ke? ";
         opserr << "posUp_0? posUpc_0? posUu_0? posFy_0? posFcapFy_0? posFresFy_0? ";
         opserr << "negUp_0? negUpc_0? negUu_0? negFy_0? negFcapFy_0? negFresFy_0? ";
@@ -116,90 +116,90 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     this->revertToLastCommit();
 
     //state determination algorithm: defines the current force and tangent stiffness
-    double Ui_1 = Ui;
-    double Fi_1 = Fi;
-    U           = strain; //set trial displacement
-    Ui          = U;
-    double dU   = Ui - Ui_1;    // Incremental deformation at current step
+    const double Ui_1 = Ui;
+    const double Fi_1 = Fi;
+    U = strain; //set trial displacement
+    Ui = U;
+    const double dU = Ui - Ui_1;    // Incremental deformation at current step
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     if (Failure_Flag) {     // When a failure has already occured
-        Fi  = 0;
+        Fi = 0;
     } else if (dU == 0) {   // When deformation doesn't change from the last
-        Fi  = Fi_1;
+        Fi = Fi_1;
     } else {
-        double  betaS=0,betaC=0,betaK=0,betaA=0;
-        bool    FailS=false,FailC=false,FailK=false,FailA=false;
-        bool    onBackbone  = (Branch > 1);
+        double betaS = 0, betaC = 0, betaK = 0, betaA = 0;
+        bool FailS = false, FailC = false, FailK = false, FailA = false;
+        const bool onBackbone = (Branch > 1);
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN REVERSAL /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        if ( (onBackbone && Fi_1*dU < 0) || (onBackbone && Fi_1==0 && Ui_1*dU<=0) ) {
-            Branch          = 1;
+        if ( (onBackbone && Fi_1 * dU < 0) || (onBackbone && Fi_1 == 0 && Ui_1 * dU <= 0) ) {
+            Branch = 1;
     /////////////////////////// UPDATE PEAK POINTS ////////////////////////////////////////////
             if ( Fi_1 > 0 ){
-                posUlocal	= Ui_1;           // UPDATE LOCAL
-                posFlocal	= Fi_1;
+                posUlocal = Ui_1;           // UPDATE LOCAL
+                posFlocal = Fi_1;
                 if ( Ui_1 > posUglobal ) {    // UPDATE GLOBAL
-                    posUglobal   	= Ui_1;
-                    posFglobal   	= Fi_1;
+                    posUglobal = Ui_1;
+                    posFglobal = Fi_1;
                 }
             } else {
-                negUlocal	= Ui_1;           // UPDATE LOCAL
-                negFlocal	= Fi_1;
+                negUlocal = Ui_1;           // UPDATE LOCAL
+                negFlocal = Fi_1;
                 if ( Ui_1 < negUglobal ) {    // UPDATE GLOBAL
-                    negUglobal   	= Ui_1;
-                    negFglobal   	= Fi_1;
+                    negUglobal = Ui_1;
+                    negFglobal = Fi_1;
                 }
             }
     /////////////////// UPDATE UNLOADING STIFFNESS ////////////////////////////////////////////
-            double  EpjK    = engAcml            - 0.5*(Fi_1 / Kunload)*Fi_1;
-            double  EiK     = engAcml - engDspt  - 0.5*(Fi_1 / Kunload)*Fi_1;
-            betaK           = pow( (EiK / (engRefK - EpjK)), c_K );
-            FailK           = (betaK>1);
-            betaK           = betaK < 0 ? 0 : (betaK>1 ? 1 : betaK);
-            Kunload         *= (1 - betaK);
+            const double  EpjK = engAcml - 0.5 * (Fi_1 / Kunload) * Fi_1;
+            const double  EiK = engAcml - engDspt - 0.5 * (Fi_1 / Kunload) * Fi_1;
+            betaK = pow( (EiK / (engRefK - EpjK)), c_K );
+            FailK = (betaK > 1);
+            betaK = betaK < 0 ? 0 : (betaK > 1 ? 1 : betaK);
+            Kunload *= (1 - betaK);
         }
-        Fi	    = Fi_1 + Kunload * dU;
+        Fi = Fi_1 + Kunload * dU;
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN NEW EXCURSION /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
         if (Branch == 1 && Fi_1*Fi <= 0.0) {
     /////////////////// UPDATE BACKBONE CURVE /////////////////////////////////////////////////
-            double Ei   = max(0.0, engAcml - engDspt);
-            betaS   = pow((Ei / (engRefS - engAcml)), c_S);
-            betaC   = pow((Ei / (engRefC - engAcml)), c_C);
-            betaA   = pow((Ei / (engRefA - engAcml)), c_A);
-            FailS   = (betaS>1);
-            FailC   = (betaC>1);
-            FailA   = (betaA>1);
-            betaS   = betaS < 0 ? 0 : (betaS>1 ? 1 : betaS);
-            betaC   = betaC < 0 ? 0 : (betaC>1 ? 1 : betaC);
-            betaA   = betaA < 0 ? 0 : (betaA>1 ? 1 : betaA);
+            const double Ei = max(0.0, engAcml - engDspt);
+            betaS = pow((Ei / (engRefS - engAcml)), c_S);
+            betaC = pow((Ei / (engRefC - engAcml)), c_C);
+            betaA = pow((Ei / (engRefA - engAcml)), c_A);
+            FailS = (betaS > 1);
+            FailC = (betaC > 1);
+            FailA = (betaA > 1);
+            betaS = betaS < 0 ? 0 : (betaS > 1 ? 1 : betaS);
+            betaC = betaC < 0 ? 0 : (betaC > 1 ? 1 : betaC);
+            betaA = betaA < 0 ? 0 : (betaA > 1 ? 1 : betaA);
             engDspt = engAcml;
         // Positive
             if (dU > 0) {
-                double FcapProj = posFcap  - posKpc * posUcap;
+                double FcapProj = posFcap - posKpc * posUcap;
             // Yield Point
-                posFy       *= (1 - betaS * D_pos);
-                posKp       *= (1 - betaS * D_pos); // Post-Yield Stiffness
-                FcapProj    *= (1 - betaC * D_pos);
-                posUglobal  *= (1 + betaA * D_pos); // Accelerated Reloading Stiffness
-                posUy       = posFy / Ke;
+                posFy *= (1 - betaS * D_pos);
+                posKp *= (1 - betaS * D_pos); // Post-Yield Stiffness
+                FcapProj *= (1 - betaC * D_pos);
+                posUglobal *= (1 + betaA * D_pos); // Accelerated Reloading Stiffness
+                posUy = posFy / Ke;
             // Capping Point
-                double FyProj   = posFy - posKp*posUy;
-                posUcap         = posKp <= posKpc ? 0 : (FcapProj - FyProj) / (posKp - posKpc);
-                posFcap         = FyProj + posKp*posUcap;
+                const double FyProj = posFy - posKp*posUy;
+                posUcap = posKp <= posKpc ? 0 : (FcapProj - FyProj) / (posKp - posKpc);
+                posFcap = FyProj + posKp*posUcap;
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (posUglobal < posUy) {           // Elastic Branch
                     posFglobal = Ke * posUglobal;
                 }
                 else if (posUglobal < posUcap) {    // Post-Yield Branch
-                    posFglobal = posFy   + posKp  * (posUglobal - posUy);
+                    posFglobal = posFy + posKp * (posUglobal - posUy);
                 }
                 else {                              // Post-Capping Branch
                     posFglobal = posFcap + posKpc * (posUglobal - posUcap);
@@ -211,55 +211,55 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
             }
         // Negative
             else {
-                double FcapProj = negFcap   - negKpc * negUcap;
+                double FcapProj = negFcap - negKpc * negUcap;
             // Yield Point
-                negFy	    *= (1 - betaS * D_neg);
-                negKp	    *= (1 - betaS * D_neg); // Post-Yield Stiffness
-                FcapProj    *= (1 - betaC * D_neg);
-                negUglobal	*= (1 + betaA * D_neg); // Accelerated Reloading Stiffness
-                negUy       = negFy / Ke;
+                negFy *= (1 - betaS * D_neg);
+                negKp *= (1 - betaS * D_neg); // Post-Yield Stiffness
+                FcapProj *= (1 - betaC * D_neg);
+                negUglobal *= (1 + betaA * D_neg); // Accelerated Reloading Stiffness
+                negUy = negFy / Ke;
             // Capping Point
-                double FyProj   = negFy - negKp*negUy;
-                negUcap         = negKp <= negKpc ? 0 : (FcapProj - FyProj) / (negKp - negKpc);
-                negFcap         = FyProj + negKp*negUcap;
+                const double FyProj = negFy - negKp*negUy;
+                negUcap = negKp <= negKpc ? 0 : (FcapProj - FyProj) / (negKp - negKpc);
+                negFcap = FyProj + negKp*negUcap;
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (negUy < negUglobal) {           // Elastic Branch
-                    negFglobal	= Ke * negUglobal;
+                    negFglobal = Ke * negUglobal;
                 }
                 else if (negUcap < negUglobal) {    // Post-Yield Branch
-                    negFglobal	= negFy   + negKp  * (negUglobal - negUy);
+                    negFglobal = negFy + negKp * (negUglobal - negUy);
                 }
                 else {                              // Post-Capping Branch
-                    negFglobal  = negFcap + negKpc * (negUglobal - negUcap);
+                    negFglobal = negFcap + negKpc * (negUglobal - negUcap);
                 }
                 if (negFres < negFglobal) {     // Residual Branch
-                    negFglobal  = negFres;
+                    negFglobal = negFres;
                 }
-                negUres  	= (negFres - negFcap + negKpc * negUcap) / negKpc;
+                negUres = (negFres - negFcap + negKpc * negUcap) / negKpc;
             }
     ////////////////////////// RELOADING TARGET DETERMINATION /////////////////////////////////
             if (dU > 0) {
-                double u0 	    = Ui_1 - (Fi_1 / Kunload);
-                double Kglobal  = posFglobal    / (posUglobal - u0);
-                double Klocal   = posFlocal     / (posUlocal  - u0);
+                const double u0 = Ui_1 - (Fi_1 / Kunload);
+                const double Kglobal = posFglobal / (posUglobal - u0);
+                const double Klocal = posFlocal / (posUlocal - u0);
                 if ( u0 < posUlocal && posFlocal < posFglobal && Klocal > Kglobal) {
-                    Branch  = 3;
+                    Branch = 3;
                     Kreload = Klocal;
                 } else {
-                    Branch  = 4;
+                    Branch = 4;
                     Kreload = Kglobal;
                 }
             }
             else {
-                double u0 	    = Ui_1 - (Fi_1 / Kunload);
-                double Kglobal  = negFglobal    / (negUglobal - u0);
-                double Klocal   = negFlocal     / (negUlocal  - u0);
+                const double u0 = Ui_1 - (Fi_1 / Kunload);
+                const double Kglobal = negFglobal / (negUglobal - u0);
+                const double Klocal = negFlocal / (negUlocal - u0);
                 if ( u0 > negUlocal && negFlocal > negFglobal && Klocal > Kglobal) {
-                    Branch  = 13;
+                    Branch = 13;
                     Kreload = Klocal;
                 } else {
-                    Branch  = 14;
+                    Branch = 14;
                     Kreload = Kglobal;
                 }
             }
@@ -285,45 +285,45 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     // Branch shifting from 3 -> 4 -> 5 -> 6 -> 7
         // int exBranch = Branch;
         if (Branch == 0 && Ui > posUy) {            // Yield in Positive
-            Branch  = 5;
+            Branch = 5;
         } else if (Branch == 0 && Ui < negUy) {     // Yield in Negative
-            Branch  = 15;
+            Branch = 15;
         } else if (Branch == 1 && Fi_1 > 0 && Ui > posUlocal) {
-            double Kglobal = (posFglobal   - posFlocal) / (posUglobal  - posUlocal);
+            const double Kglobal = (posFglobal - posFlocal) / (posUglobal - posUlocal);
             Kreload = Kglobal;
-            Branch  = 4;                        // Towards Global Peak
+            Branch = 4;                        // Towards Global Peak
         } else if (Branch == 1 && Fi_1 < 0 && Ui < negUlocal) {    // Back to Reloading (Negative)
-            double Kglobal = (negFglobal   - negFlocal) / (negUglobal  - negUlocal);
+            const double Kglobal = (negFglobal - negFlocal) / (negUglobal - negUlocal);
             Kreload = Kglobal;
-            Branch  = 14;                   // Towards Global Peak
+            Branch = 14;                   // Towards Global Peak
         }
     // Positive
         if (Branch == 3 && Ui > posUlocal) {
-            Kreload     = (posFglobal - posFlocal) / (posUglobal - posUlocal);
-            Branch      = 4;
+            Kreload = (posFglobal - posFlocal) / (posUglobal - posUlocal);
+            Branch = 4;
         }
         if (Branch == 4 && Ui > posUglobal) {
-            Branch 	    = 5;
+            Branch = 5;
         }
         if (Branch == 5 && Ui > posUcap) {
-            Branch 	    = 6;
+            Branch = 6;
         }
         if (Branch == 6 && Ui > posUres) {
-            Branch 	    = 7;
+            Branch = 7;
         }
     // Negative
         if (Branch == 13 && Ui < negUlocal) {
-            Kreload     = (negFglobal - negFlocal) / (negUglobal - negUlocal);
-            Branch      = 14;
+            Kreload = (negFglobal - negFlocal) / (negUglobal - negUlocal);
+            Branch = 14;
         }
         if (Branch == 14 && Ui < negUglobal) {
-            Branch 	    = 15;
+            Branch = 15;
         }
         if (Branch == 15 && Ui < negUcap) {
-            Branch 	    = 16;
+            Branch = 16;
         }
         if (Branch == 16 && Ui < negUres) {
-            Branch 	    = 17;
+            Branch = 17;
         }
     // Branch Change check
         // if (Branch!=exBranch) {
@@ -335,54 +335,54 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
         if (Branch == 0) {
-            Fi  = Ke*Ui;
+            Fi = Ke * Ui;
         } else if (Branch == 1) {
-            Fi  = Fi_1 + Kunload*dU;
+            Fi = Fi_1 + Kunload * dU;
     // Positive
         } else if (Branch == 3) {
-            Fi  = posFlocal + Kreload*(Ui - posUlocal);
+            Fi = posFlocal + Kreload * (Ui - posUlocal);
         } else if (Branch == 4) {
-            Fi  = posFglobal + Kreload*(Ui - posUglobal);
+            Fi = posFglobal + Kreload * (Ui - posUglobal);
         } else if (Branch == 5) {
-            Fi  = posFcap   + posKp*(Ui - posUcap);
+            Fi = posFcap + posKp * (Ui - posUcap);
         } else if (Branch == 6) {
-            Fi  = posFcap   + posKpc*(Ui - posUcap);
+            Fi = posFcap + posKpc * (Ui - posUcap);
         } else if (Branch == 7) {
-            Fi  = posFres;
+            Fi = posFres;
     // Negative
         } else if (Branch == 13) {
-            Fi  = negFlocal + Kreload*(Ui - negUlocal);
+            Fi = negFlocal + Kreload * (Ui - negUlocal);
         } else if (Branch == 14) {
-            Fi  = negFglobal + Kreload*(Ui - negUglobal);
+            Fi = negFglobal + Kreload * (Ui - negUglobal);
         } else if (Branch == 15) {
-            Fi  = negFcap   + negKp*(Ui - negUcap);
+            Fi = negFcap + negKp * (Ui - negUcap);
         } else if (Branch == 16) {
-            Fi  = negFcap   + negKpc*(Ui - negUcap);
+            Fi = negFcap + negKpc * (Ui - negUcap);
         } else if (Branch == 17) {
-            Fi  = negFres;
+            Fi = negFres;
         }
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
     // CHECK FOR FAILURE
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        bool	FailPp 	= ( posFglobal == 0           );
-        bool	FailPn 	= ( negFglobal == 0           );
-        bool	FailDp 	= ( dU > 0 && Ui >=  posUu_0  );
-        bool	FailDn 	= ( dU < 0 && Ui <= -negUu_0  );
-        bool	FailRp 	= ( Branch == 7     && Fi <= 0);
-        bool	FailRn 	= ( Branch == 17    && Fi >= 0);
-        if (FailS||FailC||FailA||FailK||FailPp||FailPn||FailRp||FailRn||FailDp||FailDn) {
-            Fi  = 0;
-            Failure_Flag    = true;
+        const bool	FailPp = ( posFglobal == 0 );
+        const bool	FailPn = ( negFglobal == 0 );
+        const bool	FailDp = ( dU > 0 && Ui >=  posUu_0 );
+        const bool	FailDn = ( dU < 0 && Ui <= -negUu_0 );
+        const bool	FailRp = ( Branch == 7 && Fi <= 0);
+        const bool	FailRn = ( Branch == 17 && Fi >= 0);
+        if (FailS || FailC || FailA || FailK || FailPp || FailPn || FailRp || FailRn || FailDp || FailDn) {
+            Fi = 0;
+            Failure_Flag = true;
         }
 
-        engAcml += 0.5*(Fi + Fi_1)*dU;   // Internal energy increment
+        engAcml += 0.5 * (Fi + Fi_1) * dU;   // Internal energy increment
 
-        KgetTangent  = (Fi - Fi_1) / dU;
+        KgetTangent = (Fi - Fi_1) / dU;
     }
     if (KgetTangent==0) {
-        KgetTangent  = 1e-6;
+        KgetTangent = 1e-6;
     }
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -422,44 +422,44 @@ int IMKPeakOriented::commitState(void)
 
     //commit trial  variables
 // 12 Pos U and F
-    cPosUy	    = posUy;
-    cPosFy	    = posFy;
-    cPosUcap	= posUcap;
-    cPosFcap	= posFcap;
-    cPosUlocal	= posUlocal;
-    cPosFlocal	= posFlocal;
-    cPosUglobal	= posUglobal;
-    cPosFglobal	= posFglobal;
-    cPosUres	= posUres;
-    cPosFres	= posFres;
-    cPosKp	    = posKp;
-    cPosKpc	    = posKpc;
+    cPosUy = posUy;
+    cPosFy = posFy;
+    cPosUcap = posUcap;
+    cPosFcap = posFcap;
+    cPosUlocal = posUlocal;
+    cPosFlocal = posFlocal;
+    cPosUglobal = posUglobal;
+    cPosFglobal = posFglobal;
+    cPosUres = posUres;
+    cPosFres = posFres;
+    cPosKp = posKp;
+    cPosKpc = posKpc;
 // 12 Neg U and F
-    cNegUy	    = negUy;
-    cNegFy	    = negFy;
-    cNegUcap	= negUcap;
-    cNegFcap	= negFcap;
-    cNegUlocal	= negUlocal;
-    cNegFlocal	= negFlocal;
-    cNegUglobal	= negUglobal;
-    cNegFglobal	= negFglobal;
-    cNegUres	= negUres;
-    cNegFres	= negFres;
-    cNegKp	    = negKp;
-    cNegKpc	    = negKpc;
+    cNegUy = negUy;
+    cNegFy = negFy;
+    cNegUcap = negUcap;
+    cNegFcap = negFcap;
+    cNegUlocal = negUlocal;
+    cNegFlocal = negFlocal;
+    cNegUglobal = negUglobal;
+    cNegFglobal = negFglobal;
+    cNegUres = negUres;
+    cNegFres = negFres;
+    cNegKp = negKp;
+    cNegKpc = negKpc;
 // 3 State
-    cU		    = U;
-    cUi	    	= Ui;
-    cFi	        = Fi;
+    cU = U;
+    cUi = Ui;
+    cFi = Fi;
 // 2 Stiffness
-    cKreload	= Kreload;
-    cKunload	= Kunload;
+    cKreload = Kreload;
+    cKunload = Kunload;
 // 2 Energy
-    cEngAcml	= engAcml;
-    cEngDspt	= engDspt;
+    cEngAcml = engAcml;
+    cEngDspt = engDspt;
 // 2 Flag
-    cFailure_Flag   = Failure_Flag;
-    cBranch         = Branch;
+    cFailure_Flag = Failure_Flag;
+    cBranch = Branch;
     return 0;
 }
 
@@ -468,44 +468,44 @@ int IMKPeakOriented::revertToLastCommit(void)
     //cout << " revertToLastCommit" << endln;
     //the opposite of commit trial history variables
 // 12 Positive U and F
-    posUy	        = cPosUy;
-    posFy	        = cPosFy;
-    posUcap	        = cPosUcap;
-    posFcap	        = cPosFcap;
-    posUlocal	    = cPosUlocal;
-    posFlocal	    = cPosFlocal;
-    posUglobal	    = cPosUglobal;
-    posFglobal	    = cPosFglobal;
-    posUres	        = cPosUres;
-    posFres	        = cPosFres;
-    posKp	        = cPosKp;
-    posKpc	        = cPosKpc;
+    posUy = cPosUy;
+    posFy = cPosFy;
+    posUcap = cPosUcap;
+    posFcap = cPosFcap;
+    posUlocal = cPosUlocal;
+    posFlocal = cPosFlocal;
+    posUglobal = cPosUglobal;
+    posFglobal = cPosFglobal;
+    posUres = cPosUres;
+    posFres = cPosFres;
+    posKp = cPosKp;
+    posKpc = cPosKpc;
 // 12 Negative U and F
-    negUy	        = cNegUy;
-    negFy	        = cNegFy;
-    negUcap	        = cNegUcap;
-    negFcap	        = cNegFcap;
-    negUlocal	    = cNegUlocal;
-    negFlocal	    = cNegFlocal;
-    negUglobal	    = cNegUglobal;
-    negFglobal	    = cNegFglobal;
-    negUres	        = cNegUres;
-    negFres	        = cNegFres;
-    negKp       	= cNegKp;
-    negKpc	        = cNegKpc;
+    negUy = cNegUy;
+    negFy = cNegFy;
+    negUcap = cNegUcap;
+    negFcap = cNegFcap;
+    negUlocal = cNegUlocal;
+    negFlocal = cNegFlocal;
+    negUglobal = cNegUglobal;
+    negFglobal = cNegFglobal;
+    negUres = cNegUres;
+    negFres = cNegFres;
+    negKp = cNegKp;
+    negKpc = cNegKpc;
 // 3 State Variables
-    U	            = cU;
-    Ui	            = cUi;
-    Fi	            = cFi;
+    U = cU;
+    Ui = cUi;
+    Fi = cFi;
 // 2 Stiffness
-    Kreload	        = cKreload;
-    Kunload	        = cKunload;
+    Kreload = cKreload;
+    Kunload = cKunload;
 // 2 Energy
-    engAcml	        = cEngAcml;
-    engDspt	        = cEngDspt;
+    engAcml = cEngAcml;
+    engDspt = cEngDspt;
 // 2 Flag
-    Failure_Flag	= cFailure_Flag;
-    Branch          = cBranch;
+    Failure_Flag = cFailure_Flag;
+    Branch = cBranch;
     return 0;
 }
 
@@ -515,60 +515,60 @@ int IMKPeakOriented::revertToStart(void)
     //////////////////////////////////////////////////////////////////// ONE TIME CALCULATIONS ////////////////////////////////////////////////////////////////////\\
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
 // 14 Initial Values
-    posUy_0  	= posFy_0   / Ke;
-    posUcap_0	= posUy_0   + posUp_0;
-    posFcap_0	= posFcapFy_0*posFy_0;
-    posKp_0 	= (posFcap_0 - posFy_0) / posUp_0;
-    posKpc_0 	= posFcap_0 / posUpc_0;
-    negUy_0 	= negFy_0   / Ke;
-    negUcap_0	= negUy_0   + negUp_0;
-    negFcap_0	= negFcapFy_0*negFy_0;
-    negKp_0 	= (negFcap_0 - negFy_0) / negUp_0;
-    negKpc_0 	= negFcap_0 / negUpc_0;
-    engRefS	    = LAMBDA_S  * posFy_0;
-    engRefC	    = LAMBDA_C  * posFy_0;
-    engRefA	    = LAMBDA_A  * posFy_0;
-    engRefK	    = LAMBDA_K  * posFy_0;
+    posUy_0 = posFy_0 / Ke;
+    posUcap_0 = posUy_0 + posUp_0;
+    posFcap_0 = posFcapFy_0*posFy_0;
+    posKp_0 = (posFcap_0 - posFy_0) / posUp_0;
+    posKpc_0 = posFcap_0 / posUpc_0;
+    negUy_0 = negFy_0 / Ke;
+    negUcap_0 = negUy_0 + negUp_0;
+    negFcap_0 = negFcapFy_0*negFy_0;
+    negKp_0 = (negFcap_0 - negFy_0) / negUp_0;
+    negKpc_0 = negFcap_0 / negUpc_0;
+    engRefS = LAMBDA_S * posFy_0;
+    engRefC = LAMBDA_C * posFy_0;
+    engRefA = LAMBDA_A * posFy_0;
+    engRefK = LAMBDA_K * posFy_0;
 // 12 Positive U and F
-    posUy		= cPosUy	    = posUy_0;
-    posFy    	= cPosFy 	    = posFy_0;
-    posUcap  	= cPosUcap	    = posUcap_0;
-    posFcap  	= cPosFcap	    = posFcap_0;
-    posUlocal	= cPosUlocal	= posUy_0;
-    posFlocal	= cPosFlocal	= posFy_0;
-    posUglobal	= cPosUglobal	= posUy_0;
-    posFglobal	= cPosFglobal	= posFy_0;
-    posFres  	= cPosFres	    = posFy_0*posFresFy_0;
-    posKp    	= cPosKp 	    =  posKp_0;
-    posKpc   	= cPosKpc   	= -posKpc_0;
-    posUres	    = cPosUres	    = (posFres - posFcap) / posKpc + posUcap;
+    posUy = cPosUy = posUy_0;
+    posFy = cPosFy = posFy_0;
+    posUcap = cPosUcap = posUcap_0;
+    posFcap = cPosFcap = posFcap_0;
+    posUlocal = cPosUlocal = posUy_0;
+    posFlocal = cPosFlocal = posFy_0;
+    posUglobal = cPosUglobal = posUy_0;
+    posFglobal = cPosFglobal = posFy_0;
+    posFres = cPosFres = posFy_0*posFresFy_0;
+    posKp = cPosKp =  posKp_0;
+    posKpc = cPosKpc = -posKpc_0;
+    posUres = cPosUres = (posFres - posFcap) / posKpc + posUcap;
 // 12 Negative U and F
-    negUy    	= cNegUy	    = -negUy_0;
-    negFy    	= cNegFy	    = -negFy_0;
-    negUcap  	= cNegUcap	    = -negUcap_0;
-    negFcap  	= cNegFcap	    = -negFcap_0;
-    negUlocal	= cNegUlocal	= -negUy_0;
-    negFlocal	= cNegFlocal	= -negFy_0;
-    negUglobal	= cNegUglobal	= -negUy_0;
-    negFglobal	= cNegFglobal	= -negFy_0;
-    negFres  	= cNegFres	    = -negFy_0*negFresFy_0;
-    negKp    	= cNegKp	    =  negKp_0;
-    negKpc   	= cNegKpc	    = -negKpc_0;
-    negUres	    = cNegUres	    = (negFres - negFcap) / negKpc + negUcap;
+    negUy = cNegUy = -negUy_0;
+    negFy = cNegFy = -negFy_0;
+    negUcap = cNegUcap = -negUcap_0;
+    negFcap = cNegFcap = -negFcap_0;
+    negUlocal = cNegUlocal = -negUy_0;
+    negFlocal = cNegFlocal = -negFy_0;
+    negUglobal = cNegUglobal = -negUy_0;
+    negFglobal = cNegFglobal = -negFy_0;
+    negFres = cNegFres = -negFy_0*negFresFy_0;
+    negKp = cNegKp =  negKp_0;
+    negKpc = cNegKpc = -negKpc_0;
+    negUres = cNegUres = (negFres - negFcap) / negKpc + negUcap;
 // 3 State Values
-    U	        = cU	        = 0;
-    Ui      	= cUi 	        = 0;
-    Fi 	        = cFi 	        = 0;
+    U = cU = 0;
+    Ui = cUi = 0;
+    Fi = cFi = 0;
 // 2 Stiffness
-    Kreload	    = cKreload	    = Ke;
-    Kunload	    = cKunload	    = Ke;
+    Kreload = cKreload = Ke;
+    Kunload = cKunload = Ke;
     KgetTangent = Ke;
 // 2 Energy
-    engAcml 	= cEngAcml	    = 0.0;
-    engDspt	    = cEngDspt	    = 0.0;
+    engAcml = cEngAcml = 0.0;
+    engDspt = cEngDspt = 0.0;
 // 2 Flag
-    Failure_Flag    = cFailure_Flag = false;
-    Branch      	= cBranch       = 0;
+    Failure_Flag= cFailure_Flag = false;
+    Branch = cBranch = 0;
     return 0;
 }
 
@@ -582,83 +582,83 @@ IMKPeakOriented::getCopy(void)
 
     //cout << " getCopy" << endln;
 // 12 Positive U and F
-    theCopy->posUy      = posUy;
-    theCopy->posFy      = posFy;
-    theCopy->posUcap    = posUcap;
-    theCopy->posFcap    = posFcap;
-    theCopy->posUlocal  = posUlocal;
-    theCopy->posFlocal  = posFlocal;
+    theCopy->posUy = posUy;
+    theCopy->posFy = posFy;
+    theCopy->posUcap = posUcap;
+    theCopy->posFcap = posFcap;
+    theCopy->posUlocal = posUlocal;
+    theCopy->posFlocal = posFlocal;
     theCopy->posUglobal = posUglobal;
     theCopy->posFglobal = posFglobal;
-    theCopy->posUres    = posUres;
-    theCopy->posFres    = posFres;
-    theCopy->posKp      = posKp;
-    theCopy->posKpc     = posKpc;
+    theCopy->posUres = posUres;
+    theCopy->posFres = posFres;
+    theCopy->posKp = posKp;
+    theCopy->posKpc = posKpc;
 // 12 Negative U and F
-    theCopy->negUy      = negUy;
-    theCopy->negFy      = negFy;
-    theCopy->negUcap    = negUcap;
-    theCopy->negFcap    = negFcap;
-    theCopy->negUlocal  = negUlocal;
-    theCopy->negFlocal  = negFlocal;
+    theCopy->negUy = negUy;
+    theCopy->negFy = negFy;
+    theCopy->negUcap = negUcap;
+    theCopy->negFcap = negFcap;
+    theCopy->negUlocal = negUlocal;
+    theCopy->negFlocal = negFlocal;
     theCopy->negUglobal = negUglobal;
     theCopy->negFglobal = negFglobal;
-    theCopy->negUres    = negUres;
-    theCopy->negFres    = negFres;
-    theCopy->negKp      = negKp;
-    theCopy->negKpc     = negKpc;
+    theCopy->negUres = negUres;
+    theCopy->negFres = negFres;
+    theCopy->negKp = negKp;
+    theCopy->negKpc = negKpc;
 // 3 State Values
-    theCopy->U          = U;
-    theCopy->Ui         = Ui;
-    theCopy->Fi         = Fi;
+    theCopy->U = U;
+    theCopy->Ui = Ui;
+    theCopy->Fi = Fi;
 // 2 Stiffness
-    theCopy->Kreload    = Kreload;
-    theCopy->Kunload    = Kunload;
+    theCopy->Kreload = Kreload;
+    theCopy->Kunload = Kunload;
 // 2 Energy
-    theCopy->engAcml    = engAcml;
-    theCopy->engDspt    = engDspt;
+    theCopy->engAcml = engAcml;
+    theCopy->engDspt = engDspt;
 // 2 Flag
-    theCopy->Failure_Flag   = Failure_Flag;
-    theCopy->Branch     = Branch;
+    theCopy->Failure_Flag = Failure_Flag;
+    theCopy->Branch = Branch;
 // 12 Positive U and F
-    theCopy->cPosUy     = cPosUy;
-    theCopy->cPosFy     = cPosFy;
-    theCopy->cPosUcap   = cPosUcap;
-    theCopy->cPosFcap   = cPosFcap;
+    theCopy->cPosUy = cPosUy;
+    theCopy->cPosFy = cPosFy;
+    theCopy->cPosUcap = cPosUcap;
+    theCopy->cPosFcap = cPosFcap;
     theCopy->cPosUlocal = cPosUlocal;
     theCopy->cPosFlocal = cPosFlocal;
     theCopy->cPosUglobal= cPosUglobal;
     theCopy->cPosFglobal= cPosFglobal;
-    theCopy->cPosUres   = cPosUres;
-    theCopy->cPosFres   = cPosFres;
-    theCopy->cPosKp     = cPosKp;
-    theCopy->cPosKpc    = cPosKpc;
+    theCopy->cPosUres = cPosUres;
+    theCopy->cPosFres = cPosFres;
+    theCopy->cPosKp = cPosKp;
+    theCopy->cPosKpc = cPosKpc;
 // 12 Negative U and F
-    theCopy->cNegUy     = cNegUy;
-    theCopy->cNegFy     = cNegFy;
-    theCopy->cNegUcap   = cNegUcap;
-    theCopy->cNegFcap   = cNegFcap;
+    theCopy->cNegUy = cNegUy;
+    theCopy->cNegFy = cNegFy;
+    theCopy->cNegUcap = cNegUcap;
+    theCopy->cNegFcap = cNegFcap;
     theCopy->cNegUglobal= cNegUglobal;
     theCopy->cNegFglobal= cNegFglobal;
     theCopy->cNegUlocal = cNegUlocal;
     theCopy->cNegFlocal = cNegFlocal;
-    theCopy->cNegUres   = cNegUres;
-    theCopy->cNegFres   = cNegFres;
-    theCopy->cNegKp     = cNegKp;
-    theCopy->cNegKpc    = cNegKpc;
+    theCopy->cNegUres = cNegUres;
+    theCopy->cNegFres = cNegFres;
+    theCopy->cNegKp = cNegKp;
+    theCopy->cNegKpc = cNegKpc;
 // 3 State
-    theCopy->cU         = cU;
-    theCopy->cUi        = cUi;
-    theCopy->cFi        = cFi;
+    theCopy->cU = cU;
+    theCopy->cUi = cUi;
+    theCopy->cFi = cFi;
 // 2 Stiffness
-    theCopy->cKreload   = cKreload;
-    theCopy->cKunload   = cKunload;
+    theCopy->cKreload = cKreload;
+    theCopy->cKunload = cKunload;
 // 2 Energy
-    theCopy->cEngAcml   = cEngAcml;
-    theCopy->cEngDspt   = cEngDspt;
+    theCopy->cEngAcml = cEngAcml;
+    theCopy->cEngDspt = cEngDspt;
 // 2 Flag
-    theCopy->cFailure_Flag  = cFailure_Flag;
-    theCopy->cBranch    = Branch;
+    theCopy->cFailure_Flag = cFailure_Flag;
+    theCopy->cBranch = cBranch;
     return theCopy;
 }
 
@@ -670,122 +670,122 @@ int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
     static Vector data(137);
     data(0) = this->getTag();
 // 23 Fixed Input Material Parameters 1-25
-    data(1)  	= Ke;
-    data(2)  	= posUp_0;
-    data(3)  	= posUpc_0;
-    data(4)  	= posUu_0;
-    data(5)  	= posFy_0;
-    data(6)  	= posFcapFy_0;
-    data(7)  	= posFresFy_0;
-    data(8)  	= negUp_0;
-    data(9)  	= negUpc_0;
-    data(10) 	= negUu_0;
-    data(11) 	= negFy_0;
-    data(12) 	= negFcapFy_0;
-    data(13) 	= negFresFy_0;
-    data(14) 	= LAMBDA_S;
-    data(15) 	= LAMBDA_C;
-    data(16) 	= LAMBDA_A;
-    data(17) 	= LAMBDA_K;
-    data(18) 	= c_S;
-    data(19) 	= c_C;
-    data(20) 	= c_A;
-    data(21) 	= c_K;
-    data(22) 	= D_pos;
-    data(23) 	= D_neg;
+    data(1) = Ke;
+    data(2) = posUp_0;
+    data(3) = posUpc_0;
+    data(4) = posUu_0;
+    data(5) = posFy_0;
+    data(6) = posFcapFy_0;
+    data(7) = posFresFy_0;
+    data(8) = negUp_0;
+    data(9) = negUpc_0;
+    data(10) = negUu_0;
+    data(11) = negFy_0;
+    data(12) = negFcapFy_0;
+    data(13) = negFresFy_0;
+    data(14) = LAMBDA_S;
+    data(15) = LAMBDA_C;
+    data(16) = LAMBDA_A;
+    data(17) = LAMBDA_K;
+    data(18) = c_S;
+    data(19) = c_C;
+    data(20) = c_A;
+    data(21) = c_K;
+    data(22) = D_pos;
+    data(23) = D_neg;
 // 14 Initial Values 31-44
-    data(31)	= posUy_0;
-    data(32)	= posUcap_0;
-    data(33)	= posFcap_0;
-    data(34)	= posKp_0;
-    data(35)	= posKpc_0;
-    data(36)	= negUy_0;
-    data(37)	= negUcap_0;
-    data(38)	= negFcap_0;
-    data(39)	= negKp_0;
-    data(40)	= negKpc_0;
-    data(41)	= engRefS;
-    data(42)	= engRefC;
-    data(43)	= engRefA;
-    data(44)	= engRefK;
+    data(31) = posUy_0;
+    data(32) = posUcap_0;
+    data(33) = posFcap_0;
+    data(34) = posKp_0;
+    data(35) = posKpc_0;
+    data(36) = negUy_0;
+    data(37) = negUcap_0;
+    data(38) = negFcap_0;
+    data(39) = negKp_0;
+    data(40) = negKpc_0;
+    data(41) = engRefS;
+    data(42) = engRefC;
+    data(43) = engRefA;
+    data(44) = engRefK;
 // 12 Positive U and F 51-62
-    data(51) 	= posUy;
-    data(52) 	= posFy;
-    data(53) 	= posUcap;
-    data(54) 	= posFcap;
-    data(55) 	= posUlocal;
-    data(56) 	= posFlocal;
-    data(57) 	= posUglobal;
-    data(58) 	= posFglobal;
-    data(59) 	= posUres;
-    data(60) 	= posFres;
-    data(51) 	= posKp;
-    data(62) 	= posKpc;
+    data(51) = posUy;
+    data(52) = posFy;
+    data(53) = posUcap;
+    data(54) = posFcap;
+    data(55) = posUlocal;
+    data(56) = posFlocal;
+    data(57) = posUglobal;
+    data(58) = posFglobal;
+    data(59) = posUres;
+    data(60) = posFres;
+    data(51) = posKp;
+    data(62) = posKpc;
 // 3 State Variables 63-65
-    data(63)    = U;
-    data(64) 	= Ui;
-    data(65) 	= Fi;
+    data(63) = U;
+    data(64) = Ui;
+    data(65) = Fi;
 // 2 Stiffness 66 67
-    data(66)	= Kreload;
-    data(67) 	= Kunload;
+    data(66) = Kreload;
+    data(67) = Kunload;
 // 2 Energy 68 69
-    data(68) 	= engAcml;
-    data(69) 	= engDspt;
+    data(68) = engAcml;
+    data(69) = engDspt;
 // 12 Negative U and F 71-82
-    data(71) 	= negUy;
-    data(72) 	= negFy;
-    data(73) 	= negUcap;
-    data(74) 	= negFcap;
-    data(75) 	= negUlocal;
-    data(76) 	= negFlocal;
-    data(77) 	= negUglobal;
-    data(78) 	= negFglobal;
-    data(79) 	= negUres;
-    data(80) 	= negFres;
-    data(81) 	= negKp;
-    data(82) 	= negKpc;
+    data(71) = negUy;
+    data(72) = negFy;
+    data(73) = negUcap;
+    data(74) = negFcap;
+    data(75) = negUlocal;
+    data(76) = negFlocal;
+    data(77) = negUglobal;
+    data(78) = negFglobal;
+    data(79) = negUres;
+    data(80) = negFres;
+    data(81) = negKp;
+    data(82) = negKpc;
 // 2 Flag 85 86
-    data(85)	= Failure_Flag;
-    data(86) 	= Branch;
+    data(85) = Failure_Flag;
+    data(86) = Branch;
 // 12 Positive U and F 101-112
-    data(101)	= cPosUy;
-    data(102)	= cPosFy;
-    data(103)	= cPosUcap;
-    data(104)	= cPosFcap;
-    data(105)	= cPosUlocal;
-    data(106)	= cPosFlocal;
-    data(107)	= cPosUglobal;
-    data(108)	= cPosFglobal;
-    data(109)	= cPosUres;
-    data(110)	= cPosFres;
-    data(111)	= cPosKp;
-    data(112)	= cPosKpc;
+    data(101) = cPosUy;
+    data(102) = cPosFy;
+    data(103) = cPosUcap;
+    data(104) = cPosFcap;
+    data(105) = cPosUlocal;
+    data(106) = cPosFlocal;
+    data(107) = cPosUglobal;
+    data(108) = cPosFglobal;
+    data(109) = cPosUres;
+    data(110) = cPosFres;
+    data(111) = cPosKp;
+    data(112) = cPosKpc;
 // 3 State Variables 113-115
-    data(113)   = cU;
-    data(114)	= cUi;
-    data(115)	= cFi;
+    data(113) = cU;
+    data(114) = cUi;
+    data(115) = cFi;
 // 2 Stiffness 116 117
-    data(116)   = cKreload;
-    data(117)	= cKunload;
+    data(116) = cKreload;
+    data(117) = cKunload;
 // 2 Energy 118 119
-    data(118)   = cEngAcml;
-    data(119)   = cEngDspt;
+    data(118) = cEngAcml;
+    data(119) = cEngDspt;
 // 12 Negative U and F 121-132
-    data(121)	= cNegUy;
-    data(122)	= cNegFy;
-    data(123)	= cNegUcap;
-    data(124)	= cNegFcap;
-    data(125)	= cNegUlocal;
-    data(126)	= cNegFlocal;
-    data(127)	= cNegUglobal;
-    data(128)	= cNegFglobal;
-    data(129)	= cNegUres;
-    data(130)	= cNegFres;
-    data(131)	= cNegKp;
-    data(132)	= cNegKpc;
+    data(121) = cNegUy;
+    data(122) = cNegFy;
+    data(123) = cNegUcap;
+    data(124) = cNegFcap;
+    data(125) = cNegUlocal;
+    data(126) = cNegFlocal;
+    data(127) = cNegUglobal;
+    data(128) = cNegFglobal;
+    data(129) = cNegUres;
+    data(130) = cNegFres;
+    data(131) = cNegKp;
+    data(132) = cNegKpc;
 // 2 Flag 135 136
-    data(135)	= cFailure_Flag;
-    data(136)	= cBranch;
+    data(135) = cFailure_Flag;
+    data(136) = cBranch;
     res = theChannel.sendVector(this->getDbTag(), cTag, data);
     if (res < 0)
         opserr << "IMKPeakOriented::sendSelf() - failed to send data\n";
@@ -806,122 +806,122 @@ int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &t
         cout << " recvSelf" << endln;
         this->setTag((int)data(0));
     // 23 Fixed Input Material Parameters
-        Ke				= data(1);
-        posUp_0			= data(2);
-        posUpc_0		= data(3);
-        posUu_0			= data(4);
-        posFy_0			= data(5);
-        posFcapFy_0		= data(6);
-        posFresFy_0		= data(7);
-        negUp_0			= data(8);
-        negUpc_0		= data(9);
-        negUu_0			= data(10);
-        negFy_0			= data(11);
-        negFcapFy_0		= data(12);
-        negFresFy_0		= data(13);
-        LAMBDA_S		= data(14);
-        LAMBDA_C		= data(15);
-        LAMBDA_A		= data(16);
-        LAMBDA_K		= data(17);
-        c_S				= data(18);
-        c_C				= data(19);
-        c_A				= data(20);
-        c_K				= data(21);
-        D_pos			= data(22);
-        D_neg			= data(23);
+        Ke = data(1);
+        posUp_0 = data(2);
+        posUpc_0 = data(3);
+        posUu_0 = data(4);
+        posFy_0 = data(5);
+        posFcapFy_0 = data(6);
+        posFresFy_0 = data(7);
+        negUp_0 = data(8);
+        negUpc_0 = data(9);
+        negUu_0 = data(10);
+        negFy_0 = data(11);
+        negFcapFy_0 = data(12);
+        negFresFy_0 = data(13);
+        LAMBDA_S = data(14);
+        LAMBDA_C = data(15);
+        LAMBDA_A = data(16);
+        LAMBDA_K = data(17);
+        c_S = data(18);
+        c_C = data(19);
+        c_A = data(20);
+        c_K = data(21);
+        D_pos = data(22);
+        D_neg = data(23);
     // 14 Initial Values
-        posUy_0			= data(31);
-        posUcap_0		= data(32);
-        posFcap_0		= data(33);
-        posKp_0			= data(34);
-        posKpc_0		= data(35);
-        negUy_0			= data(36);
-        negUcap_0		= data(37);
-        negFcap_0		= data(38);
-        negKp_0			= data(39);
-        negKpc_0		= data(40);
-        engRefS			= data(41);
-        engRefC			= data(42);
-        engRefA			= data(43);
-        engRefK			= data(44);
+        posUy_0 = data(31);
+        posUcap_0 = data(32);
+        posFcap_0 = data(33);
+        posKp_0 = data(34);
+        posKpc_0 = data(35);
+        negUy_0 = data(36);
+        negUcap_0 = data(37);
+        negFcap_0 = data(38);
+        negKp_0 = data(39);
+        negKpc_0 = data(40);
+        engRefS = data(41);
+        engRefC = data(42);
+        engRefA = data(43);
+        engRefK = data(44);
     // 12 Positive U and F
-        posUy			= data(51);
-        posFy			= data(52);
-        posUcap		    = data(53);
-        posFcap		   	= data(54);
-        posUlocal	    = data(55);
-        posFlocal	    = data(56);
-        posUglobal	    = data(57);
-        posFglobal	    = data(58);
-        posUres	    	= data(59);
-        posFres		   	= data(60);
-        posKp			= data(61);
-        posKpc		    = data(62);
+        posUy = data(51);
+        posFy = data(52);
+        posUcap = data(53);
+        posFcap = data(54);
+        posUlocal = data(55);
+        posFlocal = data(56);
+        posUglobal = data(57);
+        posFglobal = data(58);
+        posUres = data(59);
+        posFres = data(60);
+        posKp = data(61);
+        posKpc = data(62);
     // 3 State Variables
-        U               = data(63);
-        Ui				= data(64);
-        Fi				= data(65);
+        U = data(63);
+        Ui = data(64);
+        Fi = data(65);
     // 2 Stiffness
-        Kreload		= data(66);
-        Kunload	    	= data(67);
+        Kreload = data(66);
+        Kunload = data(67);
     // 2 Energy
-        engAcml			= data(68);
-        engDspt		    = data(69);
+        engAcml = data(68);
+        engDspt = data(69);
     // 12 Negative U and F
-        negUy			= data(71);
-        negFy			= data(72);
-        negUcap		    = data(73);
-        negFcap		   	= data(74);
-        negUlocal	    = data(75);
-        negFlocal  	    = data(76);
-        negUglobal	    = data(77);
-        negFglobal  	= data(78);
-        negUres		   	= data(79);
-        negFres		    = data(80);
-        negKp			= data(81);
-        negKpc		    = data(82);
+        negUy = data(71);
+        negFy = data(72);
+        negUcap = data(73);
+        negFcap = data(74);
+        negUlocal = data(75);
+        negFlocal = data(76);
+        negUglobal = data(77);
+        negFglobal = data(78);
+        negUres = data(79);
+        negFres = data(80);
+        negKp = data(81);
+        negKpc = data(82);
     // 2 Flag
-        Failure_Flag	= data(85);
-        Branch			= data(86);
+        Failure_Flag = data(85);
+        Branch = data(86);
     // 12 Positive U and F
-        cPosUy			= data(101);
-        cPosFy			= data(102);
-        cPosUcap		= data(103);
-        cPosFcap		= data(104);
-        cPosUlocal		= data(105);
-        cPosFlocal		= data(106);
-        cPosUglobal		= data(107);
-        cPosFglobal		= data(108);
-        cPosUres		= data(109);
-        cPosFres		= data(110);
-        cPosKp			= data(111);
-        cPosKpc			= data(112);
+        cPosUy = data(101);
+        cPosFy = data(102);
+        cPosUcap = data(103);
+        cPosFcap = data(104);
+        cPosUlocal = data(105);
+        cPosFlocal = data(106);
+        cPosUglobal = data(107);
+        cPosFglobal = data(108);
+        cPosUres = data(109);
+        cPosFres = data(110);
+        cPosKp = data(111);
+        cPosKpc = data(112);
     // 3 State Variables
-        cU              = data(113);
-        cUi				= data(114);
-        cFi				= data(115);
+        cU = data(113);
+        cUi = data(114);
+        cFi = data(115);
     // 2 Stiffness
-        cKreload       = data(116);
-        cKunload		= data(117);
+        cKreload = data(116);
+        cKunload = data(117);
     // 2 Energy
-        cEngAcml        = data(118);
-        cEngDspt        = data(119);
+        cEngAcml = data(118);
+        cEngDspt = data(119);
     // 12 Negative U and F
-        cNegUy			= data(121);
-        cNegFy			= data(122);
-        cNegUcap		= data(123);
-        cNegFcap		= data(124);
-        cNegUlocal		= data(125);
-        cNegFlocal		= data(126);
-        cNegUglobal		= data(127);
-        cNegFglobal		= data(128);
-        cNegUres		= data(129);
-        cNegFres		= data(130);
-        cNegKp			= data(131);
-        cNegKpc			= data(132);
+        cNegUy = data(121);
+        cNegFy = data(122);
+        cNegUcap = data(123);
+        cNegFcap = data(124);
+        cNegUlocal = data(125);
+        cNegFlocal = data(126);
+        cNegUglobal = data(127);
+        cNegFglobal = data(128);
+        cNegUres = data(129);
+        cNegFres = data(130);
+        cNegKp = data(131);
+        cNegKpc = data(132);
     // 2 Flag
-        cFailure_Flag	= data(135);
-        cBranch			= data(136);
+        cFailure_Flag = data(135);
+        cBranch = data(136);
     }
 
     return res;

--- a/SRC/material/uniaxial/IMKPeakOriented.h
+++ b/SRC/material/uniaxial/IMKPeakOriented.h
@@ -20,9 +20,9 @@
 
 //Modified Ibarra-Medina-Krawinkler with Peak-Oriented Hysteretic Response
 
-//**********************************************************************                                                                     
+//**********************************************************************
 // Code Developed by: Ahmed Elkady and Hammad ElJisr
-// Last Updated: October 2022
+// Last Updated: September 2023
 //**********************************************************************
 
 #ifndef IMKPeakOriented_h
@@ -91,7 +91,7 @@ private:
     double  engRefC;
     double  engRefA;
     double  engRefK;
-// History Variables 
+// History Variables
 // 12 Positive U and F
     double  posUy,          cPosUy;
     double  posFy,          cPosFy;
@@ -118,7 +118,7 @@ private:
     double  negFres,        cNegFres;
     double  negKp,          cNegKp;
     double  negKpc,         cNegKpc;
-// 3 State Variables 
+// 3 State Variables
     double  U,              cU;
     double  Ui,             cUi;
     double  Fi,             cFi;
@@ -127,7 +127,7 @@ private:
     double  Kunload,        cKunload;
 // 2 Energy
     double  engAcml,        cEngAcml;
-    double  engDspt,        cEngDspt;    
+    double  engDspt,        cEngDspt;
 // 2 Flag
     bool    Failure_Flag,   cFailure_Flag;
     int     Branch,         cBranch;

--- a/SRC/material/uniaxial/IMKPeakOriented.h
+++ b/SRC/material/uniaxial/IMKPeakOriented.h
@@ -119,7 +119,6 @@ private:
     double  negKp,          cNegKp;
     double  negKpc,         cNegKpc;
 // 3 State Variables
-    double  U,              cU;
     double  Ui,             cUi;
     double  Fi,             cFi;
 // 3 Stiffness

--- a/SRC/material/uniaxial/IMKPinching.cpp
+++ b/SRC/material/uniaxial/IMKPinching.cpp
@@ -69,8 +69,7 @@ OPS_IMKPinching()
 
 
     // Parsing was successful, allocate the material
-    theMaterial = new IMKPinching(iData[0],
-        dData[0],
+    theMaterial = new IMKPinching(iData[0], dData[0],
         dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
         dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
         dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
@@ -118,8 +117,7 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     //state determination algorithm: defines the current force and tangent stiffness
     const double Ui_1 = Ui;
     const double Fi_1 = Fi;
-    U = strain; //set trial displacement
-    Ui = U;
+    Ui = strain; //set trial displacement
     const double dU = Ui - Ui_1;    // Incremental deformation at current step
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -131,13 +129,13 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     } else if (dU == 0) {   // When deformation doesn't change from the last
         Fi = Fi_1;
     } else {
-        double betaS=0, betaC=0, betaK=0, betaA=0;
-        bool FailS=false, FailC=false, FailK=false, FailA=false;
+        double betaS = 0, betaC = 0, betaK = 0, betaA = 0;
+        bool FailS = false, FailC = false, FailK = false, FailA = false;
         const bool onBackbone = (Branch > 1);
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN REVERSAL /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        if ( (onBackbone && Fi_1*dU < 0) || (onBackbone && Fi_1==0 && Ui_1*dU <= 0) ) {
+        if ( (onBackbone && Fi_1 * dU < 0) || (onBackbone && Fi_1 == 0 && Ui_1 * dU <= 0) ) {
             Branch = 1;
     /////////////////////////// UPDATE PEAK POINTS ////////////////////////////////////////////
             if ( Fi_1 > 0 ){
@@ -160,7 +158,7 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
             const double  EiK = engAcml - engDspt - 0.5 * (Fi_1 / Kunload) * Fi_1;
             betaK = pow( (EiK / (engRefK - EpjK)), c_K );
             FailK = (betaK > 1);
-            betaK = betaK < 0 ? 0 : (betaK >1 ? 1 : betaK);
+            betaK = betaK < 0 ? 0 : (betaK > 1 ? 1 : betaK);
             Kunload *= (1 - betaK);
         }
         Fi = Fi_1 + Kunload * dU;
@@ -385,9 +383,9 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
         if (Branch == 0) {
-            Fi = Ke*Ui;
+            Fi = Ke * Ui;
         } else if (Branch == 1) {
-            Fi = Fi_1 + Kunload*dU;
+            Fi = Fi_1 + Kunload * dU;
     // Positive
         } else if (Branch == 2) {
             Fi = Fpinch + Kreload * (Ui - Upinch);
@@ -467,7 +465,7 @@ double IMKPinching::getInitialTangent(void)
 double IMKPinching::getStrain(void)
 {
     //cout << " getStrain" << endln;
-    return (U);
+    return (Ui);
 }
 
 int IMKPinching::commitState(void)
@@ -505,7 +503,6 @@ int IMKPinching::commitState(void)
     cFpinch = Fpinch;
     cUpinch = Upinch;
 // 3 State
-    cU = U;
     cUi = Ui;
     cFi = Fi;
 // 2 Stiffness
@@ -554,7 +551,6 @@ int IMKPinching::revertToLastCommit(void)
     Fpinch = cFpinch;
     Upinch = cUpinch;
 // 3 State Variables
-    U = cU;
     Ui = cUi;
     Fi = cFi;
 // 2 Stiffness
@@ -616,7 +612,6 @@ int IMKPinching::revertToStart(void)
     negKpc = cNegKpc = -negKpc_0;
     negUres = cNegUres = (negFres - negFcap) / negKpc + negUcap;
 // 3 State Values
-    U = cU = 0;
     Ui = cUi = 0;
     Fi = cFi = 0;
 // 2 Stiffness
@@ -632,7 +627,6 @@ int IMKPinching::revertToStart(void)
 // 2 Pinching
     Fpinch = cFpinch = 0.0;
     Upinch = cUpinch = 0.0;
-    //cout << " revertToStart:" << endln; //<< " U=" << U << " Ui=" << Ui << " TanK=" << Kreload << endln;
     return 0;
 }
 
@@ -672,7 +666,6 @@ IMKPinching::getCopy(void)
     theCopy->negKp = negKp;
     theCopy->negKpc = negKpc;
 // 3 State Values
-    theCopy->U = U;
     theCopy->Ui = Ui;
     theCopy->Fi = Fi;
 // 2 Stiffness
@@ -711,7 +704,6 @@ IMKPinching::getCopy(void)
     theCopy->cNegKp = cNegKp;
     theCopy->cNegKpc = cNegKpc;
 // 3 State
-    theCopy->cU = cU;
     theCopy->cUi = cUi;
     theCopy->cFi = cFi;
 // 2 Stiffness
@@ -791,7 +783,7 @@ int IMKPinching::sendSelf(int cTag, Channel &theChannel)
     data(51) = posKp;
     data(62) = posKpc;
 // 3 State Variables 63-65
-    data(63) = U;
+    // data(63) = U;
     data(64) = Ui;
     data(65) = Fi;
 // 2 Stiffness 66 67
@@ -833,7 +825,6 @@ int IMKPinching::sendSelf(int cTag, Channel &theChannel)
     data(111) = cPosKp;
     data(112) = cPosKpc;
 // 3 State Variables 113-115
-    data(113) = cU;
     data(114) = cUi;
     data(115) = cFi;
 // 2 Stiffness 116 117
@@ -935,7 +926,6 @@ int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBr
         posKp = data(61);
         posKpc = data(62);
     // 3 State Variables
-        U = data(63);
         Ui = data(64);
         Fi = data(65);
     // 2 Stiffness
@@ -977,7 +967,6 @@ int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBr
         cPosKp = data(111);
         cPosKpc = data(112);
     // 3 State Variables
-        cU = data(113);
         cUi = data(114);
         cFi = data(115);
     // 2 Stiffness

--- a/SRC/material/uniaxial/IMKPinching.cpp
+++ b/SRC/material/uniaxial/IMKPinching.cpp
@@ -41,7 +41,7 @@ OPS_IMKPinching()
 {
     if (numIMKPinchingMaterials == 0) {
         numIMKPinchingMaterials++;
-        opserr << "IMK with Pinched Response - Code by AE_KI (Nov22)\n";
+        opserr << "IMK with Pinched Response - Code by AE_KI (Sep23)\n";
     }
 
     // Pointer to a uniaxial material that will be returned
@@ -49,17 +49,17 @@ OPS_IMKPinching()
 
     int    iData[1];
     double dData[25];
-    int numData = 1;
+    int numInt = 1;
 
-    if (OPS_GetIntInput(&numData, iData) != 0) {
+    if (OPS_GetIntInput(&numInt, iData) != 0) {
         opserr << "WARNING invalid uniaxialMaterial IMKPinching tag" << endln;
         return 0;
     }
 
-    numData = 25;
+    int numDouble = 25;
 
 
-    if (OPS_GetDoubleInput(&numData, dData) != 0) {
+    if (OPS_GetDoubleInput(&numDouble, dData) != 0) {
         opserr << "Invalid Args want: uniaxialMaterial IMKPinching tag? Ke? ";
         opserr << "posUp_0? posUpc_0? posUu_0? posFy_0? posFcapFy_0? posFresFy_0? ";
         opserr << "negUp_0? negUpc_0? negUu_0? negFy_0? negFcapFy_0? negFresFy_0? ";
@@ -116,90 +116,90 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     this->revertToLastCommit();
 
     //state determination algorithm: defines the current force and tangent stiffness
-    double Ui_1 = Ui;
-    double Fi_1 = Fi;
-    U           = strain; //set trial displacement
-    Ui          = U;
-    double dU   = Ui - Ui_1;    // Incremental deformation at current step
+    const double Ui_1 = Ui;
+    const double Fi_1 = Fi;
+    U = strain; //set trial displacement
+    Ui = U;
+    const double dU = Ui - Ui_1;    // Incremental deformation at current step
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     if (Failure_Flag) {     // When a failure has already occured
-        Fi  = 0;
+        Fi = 0;
     } else if (dU == 0) {   // When deformation doesn't change from the last
-        Fi  = Fi_1;
+        Fi = Fi_1;
     } else {
-        double  betaS=0,betaC=0,betaK=0,betaA=0;
-        bool    FailS=false,FailC=false,FailK=false,FailA=false;
-        bool    onBackbone  = (Branch > 1);
+        double betaS=0, betaC=0, betaK=0, betaA=0;
+        bool FailS=false, FailC=false, FailK=false, FailA=false;
+        const bool onBackbone = (Branch > 1);
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN REVERSAL /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        if ( (onBackbone && Fi_1*dU < 0) || (onBackbone && Fi_1==0 && Ui_1*dU<=0) ) {
-            Branch          = 1;
+        if ( (onBackbone && Fi_1*dU < 0) || (onBackbone && Fi_1==0 && Ui_1*dU <= 0) ) {
+            Branch = 1;
     /////////////////////////// UPDATE PEAK POINTS ////////////////////////////////////////////
             if ( Fi_1 > 0 ){
-                posUlocal	= Ui_1;           // UPDATE LOCAL
-                posFlocal	= Fi_1;
+                posUlocal = Ui_1;           // UPDATE LOCAL
+                posFlocal = Fi_1;
                 if ( Ui_1 > posUglobal ) {    // UPDATE GLOBAL
-                    posUglobal   	= Ui_1;
-                    posFglobal   	= Fi_1;
+                    posUglobal = Ui_1;
+                    posFglobal = Fi_1;
                 }
             } else {
-                negUlocal	= Ui_1;           // UPDATE LOCAL
-                negFlocal	= Fi_1;
+                negUlocal = Ui_1;           // UPDATE LOCAL
+                negFlocal = Fi_1;
                 if ( Ui_1 < negUglobal ) {    // UPDATE GLOBAL
-                    negUglobal   	= Ui_1;
-                    negFglobal   	= Fi_1;
+                    negUglobal = Ui_1;
+                    negFglobal = Fi_1;
                 }
             }
     /////////////////// UPDATE UNLOADING STIFFNESS ////////////////////////////////////////////
-            double  EpjK    = engAcml            - 0.5*(Fi_1 / Kunload)*Fi_1;
-            double  EiK     = engAcml - engDspt  - 0.5*(Fi_1 / Kunload)*Fi_1;
-            betaK           = pow( (EiK / (engRefK - EpjK)), c_K );
-            FailK           = (betaK>1);
-            betaK           = betaK < 0 ? 0 : (betaK>1 ? 1 : betaK);
-            Kunload         *= (1 - betaK);
+            const double  EpjK = engAcml - 0.5 * (Fi_1 / Kunload) * Fi_1;
+            const double  EiK = engAcml - engDspt - 0.5 * (Fi_1 / Kunload) * Fi_1;
+            betaK = pow( (EiK / (engRefK - EpjK)), c_K );
+            FailK = (betaK > 1);
+            betaK = betaK < 0 ? 0 : (betaK >1 ? 1 : betaK);
+            Kunload *= (1 - betaK);
         }
-        Fi	    = Fi_1 + Kunload * dU;
+        Fi = Fi_1 + Kunload * dU;
     ///////////////////////////////////////////////////////////////////////////////////////////
     /////////////////// WHEN NEW EXCURSION /////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        if (Branch == 1 && Fi_1*Fi <= 0.0) {
+        if (Branch == 1 && Fi_1 * Fi <= 0.0) {
     /////////////////// UPDATE BACKBONE CURVE /////////////////////////////////////////////////
-            double Ei   = max(0.0, engAcml - engDspt);
-            betaS   = pow((Ei / (engRefS - engAcml)), c_S);
-            betaC   = pow((Ei / (engRefC - engAcml)), c_C);
-            betaA   = pow((Ei / (engRefA - engAcml)), c_A);
-            FailS   = (betaS>1);
-            FailC   = (betaC>1);
-            FailA   = (betaA>1);
-            betaS   = betaS < 0 ? 0 : (betaS>1 ? 1 : betaS);
-            betaC   = betaC < 0 ? 0 : (betaC>1 ? 1 : betaC);
-            betaA   = betaA < 0 ? 0 : (betaA>1 ? 1 : betaA);
+            const double Ei = max(0.0, engAcml - engDspt);
+            betaS = pow((Ei / (engRefS - engAcml)), c_S);
+            betaC = pow((Ei / (engRefC - engAcml)), c_C);
+            betaA = pow((Ei / (engRefA - engAcml)), c_A);
+            FailS = (betaS > 1);
+            FailC = (betaC > 1);
+            FailA = (betaA > 1);
+            betaS = betaS < 0 ? 0 : (betaS > 1 ? 1 : betaS);
+            betaC = betaC < 0 ? 0 : (betaC > 1 ? 1 : betaC);
+            betaA = betaA < 0 ? 0 : (betaA > 1 ? 1 : betaA);
             engDspt = engAcml;
         // Positive
             if (dU > 0) {
-                double FcapProj = posFcap  - posKpc * posUcap;
+                double FcapProj = posFcap - posKpc * posUcap;
             // Yield Point
-                posFy       *= (1 - betaS * D_pos);
-                posKp       *= (1 - betaS * D_pos); // Post-Yield Stiffness
-                FcapProj    *= (1 - betaC * D_pos);
-                posUglobal  *= (1 + betaA * D_pos); // Accelerated Reloading Stiffness
-                posUy       = posFy / Ke;
+                posFy *= (1 - betaS * D_pos);
+                posKp *= (1 - betaS * D_pos); // Post-Yield Stiffness
+                FcapProj *= (1 - betaC * D_pos);
+                posUglobal *= (1 + betaA * D_pos); // Accelerated Reloading Stiffness
+                posUy = posFy / Ke;
             // Capping Point
-                double FyProj   = posFy - posKp*posUy;
-                posUcap         = posKp <= posKpc ? 0 : (FcapProj - FyProj) / (posKp - posKpc);
-                posFcap         = FyProj + posKp*posUcap;
+                const double FyProj = posFy - posKp*posUy;
+                posUcap = posKp <= posKpc ? 0 : (FcapProj - FyProj) / (posKp - posKpc);
+                posFcap = FyProj + posKp*posUcap;
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (posUglobal < posUy) {           // Elastic Branch
                     posFglobal = Ke * posUglobal;
                 }
                 else if (posUglobal < posUcap) {    // Post-Yield Branch
-                    posFglobal = posFy   + posKp  * (posUglobal - posUy);
+                    posFglobal = posFy + posKp * (posUglobal - posUy);
                 }
                 else {                              // Post-Capping Branch
                     posFglobal = posFcap + posKpc * (posUglobal - posUcap);
@@ -211,69 +211,69 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
             }
         // Negative
             else {
-                double FcapProj = negFcap   - negKpc * negUcap;
+                double FcapProj = negFcap - negKpc * negUcap;
             // Yield Point
-                negFy	    *= (1 - betaS * D_neg);
-                negKp	    *= (1 - betaS * D_neg); // Post-Yield Stiffness
-                FcapProj    *= (1 - betaC * D_neg);
-                negUglobal	*= (1 + betaA * D_neg); // Accelerated Reloading Stiffness
-                negUy       = negFy / Ke;
+                negFy *= (1 - betaS * D_neg);
+                negKp *= (1 - betaS * D_neg); // Post-Yield Stiffness
+                FcapProj *= (1 - betaC * D_neg);
+                negUglobal *= (1 + betaA * D_neg); // Accelerated Reloading Stiffness
+                negUy = negFy / Ke;
             // Capping Point
-                double FyProj   = negFy - negKp*negUy;
-                negUcap         = negKp <= negKpc ? 0 : (FcapProj - FyProj) / (negKp - negKpc);
-                negFcap         = FyProj + negKp*negUcap;
+                const double FyProj = negFy - negKp * negUy;
+                negUcap = negKp <= negKpc ? 0 : (FcapProj - FyProj) / (negKp - negKpc);
+                negFcap = FyProj + negKp * negUcap;
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (negUy < negUglobal) {           // Elastic Branch
-                    negFglobal	= Ke * negUglobal;
+                    negFglobal = Ke * negUglobal;
                 }
                 else if (negUcap < negUglobal) {    // Post-Yield Branch
-                    negFglobal	= negFy   + negKp  * (negUglobal - negUy);
+                    negFglobal = negFy + negKp * (negUglobal - negUy);
                 }
                 else {                              // Post-Capping Branch
-                    negFglobal  = negFcap + negKpc * (negUglobal - negUcap);
+                    negFglobal = negFcap + negKpc * (negUglobal - negUcap);
                 }
                 if (negFres < negFglobal) {     // Residual Branch
-                    negFglobal  = negFres;
+                    negFglobal = negFres;
                 }
-                negUres  	= (negFres - negFcap + negKpc * negUcap) / negKpc;
+                negUres = (negFres - negFcap + negKpc * negUcap) / negKpc;
             }
     ////////////////////////// RELOADING TARGET DETERMINATION /////////////////////////////////
             if (dU > 0) {
-                double u0 	    = Ui_1 - (Fi_1 / Kunload);
-                double Uplstc   = posUglobal    - (posFglobal / Kunload);
-                Upinch          = (1-kappaD)*Uplstc;
-                Fpinch          = kappaF*posFglobal*(Upinch-u0)/(posUglobal-u0);
-                double Kpinch   = Fpinch        / (Upinch       - u0);
-                double Kglobal  = posFglobal    / (posUglobal - u0);
-                double Klocal   = posFlocal     / (posUlocal  - u0);
+                const double u0 = Ui_1 - (Fi_1 / Kunload);
+                const double Uplstc = posUglobal - (posFglobal / Kunload);
+                Upinch = (1 - kappaD) * Uplstc;
+                Fpinch = kappaF * posFglobal * (Upinch - u0) / (posUglobal - u0);
+                const double Kpinch = Fpinch / (Upinch - u0);
+                const double Kglobal = posFglobal / (posUglobal - u0);
+                const double Klocal = posFlocal / (posUlocal - u0);
                 if (u0 < Upinch) {
-                    Branch  = 2;
+                    Branch = 2;
                     Kreload = Kpinch;
                 } else  if ( u0 < posUlocal && posFlocal < posFglobal && Klocal > Kglobal) {
-                    Branch  = 3;
+                    Branch = 3;
                     Kreload = Klocal;
                 } else {
-                    Branch  = 4;
+                    Branch = 4;
                     Kreload = Kglobal;
                 }
             }
             else {
-                double u0 	    = Ui_1 - (Fi_1 / Kunload);
-                double Uplstc   = negUglobal    - (negFglobal / Kunload);
-                Upinch          = (1-kappaD)*Uplstc;
-                Fpinch          = kappaF*negFglobal*(Upinch-u0)/(negUglobal-u0);
-                double Kpinch   = Fpinch        / (Upinch       - u0);
-                double Kglobal  = negFglobal    / (negUglobal - u0);
-                double Klocal   = negFlocal     / (negUlocal  - u0);
+                const double u0 = Ui_1 - (Fi_1 / Kunload);
+                const double Uplstc = negUglobal - (negFglobal / Kunload);
+                Upinch = (1 - kappaD) * Uplstc;
+                Fpinch = kappaF * negFglobal * (Upinch - u0) / (negUglobal - u0);
+                const double Kpinch = Fpinch / (Upinch - u0);
+                const double Kglobal = negFglobal / (negUglobal - u0);
+                const double Klocal = negFlocal / (negUlocal - u0);
                 if (u0 > Upinch) {
-                    Branch 	= 12;
+                    Branch = 12;
                     Kreload = Kpinch;
                 } else  if ( u0 > negUlocal && negFlocal > negFglobal && Klocal > Kglobal) {
-                    Branch  = 13;
+                    Branch = 13;
                     Kreload = Klocal;
                 } else {
-                    Branch  = 14;
+                    Branch = 14;
                     Kreload = Kglobal;
                 }
             }
@@ -301,79 +301,79 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     // Branch shifting from 2 -> 3 -> 4 -> 5 -> 6 -> 7
         // int exBranch = Branch;
         if (Branch == 0 && Ui > posUy) {            // Yield in Positive
-            Branch  = 5;
+            Branch = 5;
         } else if (Branch == 0 && Ui < negUy) {     // Yield in Negative
-            Branch  = 15;
+            Branch = 15;
         } else if (Branch == 1 && Fi_1 > 0 && Ui > posUlocal) {
-            double Kpinch  = (Fpinch       - posFlocal) / (Upinch      - posUlocal);
-            double Kglobal = (posFglobal   - posFlocal) / (posUglobal  - posUlocal);
+            const double Kpinch = (Fpinch - posFlocal) / (Upinch - posUlocal);
+            const double Kglobal = (posFglobal - posFlocal) / (posUglobal - posUlocal);
             if (posUlocal < Upinch && posFlocal < Fpinch && Upinch < posUglobal && Fpinch < posFglobal && Kpinch < Kglobal) {
                 Kreload = Kpinch;
-                Branch  = 2;                        // Pinching Branch
+                Branch = 2;                        // Pinching Branch
             } else {
                 Kreload = Kglobal;
-                Branch  = 4;                        // Towards Global Peak
+                Branch = 4;                        // Towards Global Peak
             }
         } else if (Branch == 1 && Fi_1 < 0 && Ui < negUlocal) {    // Back to Reloading (Negative)
-            double Kpinch  = (Fpinch       - negFlocal) / (Upinch      - negUlocal);
-            double Kglobal = (negFglobal   - negFlocal) / (negUglobal  - negUlocal);
+            const double Kpinch = (Fpinch - negFlocal) / (Upinch - negUlocal);
+            const double Kglobal = (negFglobal - negFlocal) / (negUglobal - negUlocal);
             if (negUglobal < Upinch && negFglobal < Fpinch && Upinch < negUlocal && Fpinch < negFlocal && Kpinch < Kglobal) {
                 Kreload = Kpinch;
-                Branch  = 12;                   // Pinching Branch
+                Branch = 12;                   // Pinching Branch
             } else {
                 Kreload = Kglobal;
-                Branch  = 14;                   // Towards Global Peak
+                Branch = 14;                   // Towards Global Peak
             }
         }
     // Positive
         if (Branch == 2 && Ui > Upinch) {
-            double Kglobal  = (posFglobal   - Fpinch) / (posUglobal - Upinch);
-            double Klocal   = (posFlocal    - Fpinch) / (posUlocal  - Upinch);
+            const double Kglobal = (posFglobal - Fpinch) / (posUglobal - Upinch);
+            const double Klocal = (posFlocal - Fpinch) / (posUlocal - Upinch);
             if (Upinch < posUlocal && Fpinch < posFlocal && posFlocal < posFglobal && Klocal > Kglobal) {
                 Kreload = Klocal;
-                Branch  = 3;
+                Branch = 3;
             } else {
                 Kreload = Kglobal;
-                Branch 	= 4;
+                Branch = 4;
             }
         }
         if (Branch == 3 && Ui > posUlocal) {
-            Kreload     = (posFglobal - posFlocal) / (posUglobal - posUlocal);
-            Branch      = 4;
+            Kreload = (posFglobal - posFlocal) / (posUglobal - posUlocal);
+            Branch = 4;
         }
         if (Branch == 4 && Ui > posUglobal) {
-            Branch 	    = 5;
+            Branch = 5;
         }
         if (Branch == 5 && Ui > posUcap) {
-            Branch 	    = 6;
+            Branch = 6;
         }
         if (Branch == 6 && Ui > posUres) {
-            Branch 	    = 7;
+            Branch = 7;
         }
     // Negative
         if (Branch == 12 && Ui < Upinch) {
-            double Kglobal  = (negFglobal   - Fpinch) / (negUglobal - Upinch);
-            double Klocal   = (negFlocal    - Fpinch) / (negUlocal  - Upinch);
+            const double Kglobal = (negFglobal - Fpinch) / (negUglobal - Upinch);
+            const double Klocal = (negFlocal - Fpinch) / (negUlocal - Upinch);
             if (negFglobal < negFlocal && negUlocal < Upinch && negFlocal < Fpinch && Klocal > Kglobal) {
                 Kreload = Klocal;
-                Branch  = 13;
+                Branch = 13;
             } else {
                 Kreload = Kglobal;
-                Branch 	= 14;
+                Branch = 14;
             }
         }
         if (Branch == 13 && Ui < negUlocal) {
-            Kreload     = (negFglobal - negFlocal) / (negUglobal - negUlocal);
-            Branch      = 14;
+            Kreload = (negFglobal - negFlocal) / (negUglobal - negUlocal);
+            Branch = 14;
         }
         if (Branch == 14 && Ui < negUglobal) {
-            Branch 	    = 15;
+            Branch = 15;
         }
         if (Branch == 15 && Ui < negUcap) {
-            Branch 	    = 16;
+            Branch = 16;
         }
         if (Branch == 16 && Ui < negUres) {
-            Branch 	    = 17;
+            Branch = 17;
         }
     // Branch Change check
         // if (Branch!=exBranch) {
@@ -385,58 +385,58 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
         if (Branch == 0) {
-            Fi  = Ke*Ui;
+            Fi = Ke*Ui;
         } else if (Branch == 1) {
-            Fi  = Fi_1 + Kunload*dU;
+            Fi = Fi_1 + Kunload*dU;
     // Positive
         } else if (Branch == 2) {
-            Fi  = Fpinch    + Kreload*(Ui - Upinch);
+            Fi = Fpinch + Kreload * (Ui - Upinch);
         } else if (Branch == 3) {
-            Fi  = posFlocal + Kreload*(Ui - posUlocal);
+            Fi = posFlocal + Kreload * (Ui - posUlocal);
         } else if (Branch == 4) {
-            Fi  = posFglobal + Kreload*(Ui - posUglobal);
+            Fi = posFglobal + Kreload * (Ui - posUglobal);
         } else if (Branch == 5) {
-            Fi  = posFcap   + posKp*(Ui - posUcap);
+            Fi = posFcap + posKp * (Ui - posUcap);
         } else if (Branch == 6) {
-            Fi  = posFcap   + posKpc*(Ui - posUcap);
+            Fi = posFcap + posKpc * (Ui - posUcap);
         } else if (Branch == 7) {
-            Fi  = posFres;
+            Fi = posFres;
     // Negative
         } else if (Branch == 12) {
-            Fi  = Fpinch    + Kreload*(Ui - Upinch);
+            Fi = Fpinch + Kreload * (Ui - Upinch);
         } else if (Branch == 13) {
-            Fi  = negFlocal + Kreload*(Ui - negUlocal);
+            Fi = negFlocal + Kreload * (Ui - negUlocal);
         } else if (Branch == 14) {
-            Fi  = negFglobal + Kreload*(Ui - negUglobal);
+            Fi = negFglobal + Kreload * (Ui - negUglobal);
         } else if (Branch == 15) {
-            Fi  = negFcap   + negKp*(Ui - negUcap);
+            Fi = negFcap + negKp * (Ui - negUcap);
         } else if (Branch == 16) {
-            Fi  = negFcap   + negKpc*(Ui - negUcap);
+            Fi = negFcap + negKpc * (Ui - negUcap);
         } else if (Branch == 17) {
-            Fi  = negFres;
+            Fi = negFres;
         }
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
     // CHECK FOR FAILURE
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
-        bool	FailPp 	= ( posFglobal == 0           );
-        bool	FailPn 	= ( negFglobal == 0           );
-        bool	FailDp 	= ( dU > 0 && Ui >=  posUu_0  );
-        bool	FailDn 	= ( dU < 0 && Ui <= -negUu_0  );
-        bool	FailRp 	= ( Branch == 7     && Fi <= 0);
-        bool	FailRn 	= ( Branch == 17    && Fi >= 0);
-        if (FailS||FailC||FailA||FailK||FailPp||FailPn||FailRp||FailRn||FailDp||FailDn) {
-            Fi  = 0;
-            Failure_Flag    = true;
+        const bool FailPp = ( posFglobal == 0 );
+        const bool FailPn = ( negFglobal == 0 );
+        const bool FailDp = ( dU > 0 && Ui >=  posUu_0 );
+        const bool FailDn = ( dU < 0 && Ui <= -negUu_0 );
+        const bool FailRp = ( Branch == 7 && Fi <= 0);
+        const bool FailRn = ( Branch == 17 && Fi >= 0);
+        if (FailS || FailC || FailA || FailK || FailPp || FailPn || FailRp || FailRn || FailDp || FailDn) {
+            Fi = 0;
+            Failure_Flag = true;
         }
 
-        engAcml += 0.5*(Fi + Fi_1)*dU;   // Internal energy increment
+        engAcml += 0.5 * (Fi + Fi_1) * dU;   // Internal energy increment
 
-        KgetTangent  = (Fi - Fi_1) / dU;
+        KgetTangent = (Fi - Fi_1) / dU;
     }
-    if (KgetTangent==0) {
-        KgetTangent  = 1e-6;
+    if (KgetTangent == 0) {
+        KgetTangent = 1e-6;
     }
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -476,47 +476,47 @@ int IMKPinching::commitState(void)
 
     //commit trial  variables
 // 12 Pos U and F
-    cPosUy	    = posUy;
-    cPosFy	    = posFy;
-    cPosUcap	= posUcap;
-    cPosFcap	= posFcap;
-    cPosUlocal	= posUlocal;
-    cPosFlocal	= posFlocal;
-    cPosUglobal	= posUglobal;
-    cPosFglobal	= posFglobal;
-    cPosUres	= posUres;
-    cPosFres	= posFres;
-    cPosKp	    = posKp;
-    cPosKpc	    = posKpc;
+    cPosUy = posUy;
+    cPosFy = posFy;
+    cPosUcap = posUcap;
+    cPosFcap = posFcap;
+    cPosUlocal = posUlocal;
+    cPosFlocal = posFlocal;
+    cPosUglobal = posUglobal;
+    cPosFglobal = posFglobal;
+    cPosUres = posUres;
+    cPosFres = posFres;
+    cPosKp = posKp;
+    cPosKpc = posKpc;
 // 12 Neg U and F
-    cNegUy	    = negUy;
-    cNegFy	    = negFy;
-    cNegUcap	= negUcap;
-    cNegFcap	= negFcap;
-    cNegUlocal	= negUlocal;
-    cNegFlocal	= negFlocal;
-    cNegUglobal	= negUglobal;
-    cNegFglobal	= negFglobal;
-    cNegUres	= negUres;
-    cNegFres	= negFres;
-    cNegKp	    = negKp;
-    cNegKpc	    = negKpc;
+    cNegUy = negUy;
+    cNegFy = negFy;
+    cNegUcap = negUcap;
+    cNegFcap = negFcap;
+    cNegUlocal = negUlocal;
+    cNegFlocal = negFlocal;
+    cNegUglobal = negUglobal;
+    cNegFglobal = negFglobal;
+    cNegUres = negUres;
+    cNegFres = negFres;
+    cNegKp = negKp;
+    cNegKpc = negKpc;
 // 2 Pinching
-    cFpinch     = Fpinch;
-    cUpinch     = Upinch;
+    cFpinch = Fpinch;
+    cUpinch = Upinch;
 // 3 State
-    cU		    = U;
-    cUi	    	= Ui;
-    cFi	        = Fi;
+    cU = U;
+    cUi = Ui;
+    cFi = Fi;
 // 2 Stiffness
-    cKreload	= Kreload;
-    cKunload	= Kunload;
+    cKreload = Kreload;
+    cKunload = Kunload;
 // 2 Energy
-    cEngAcml	= engAcml;
-    cEngDspt	= engDspt;
+    cEngAcml = engAcml;
+    cEngDspt = engDspt;
 // 2 Flag
-    cFailure_Flag   = Failure_Flag;
-    cBranch         = Branch;
+    cFailure_Flag = Failure_Flag;
+    cBranch = Branch;
     return 0;
 }
 
@@ -525,47 +525,47 @@ int IMKPinching::revertToLastCommit(void)
     //cout << " revertToLastCommit" << endln;
     //the opposite of commit trial history variables
 // 12 Positive U and F
-    posUy	        = cPosUy;
-    posFy	        = cPosFy;
-    posUcap	        = cPosUcap;
-    posFcap	        = cPosFcap;
-    posUlocal	    = cPosUlocal;
-    posFlocal	    = cPosFlocal;
-    posUglobal	    = cPosUglobal;
-    posFglobal	    = cPosFglobal;
-    posUres	        = cPosUres;
-    posFres	        = cPosFres;
-    posKp	        = cPosKp;
-    posKpc	        = cPosKpc;
+    posUy = cPosUy;
+    posFy = cPosFy;
+    posUcap = cPosUcap;
+    posFcap = cPosFcap;
+    posUlocal = cPosUlocal;
+    posFlocal = cPosFlocal;
+    posUglobal = cPosUglobal;
+    posFglobal = cPosFglobal;
+    posUres = cPosUres;
+    posFres = cPosFres;
+    posKp = cPosKp;
+    posKpc = cPosKpc;
 // 12 Negative U and F
-    negUy	        = cNegUy;
-    negFy	        = cNegFy;
-    negUcap	        = cNegUcap;
-    negFcap	        = cNegFcap;
-    negUlocal	    = cNegUlocal;
-    negFlocal	    = cNegFlocal;
-    negUglobal	    = cNegUglobal;
-    negFglobal	    = cNegFglobal;
-    negUres	        = cNegUres;
-    negFres	        = cNegFres;
-    negKp       	= cNegKp;
-    negKpc	        = cNegKpc;
+    negUy = cNegUy;
+    negFy = cNegFy;
+    negUcap = cNegUcap;
+    negFcap = cNegFcap;
+    negUlocal = cNegUlocal;
+    negFlocal = cNegFlocal;
+    negUglobal = cNegUglobal;
+    negFglobal = cNegFglobal;
+    negUres = cNegUres;
+    negFres = cNegFres;
+    negKp = cNegKp;
+    negKpc = cNegKpc;
 // 2 Pinching
-    Fpinch          = cFpinch;
-    Upinch          = cUpinch;
+    Fpinch = cFpinch;
+    Upinch = cUpinch;
 // 3 State Variables
-    U	            = cU;
-    Ui	            = cUi;
-    Fi	            = cFi;
+    U = cU;
+    Ui = cUi;
+    Fi = cFi;
 // 2 Stiffness
-    Kreload	    = cKreload;
-    Kunload	        = cKunload;
+    Kreload = cKreload;
+    Kunload = cKunload;
 // 2 Energy
-    engAcml	        = cEngAcml;
-    engDspt	        = cEngDspt;
+    engAcml = cEngAcml;
+    engDspt = cEngDspt;
 // 2 Flag
-    Failure_Flag	= cFailure_Flag;
-    Branch          = cBranch;
+    Failure_Flag = cFailure_Flag;
+    Branch = cBranch;
     return 0;
 }
 
@@ -575,63 +575,63 @@ int IMKPinching::revertToStart(void)
     //////////////////////////////////////////////////////////////////// ONE TIME CALCULATIONS ////////////////////////////////////////////////////////////////////\\
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
 // 14 Initial Values
-    posUy_0  	= posFy_0   / Ke;
-    posUcap_0	= posUy_0   + posUp_0;
-    posFcap_0	= posFcapFy_0*posFy_0;
-    posKp_0 	= (posFcap_0 - posFy_0) / posUp_0;
-    posKpc_0 	= posFcap_0 / posUpc_0;
-    negUy_0 	= negFy_0   / Ke;
-    negUcap_0	= negUy_0   + negUp_0;
-    negFcap_0	= negFcapFy_0*negFy_0;
-    negKp_0 	= (negFcap_0 - negFy_0) / negUp_0;
-    negKpc_0 	= negFcap_0 / negUpc_0;
-    engRefS	    = LAMBDA_S  * posFy_0;
-    engRefC	    = LAMBDA_C  * posFy_0;
-    engRefA	    = LAMBDA_A  * posFy_0;
-    engRefK	    = LAMBDA_K  * posFy_0;
+    posUy_0 = posFy_0 / Ke;
+    posUcap_0 = posUy_0 + posUp_0;
+    posFcap_0 = posFcapFy_0*posFy_0;
+    posKp_0 = (posFcap_0 - posFy_0) / posUp_0;
+    posKpc_0 = posFcap_0 / posUpc_0;
+    negUy_0 = negFy_0 / Ke;
+    negUcap_0 = negUy_0 + negUp_0;
+    negFcap_0 = negFcapFy_0*negFy_0;
+    negKp_0 = (negFcap_0 - negFy_0) / negUp_0;
+    negKpc_0 = negFcap_0 / negUpc_0;
+    engRefS = LAMBDA_S * posFy_0;
+    engRefC = LAMBDA_C * posFy_0;
+    engRefA = LAMBDA_A * posFy_0;
+    engRefK = LAMBDA_K * posFy_0;
 // 12 Positive U and F
-    posUy		= cPosUy	    = posUy_0;
-    posFy    	= cPosFy 	    = posFy_0;
-    posUcap  	= cPosUcap	    = posUcap_0;
-    posFcap  	= cPosFcap	    = posFcap_0;
-    posUlocal	= cPosUlocal	= posUy_0;
-    posFlocal	= cPosFlocal	= posFy_0;
-    posUglobal	= cPosUglobal	= posUy_0;
-    posFglobal	= cPosFglobal	= posFy_0;
-    posFres  	= cPosFres	    = posFy_0*posFresFy_0;
-    posKp    	= cPosKp 	    =  posKp_0;
-    posKpc   	= cPosKpc   	= -posKpc_0;
-    posUres	    = cPosUres	    = (posFres - posFcap) / posKpc + posUcap;
+    posUy = cPosUy = posUy_0;
+    posFy = cPosFy = posFy_0;
+    posUcap = cPosUcap = posUcap_0;
+    posFcap = cPosFcap = posFcap_0;
+    posUlocal = cPosUlocal = posUy_0;
+    posFlocal = cPosFlocal = posFy_0;
+    posUglobal = cPosUglobal = posUy_0;
+    posFglobal = cPosFglobal = posFy_0;
+    posFres = cPosFres = posFy_0*posFresFy_0;
+    posKp = cPosKp =  posKp_0;
+    posKpc = cPosKpc = -posKpc_0;
+    posUres = cPosUres = (posFres - posFcap) / posKpc + posUcap;
 // 12 Negative U and F
-    negUy    	= cNegUy	    = -negUy_0;
-    negFy    	= cNegFy	    = -negFy_0;
-    negUcap  	= cNegUcap	    = -negUcap_0;
-    negFcap  	= cNegFcap	    = -negFcap_0;
-    negUlocal	= cNegUlocal	= -negUy_0;
-    negFlocal	= cNegFlocal	= -negFy_0;
-    negUglobal	= cNegUglobal	= -negUy_0;
-    negFglobal	= cNegFglobal	= -negFy_0;
-    negFres  	= cNegFres	    = -negFy_0*negFresFy_0;
-    negKp    	= cNegKp	    =  negKp_0;
-    negKpc   	= cNegKpc	    = -negKpc_0;
-    negUres	    = cNegUres	    = (negFres - negFcap) / negKpc + negUcap;
+    negUy = cNegUy = -negUy_0;
+    negFy = cNegFy = -negFy_0;
+    negUcap = cNegUcap = -negUcap_0;
+    negFcap = cNegFcap = -negFcap_0;
+    negUlocal = cNegUlocal = -negUy_0;
+    negFlocal = cNegFlocal = -negFy_0;
+    negUglobal = cNegUglobal = -negUy_0;
+    negFglobal = cNegFglobal = -negFy_0;
+    negFres = cNegFres = -negFy_0*negFresFy_0;
+    negKp = cNegKp =  negKp_0;
+    negKpc = cNegKpc = -negKpc_0;
+    negUres = cNegUres = (negFres - negFcap) / negKpc + negUcap;
 // 3 State Values
-    U	        = cU	        = 0;
-    Ui      	= cUi 	        = 0;
-    Fi 	        = cFi 	        = 0;
+    U = cU = 0;
+    Ui = cUi = 0;
+    Fi = cFi = 0;
 // 2 Stiffness
-    Kreload	    = cKreload	    = Ke;
-    Kunload	    = cKunload	    = Ke;
+    Kreload = cKreload = Ke;
+    Kunload = cKunload = Ke;
     KgetTangent = Ke;
 // 2 Energy
-    engAcml 	= cEngAcml	    = 0.0;
-    engDspt	    = cEngDspt	    = 0.0;
+    engAcml = cEngAcml = 0.0;
+    engDspt = cEngDspt = 0.0;
 // 2 Flag
-    Failure_Flag    = cFailure_Flag = false;
-    Branch      	= cBranch       = 0;
+    Failure_Flag = cFailure_Flag = false;
+    Branch = cBranch = 0;
 // 2 Pinching
-    Fpinch      = cFpinch       = 0.0;
-    Upinch      = cUpinch       = 0.0;
+    Fpinch = cFpinch = 0.0;
+    Upinch = cUpinch = 0.0;
     //cout << " revertToStart:" << endln; //<< " U=" << U << " Ui=" << Ui << " TanK=" << Kreload << endln;
     return 0;
 }
@@ -646,86 +646,86 @@ IMKPinching::getCopy(void)
 
     //cout << " getCopy" << endln;
 // 12 Positive U and F
-    theCopy->posUy      = posUy;
-    theCopy->posFy      = posFy;
-    theCopy->posUcap    = posUcap;
-    theCopy->posFcap    = posFcap;
-    theCopy->posUlocal  = posUlocal;
-    theCopy->posFlocal  = posFlocal;
+    theCopy->posUy = posUy;
+    theCopy->posFy = posFy;
+    theCopy->posUcap = posUcap;
+    theCopy->posFcap = posFcap;
+    theCopy->posUlocal = posUlocal;
+    theCopy->posFlocal = posFlocal;
     theCopy->posUglobal = posUglobal;
     theCopy->posFglobal = posFglobal;
-    theCopy->posUres    = posUres;
-    theCopy->posFres    = posFres;
-    theCopy->posKp      = posKp;
-    theCopy->posKpc     = posKpc;
+    theCopy->posUres = posUres;
+    theCopy->posFres = posFres;
+    theCopy->posKp = posKp;
+    theCopy->posKpc = posKpc;
 // 12 Negative U and F
-    theCopy->negUy      = negUy;
-    theCopy->negFy      = negFy;
-    theCopy->negUcap    = negUcap;
-    theCopy->negFcap    = negFcap;
-    theCopy->negUlocal  = negUlocal;
-    theCopy->negFlocal  = negFlocal;
+    theCopy->negUy = negUy;
+    theCopy->negFy = negFy;
+    theCopy->negUcap = negUcap;
+    theCopy->negFcap = negFcap;
+    theCopy->negUlocal = negUlocal;
+    theCopy->negFlocal = negFlocal;
     theCopy->negUglobal = negUglobal;
     theCopy->negFglobal = negFglobal;
-    theCopy->negUres    = negUres;
-    theCopy->negFres    = negFres;
-    theCopy->negKp      = negKp;
-    theCopy->negKpc     = negKpc;
+    theCopy->negUres = negUres;
+    theCopy->negFres = negFres;
+    theCopy->negKp = negKp;
+    theCopy->negKpc = negKpc;
 // 3 State Values
-    theCopy->U          = U;
-    theCopy->Ui         = Ui;
-    theCopy->Fi         = Fi;
+    theCopy->U = U;
+    theCopy->Ui = Ui;
+    theCopy->Fi = Fi;
 // 2 Stiffness
-    theCopy->Kreload    = Kreload;
-    theCopy->Kunload    = Kunload;
+    theCopy->Kreload = Kreload;
+    theCopy->Kunload = Kunload;
 // 2 Energy
-    theCopy->engAcml    = engAcml;
-    theCopy->engDspt    = engDspt;
+    theCopy->engAcml = engAcml;
+    theCopy->engDspt = engDspt;
 // 2 Flag
-    theCopy->Failure_Flag   = Failure_Flag;
-    theCopy->Branch     = Branch;
+    theCopy->Failure_Flag = Failure_Flag;
+    theCopy->Branch = Branch;
 // 12 Positive U and F
-    theCopy->cPosUy     = cPosUy;
-    theCopy->cPosFy     = cPosFy;
-    theCopy->cPosUcap   = cPosUcap;
-    theCopy->cPosFcap   = cPosFcap;
+    theCopy->cPosUy = cPosUy;
+    theCopy->cPosFy = cPosFy;
+    theCopy->cPosUcap = cPosUcap;
+    theCopy->cPosFcap = cPosFcap;
     theCopy->cPosUlocal = cPosUlocal;
     theCopy->cPosFlocal = cPosFlocal;
     theCopy->cPosUglobal= cPosUglobal;
     theCopy->cPosFglobal= cPosFglobal;
-    theCopy->cPosUres   = cPosUres;
-    theCopy->cPosFres   = cPosFres;
-    theCopy->cPosKp     = cPosKp;
-    theCopy->cPosKpc    = cPosKpc;
+    theCopy->cPosUres = cPosUres;
+    theCopy->cPosFres = cPosFres;
+    theCopy->cPosKp = cPosKp;
+    theCopy->cPosKpc = cPosKpc;
 // 12 Negative U and F
-    theCopy->cNegUy     = cNegUy;
-    theCopy->cNegFy     = cNegFy;
-    theCopy->cNegUcap   = cNegUcap;
-    theCopy->cNegFcap   = cNegFcap;
+    theCopy->cNegUy = cNegUy;
+    theCopy->cNegFy = cNegFy;
+    theCopy->cNegUcap = cNegUcap;
+    theCopy->cNegFcap = cNegFcap;
     theCopy->cNegUglobal= cNegUglobal;
     theCopy->cNegFglobal= cNegFglobal;
     theCopy->cNegUlocal = cNegUlocal;
     theCopy->cNegFlocal = cNegFlocal;
-    theCopy->cNegUres   = cNegUres;
-    theCopy->cNegFres   = cNegFres;
-    theCopy->cNegKp     = cNegKp;
-    theCopy->cNegKpc    = cNegKpc;
+    theCopy->cNegUres = cNegUres;
+    theCopy->cNegFres = cNegFres;
+    theCopy->cNegKp = cNegKp;
+    theCopy->cNegKpc = cNegKpc;
 // 3 State
-    theCopy->cU         = cU;
-    theCopy->cUi        = cUi;
-    theCopy->cFi        = cFi;
+    theCopy->cU = cU;
+    theCopy->cUi = cUi;
+    theCopy->cFi = cFi;
 // 2 Stiffness
-    theCopy->cKreload   = cKreload;
-    theCopy->cKunload   = cKunload;
+    theCopy->cKreload = cKreload;
+    theCopy->cKunload = cKunload;
 // 2 Energy
-    theCopy->cEngAcml   = cEngAcml;
-    theCopy->cEngDspt   = cEngDspt;
+    theCopy->cEngAcml = cEngAcml;
+    theCopy->cEngDspt = cEngDspt;
 // 2 Pinching
-    theCopy->cFpinch    = Fpinch;
-    theCopy->cUpinch    = Upinch;
+    theCopy->cFpinch = cFpinch;
+    theCopy->cUpinch = cUpinch;
 // 2 Flag
-    theCopy->cFailure_Flag  = cFailure_Flag;
-    theCopy->cBranch    = Branch;
+    theCopy->cFailure_Flag = cFailure_Flag;
+    theCopy->cBranch = cBranch;
     return theCopy;
 }
 
@@ -737,130 +737,130 @@ int IMKPinching::sendSelf(int cTag, Channel &theChannel)
     static Vector data(137);
     data(0) = this->getTag();
 // 25 Fixed Input Material Parameters 1-25
-    data(1)  	= Ke;
-    data(2)  	= posUp_0;
-    data(3)  	= posUpc_0;
-    data(4)  	= posUu_0;
-    data(5)  	= posFy_0;
-    data(6)  	= posFcapFy_0;
-    data(7)  	= posFresFy_0;
-    data(8)  	= negUp_0;
-    data(9)  	= negUpc_0;
-    data(10) 	= negUu_0;
-    data(11) 	= negFy_0;
-    data(12) 	= negFcapFy_0;
-    data(13) 	= negFresFy_0;
-    data(14) 	= LAMBDA_S;
-    data(15) 	= LAMBDA_C;
-    data(16) 	= LAMBDA_A;
-    data(17) 	= LAMBDA_K;
-    data(18) 	= c_S;
-    data(19) 	= c_C;
-    data(20) 	= c_A;
-    data(21) 	= c_K;
-    data(22) 	= D_pos;
-    data(23) 	= D_neg;
-    data(24)    = kappaF;
-    data(25)    = kappaD;
+    data(1) = Ke;
+    data(2) = posUp_0;
+    data(3) = posUpc_0;
+    data(4) = posUu_0;
+    data(5) = posFy_0;
+    data(6) = posFcapFy_0;
+    data(7) = posFresFy_0;
+    data(8) = negUp_0;
+    data(9) = negUpc_0;
+    data(10) = negUu_0;
+    data(11) = negFy_0;
+    data(12) = negFcapFy_0;
+    data(13) = negFresFy_0;
+    data(14) = LAMBDA_S;
+    data(15) = LAMBDA_C;
+    data(16) = LAMBDA_A;
+    data(17) = LAMBDA_K;
+    data(18) = c_S;
+    data(19) = c_C;
+    data(20) = c_A;
+    data(21) = c_K;
+    data(22) = D_pos;
+    data(23) = D_neg;
+    data(24) = kappaF;
+    data(25) = kappaD;
 // 14 Initial Values 31-44
-    data(31)	= posUy_0;
-    data(32)	= posUcap_0;
-    data(33)	= posFcap_0;
-    data(34)	= posKp_0;
-    data(35)	= posKpc_0;
-    data(36)	= negUy_0;
-    data(37)	= negUcap_0;
-    data(38)	= negFcap_0;
-    data(39)	= negKp_0;
-    data(40)	= negKpc_0;
-    data(41)	= engRefS;
-    data(42)	= engRefC;
-    data(43)	= engRefA;
-    data(44)	= engRefK;
+    data(31) = posUy_0;
+    data(32) = posUcap_0;
+    data(33) = posFcap_0;
+    data(34) = posKp_0;
+    data(35) = posKpc_0;
+    data(36) = negUy_0;
+    data(37) = negUcap_0;
+    data(38) = negFcap_0;
+    data(39) = negKp_0;
+    data(40) = negKpc_0;
+    data(41) = engRefS;
+    data(42) = engRefC;
+    data(43) = engRefA;
+    data(44) = engRefK;
 // 12 Positive U and F 51-62
-    data(51) 	= posUy;
-    data(52) 	= posFy;
-    data(53) 	= posUcap;
-    data(54) 	= posFcap;
-    data(55) 	= posUlocal;
-    data(56) 	= posFlocal;
-    data(57) 	= posUglobal;
-    data(58) 	= posFglobal;
-    data(59) 	= posUres;
-    data(60) 	= posFres;
-    data(51) 	= posKp;
-    data(62) 	= posKpc;
+    data(51) = posUy;
+    data(52) = posFy;
+    data(53) = posUcap;
+    data(54) = posFcap;
+    data(55) = posUlocal;
+    data(56) = posFlocal;
+    data(57) = posUglobal;
+    data(58) = posFglobal;
+    data(59) = posUres;
+    data(60) = posFres;
+    data(51) = posKp;
+    data(62) = posKpc;
 // 3 State Variables 63-65
-    data(63)    = U;
-    data(64) 	= Ui;
-    data(65) 	= Fi;
+    data(63) = U;
+    data(64) = Ui;
+    data(65) = Fi;
 // 2 Stiffness 66 67
-    data(66)	= Kreload;
-    data(67) 	= Kunload;
+    data(66) = Kreload;
+    data(67) = Kunload;
 // 2 Energy 68 69
-    data(68) 	= engAcml;
-    data(69) 	= engDspt;
+    data(68) = engAcml;
+    data(69) = engDspt;
 // 12 Negative U and F 71-82
-    data(71) 	= negUy;
-    data(72) 	= negFy;
-    data(73) 	= negUcap;
-    data(74) 	= negFcap;
-    data(75) 	= negUlocal;
-    data(76) 	= negFlocal;
-    data(77) 	= negUglobal;
-    data(78) 	= negFglobal;
-    data(79) 	= negUres;
-    data(80) 	= negFres;
-    data(81) 	= negKp;
-    data(82) 	= negKpc;
+    data(71) = negUy;
+    data(72) = negFy;
+    data(73) = negUcap;
+    data(74) = negFcap;
+    data(75) = negUlocal;
+    data(76) = negFlocal;
+    data(77) = negUglobal;
+    data(78) = negFglobal;
+    data(79) = negUres;
+    data(80) = negFres;
+    data(81) = negKp;
+    data(82) = negKpc;
 // 2 Pinching 83 84
-    data(83)    = Fpinch;
-    data(84)    = Upinch;
+    data(83) = Fpinch;
+    data(84) = Upinch;
 // 2 Flag 85 86
-    data(85)	= Failure_Flag;
-    data(86) 	= Branch;
+    data(85) = Failure_Flag;
+    data(86) = Branch;
 // 12 Positive U and F 101-112
-    data(101)	= cPosUy;
-    data(102)	= cPosFy;
-    data(103)	= cPosUcap;
-    data(104)	= cPosFcap;
-    data(105)	= cPosUlocal;
-    data(106)	= cPosFlocal;
-    data(107)	= cPosUglobal;
-    data(108)	= cPosFglobal;
-    data(109)	= cPosUres;
-    data(110)	= cPosFres;
-    data(111)	= cPosKp;
-    data(112)	= cPosKpc;
+    data(101) = cPosUy;
+    data(102) = cPosFy;
+    data(103) = cPosUcap;
+    data(104) = cPosFcap;
+    data(105) = cPosUlocal;
+    data(106) = cPosFlocal;
+    data(107) = cPosUglobal;
+    data(108) = cPosFglobal;
+    data(109) = cPosUres;
+    data(110) = cPosFres;
+    data(111) = cPosKp;
+    data(112) = cPosKpc;
 // 3 State Variables 113-115
-    data(113)   = cU;
-    data(114)	= cUi;
-    data(115)	= cFi;
+    data(113) = cU;
+    data(114) = cUi;
+    data(115) = cFi;
 // 2 Stiffness 116 117
-    data(116)   = cKreload;
-    data(117)	= cKunload;
+    data(116) = cKreload;
+    data(117) = cKunload;
 // 2 Energy 118 119
-    data(118)   = cEngAcml;
-    data(119)   = cEngDspt;
+    data(118) = cEngAcml;
+    data(119) = cEngDspt;
 // 12 Negative U and F 121-132
-    data(121)	= cNegUy;
-    data(122)	= cNegFy;
-    data(123)	= cNegUcap;
-    data(124)	= cNegFcap;
-    data(125)	= cNegUlocal;
-    data(126)	= cNegFlocal;
-    data(127)	= cNegUglobal;
-    data(128)	= cNegFglobal;
-    data(129)	= cNegUres;
-    data(130)	= cNegFres;
-    data(131)	= cNegKp;
-    data(132)	= cNegKpc;
+    data(121) = cNegUy;
+    data(122) = cNegFy;
+    data(123) = cNegUcap;
+    data(124) = cNegFcap;
+    data(125) = cNegUlocal;
+    data(126) = cNegFlocal;
+    data(127) = cNegUglobal;
+    data(128) = cNegFglobal;
+    data(129) = cNegUres;
+    data(130) = cNegFres;
+    data(131) = cNegKp;
+    data(132) = cNegKpc;
 // 2 Pinching 133 134
-    data(133)   = cFpinch;
-    data(134)   = cUpinch;
+    data(133) = cFpinch;
+    data(134) = cUpinch;
 // 2 Flag 135 136
-    data(135)	= cFailure_Flag;
-    data(136)	= cBranch;
+    data(135) = cFailure_Flag;
+    data(136) = cBranch;
     res = theChannel.sendVector(this->getDbTag(), cTag, data);
     if (res < 0)
         opserr << "IMKPinching::sendSelf() - failed to send data\n";
@@ -881,130 +881,130 @@ int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBr
         cout << " recvSelf" << endln;
         this->setTag((int)data(0));
     // 25 Fixed Input Material Parameters
-        Ke				= data(1);
-        posUp_0			= data(2);
-        posUpc_0		= data(3);
-        posUu_0			= data(4);
-        posFy_0			= data(5);
-        posFcapFy_0		= data(6);
-        posFresFy_0		= data(7);
-        negUp_0			= data(8);
-        negUpc_0		= data(9);
-        negUu_0			= data(10);
-        negFy_0			= data(11);
-        negFcapFy_0		= data(12);
-        negFresFy_0		= data(13);
-        LAMBDA_S		= data(14);
-        LAMBDA_C		= data(15);
-        LAMBDA_A		= data(16);
-        LAMBDA_K		= data(17);
-        c_S				= data(18);
-        c_C				= data(19);
-        c_A				= data(20);
-        c_K				= data(21);
-        D_pos			= data(22);
-        D_neg			= data(23);
-        kappaF          = data(24);
-        kappaD          = data(25);
+        Ke = data(1);
+        posUp_0 = data(2);
+        posUpc_0 = data(3);
+        posUu_0 = data(4);
+        posFy_0 = data(5);
+        posFcapFy_0 = data(6);
+        posFresFy_0 = data(7);
+        negUp_0 = data(8);
+        negUpc_0 = data(9);
+        negUu_0 = data(10);
+        negFy_0 = data(11);
+        negFcapFy_0 = data(12);
+        negFresFy_0 = data(13);
+        LAMBDA_S = data(14);
+        LAMBDA_C = data(15);
+        LAMBDA_A = data(16);
+        LAMBDA_K = data(17);
+        c_S = data(18);
+        c_C = data(19);
+        c_A = data(20);
+        c_K = data(21);
+        D_pos = data(22);
+        D_neg = data(23);
+        kappaF = data(24);
+        kappaD = data(25);
     // 14 Initial Values
-        posUy_0			= data(31);
-        posUcap_0		= data(32);
-        posFcap_0		= data(33);
-        posKp_0			= data(34);
-        posKpc_0		= data(35);
-        negUy_0			= data(36);
-        negUcap_0		= data(37);
-        negFcap_0		= data(38);
-        negKp_0			= data(39);
-        negKpc_0		= data(40);
-        engRefS			= data(41);
-        engRefC			= data(42);
-        engRefA			= data(43);
-        engRefK			= data(44);
+        posUy_0 = data(31);
+        posUcap_0 = data(32);
+        posFcap_0 = data(33);
+        posKp_0 = data(34);
+        posKpc_0 = data(35);
+        negUy_0 = data(36);
+        negUcap_0 = data(37);
+        negFcap_0 = data(38);
+        negKp_0 = data(39);
+        negKpc_0 = data(40);
+        engRefS = data(41);
+        engRefC = data(42);
+        engRefA = data(43);
+        engRefK = data(44);
     // 12 Positive U and F
-        posUy			= data(51);
-        posFy			= data(52);
-        posUcap		    = data(53);
-        posFcap		   	= data(54);
-        posUlocal	    = data(55);
-        posFlocal	    = data(56);
-        posUglobal	    = data(57);
-        posFglobal	    = data(58);
-        posUres	    	= data(59);
-        posFres		   	= data(60);
-        posKp			= data(61);
-        posKpc		    = data(62);
+        posUy = data(51);
+        posFy = data(52);
+        posUcap = data(53);
+        posFcap = data(54);
+        posUlocal = data(55);
+        posFlocal = data(56);
+        posUglobal = data(57);
+        posFglobal = data(58);
+        posUres = data(59);
+        posFres = data(60);
+        posKp = data(61);
+        posKpc = data(62);
     // 3 State Variables
-        U               = data(63);
-        Ui				= data(64);
-        Fi				= data(65);
+        U = data(63);
+        Ui = data(64);
+        Fi = data(65);
     // 2 Stiffness
-        Kreload		= data(66);
-        Kunload	    	= data(67);
+        Kreload = data(66);
+        Kunload = data(67);
     // 2 Energy
-        engAcml			= data(68);
-        engDspt		    = data(69);
+        engAcml = data(68);
+        engDspt = data(69);
     // 12 Negative U and F
-        negUy			= data(71);
-        negFy			= data(72);
-        negUcap		    = data(73);
-        negFcap		   	= data(74);
-        negUlocal	    = data(75);
-        negFlocal  	    = data(76);
-        negUglobal	    = data(77);
-        negFglobal  	= data(78);
-        negUres		   	= data(79);
-        negFres		    = data(80);
-        negKp			= data(81);
-        negKpc		    = data(82);
+        negUy = data(71);
+        negFy = data(72);
+        negUcap = data(73);
+        negFcap = data(74);
+        negUlocal = data(75);
+        negFlocal = data(76);
+        negUglobal = data(77);
+        negFglobal = data(78);
+        negUres = data(79);
+        negFres = data(80);
+        negKp = data(81);
+        negKpc = data(82);
     // 2 Pinching
-        Fpinch          = data(83);
-        Upinch          = data(84);
+        Fpinch = data(83);
+        Upinch = data(84);
     // 2 Flag
-        Failure_Flag	= data(85);
-        Branch			= data(86);
+        Failure_Flag = data(85);
+        Branch = data(86);
     // 12 Positive U and F
-        cPosUy			= data(101);
-        cPosFy			= data(102);
-        cPosUcap		= data(103);
-        cPosFcap		= data(104);
-        cPosUlocal		= data(105);
-        cPosFlocal		= data(106);
-        cPosUglobal		= data(107);
-        cPosFglobal		= data(108);
-        cPosUres		= data(109);
-        cPosFres		= data(110);
-        cPosKp			= data(111);
-        cPosKpc			= data(112);
+        cPosUy = data(101);
+        cPosFy = data(102);
+        cPosUcap = data(103);
+        cPosFcap = data(104);
+        cPosUlocal = data(105);
+        cPosFlocal = data(106);
+        cPosUglobal = data(107);
+        cPosFglobal = data(108);
+        cPosUres = data(109);
+        cPosFres = data(110);
+        cPosKp = data(111);
+        cPosKpc = data(112);
     // 3 State Variables
-        cU              = data(113);
-        cUi				= data(114);
-        cFi				= data(115);
+        cU = data(113);
+        cUi = data(114);
+        cFi = data(115);
     // 2 Stiffness
-        cKreload       = data(116);
-        cKunload		= data(117);
+        cKreload = data(116);
+        cKunload = data(117);
     // 2 Energy
-        cEngAcml        = data(118);
-        cEngDspt        = data(119);
+        cEngAcml = data(118);
+        cEngDspt = data(119);
     // 12 Negative U and F
-        cNegUy			= data(121);
-        cNegFy			= data(122);
-        cNegUcap		= data(123);
-        cNegFcap		= data(124);
-        cNegUlocal		= data(125);
-        cNegFlocal		= data(126);
-        cNegUglobal		= data(127);
-        cNegFglobal		= data(128);
-        cNegUres		= data(129);
-        cNegFres		= data(130);
-        cNegKp			= data(131);
-        cNegKpc			= data(132);
+        cNegUy = data(121);
+        cNegFy = data(122);
+        cNegUcap = data(123);
+        cNegFcap = data(124);
+        cNegUlocal = data(125);
+        cNegFlocal = data(126);
+        cNegUglobal = data(127);
+        cNegFglobal = data(128);
+        cNegUres = data(129);
+        cNegFres = data(130);
+        cNegKp = data(131);
+        cNegKpc = data(132);
     // 2 Pinching
-        cFpinch         = data(133);
-        cUpinch         = data(134);
+        cFpinch = data(133);
+        cUpinch = data(134);
     // 2 Flag
-        cFailure_Flag	= data(135);
-        cBranch			= data(136);
+        cFailure_Flag = data(135);
+        cBranch = data(136);
     }
 
     return res;

--- a/SRC/material/uniaxial/IMKPinching.cpp
+++ b/SRC/material/uniaxial/IMKPinching.cpp
@@ -783,7 +783,6 @@ int IMKPinching::sendSelf(int cTag, Channel &theChannel)
     data(51) = posKp;
     data(62) = posKpc;
 // 3 State Variables 63-65
-    // data(63) = U;
     data(64) = Ui;
     data(65) = Fi;
 // 2 Stiffness 66 67

--- a/SRC/material/uniaxial/IMKPinching.h
+++ b/SRC/material/uniaxial/IMKPinching.h
@@ -20,9 +20,9 @@
 
 //Modified Ibarra-Medina-Krawinkler with Peak-Oriented Hysteretic Response
 
-//**********************************************************************                                                                     
+//**********************************************************************
 // Code Developed by: Ahmed Elkady and Hammad ElJisr
-// Last Updated: October 2022
+// Last Updated: September 2023
 //**********************************************************************
 
 #ifndef IMKPinching_h
@@ -57,7 +57,7 @@ public:
 protected:
 
 private:
-// 25 Fixed input material parameters 	
+// 25 Fixed input material parameters
     double  Ke;
     double  posUp_0;
     double  posUpc_0;
@@ -93,7 +93,7 @@ private:
     double  engRefC;
     double  engRefA;
     double  engRefK;
-// History Variables 
+// History Variables
 // 12 Positive U and F
     double  posUy,          cPosUy;
     double  posFy,          cPosFy;
@@ -124,11 +124,10 @@ private:
     double  Fpinch,         cFpinch;
     double  Upinch,         cUpinch;
 // 3 State Variables
-    double  U,              cU;
     double  Ui,             cUi;
     double  Fi,             cFi;
 // 3 Stiffness
-    double  Kreload,       cKreload, KgetTangent;
+    double  Kreload,        cKreload, KgetTangent;
     double  Kunload,        cKunload;
 // 2 Energy
     double  engAcml,        cEngAcml;


### PR DESCRIPTION
I've just noticed that a variable (Branch) was not correctly copied in copy function. Then, I've fixed that and executed refactoring including removal of an unnecessary variable. You'll see that GitHub says there are a number of lines changed, but they are just insertion or removal of spaces. I'll show a figure below illustrating of the behaviors of IMK models comparison between before and after this fix. Blue solid line is the old one, and orange dashed line is the new one.

![1023_plot](https://github.com/OpenSees/OpenSees/assets/76049354/69109799-63e6-4991-a404-f969471d91ba)
