### PR TITLE
Additional output for Bilin material

### DIFF
--- a/SRC/material/uniaxial/Bilin.cpp
+++ b/SRC/material/uniaxial/Bilin.cpp
@@ -40,6 +40,7 @@
 #include <Vector.h>
 #include <Channel.h>
 #include <cfloat>
+#include <MaterialResponse.h>
 
 #include <OPS_Globals.h>
 
@@ -1975,6 +1976,37 @@ Bilin::Print(OPS_Stream &s, int flag)
         s << "\"PDNeg\": " << PDNeg << ", ";
         s << "\"nFactor\": " << nFactor << "}";
     }
+}
+
+Response *Bilin::setResponse(const char **argv, int argc, OPS_Stream &theOutput)
+{
+  // See if the response is one of the defaults
+  Response *theResponse = UniaxialMaterial::setResponse(argv, argc, theOutput);
+
+  if (theResponse != 0)
+    return theResponse;
+
+  if (strcmp(argv[0], "RSE") == 0)
+  {
+    theOutput.tag("ResponseType", "RSE");
+    theResponse = new MaterialResponse(this, 101, CRSE);
+  }
+
+  theOutput.endTag();
+  return theResponse;
+}
+
+int Bilin::getResponse(int responseID, Information &matInformation)
+{
+  if (responseID == 101)
+  {
+    matInformation.setDouble(CRSE);
+  }
+  else
+  {
+    return UniaxialMaterial::getResponse(responseID, matInformation);
+  }
+  return 0;
 }
 
 //my functions

--- a/SRC/material/uniaxial/Bilin.h
+++ b/SRC/material/uniaxial/Bilin.h
@@ -73,6 +73,8 @@ class Bilin : public UniaxialMaterial
                FEM_ObjectBroker &theBroker);    
  
   void Print(OPS_Stream &s, int flag =0);
+  Response *setResponse(const char **argv, int argc, OPS_Stream &s);
+  int getResponse(int responseID, Information &matInformation);
   
   virtual double getEnergy(void) { return CEnrgtot; } //by SAJalali
 


### PR DESCRIPTION
This adds an additional output, `"RSE"`, to the `Bilin` material, which tracks the recoverable portion of the strain energy. This makes it easier to calculate when the material's energy dissipating capacity is exhausted, since `"energy"` gives you all the energy.