### PR TITLE
add a new pulse

### DIFF
--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -587,6 +587,7 @@
 #include "ConstantSeries.h"
 #include "TrigSeries.h"
 #include "TriangleSeries.h"
+#include "MPAccSeries.h"   //Tang.S
 
 // time series integrators
 #include "TrapezoidalTimeSeriesIntegrator.h"
@@ -2033,6 +2034,9 @@ FEM_ObjectBrokerAllClasses::getNewTimeSeries(int classTag)
 
         case TSERIES_TAG_TrigSeries:
 	  return new TrigSeries;
+	  //Tang.S
+		case TSERIES_TAG_MPAccSeries:
+			return new MPAccSeries;
 
 	default:
 	     opserr << "FEM_ObjectBrokerAllClasses::getPtrTimeSeries - ";

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -102,6 +102,7 @@
 #define TSERIES_TAG_PeerNGAMotion       12
 #define TSERIES_TAG_PathTimeSeriesThermal  13  //L.Jiang [ SIF ]
 #define TSERIES_TAG_RampSeries  14  //CDM
+#define TSERIES_TAG_MPAccSeries       15 //Tang.S[SEU]
 
 #define PARAMETER_TAG_Parameter			   1
 #define PARAMETER_TAG_MaterialStageParameter       2

--- a/SRC/domain/pattern/MPAccSeries.cpp
+++ b/SRC/domain/pattern/MPAccSeries.cpp
@@ -1,0 +1,230 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Date: 2023-01-20 20:16:29 $
+// $Source: /usr/local/cvs/OpenSees/SRC/domain/pattern/MPAccSeries.cpp,v $
+
+// Written: Tang.S
+// Created: 2023-01-20
+//
+// Purpose: This file contains the class implementation of MPAccSeries.
+//
+// What: "@(#) MPAccSeries.C, revA"
+
+
+#include <MPAccSeries.h>
+#include <Vector.h>
+#include <Channel.h>
+#include <classTags.h>
+
+#include <math.h>
+
+#include <elementAPI.h>
+
+
+void *OPS_MPAccSeries(void)
+{
+    // Pointer to a uniaxial material that will be returned
+    TimeSeries *theSeries = 0;
+
+    int numRemainingArgs = OPS_GetNumRemainingInputArgs();
+
+    if (numRemainingArgs < 3) {
+        opserr << "WARNING: invalid num args MPAcc <tag?> $tStart $tFinish $period <-AFactor> <-gammaMP> <-nuMP>\n";
+        return 0;
+    }
+
+    int tag = 0;      // default tag = 0
+    double dData[6];
+    dData[3] = 0.0;   // default gammaMP = 0.0
+    dData[4] = 0.0;   // default nuMP = 0.0
+    dData[5] = 1.0;   // default AFactor = 1.0
+    int numData = 0;
+
+    // get tag if provided
+    if (numRemainingArgs == 4 || numRemainingArgs == 6 || numRemainingArgs == 8 || numRemainingArgs == 10) {
+        numData = 1;
+        if (OPS_GetIntInput(&numData, &tag) != 0) {
+            opserr << "WARNING invalid series tag in MPAcc tag?" << endln;
+            return 0;
+        }
+        numRemainingArgs -= 1;
+    }
+
+    numData = 3;
+    if (OPS_GetDouble(&numData, dData) != 0) {
+        opserr << "WARNING invalid double data in MPAcc Series with tag: " << tag << endln;
+        return 0;
+    }
+    numRemainingArgs -= 3;
+
+    // parse the optional args
+    while (numRemainingArgs > 1) {
+      const char *argvS = OPS_GetString();
+
+      if (strcmp(argvS,"-gammaMP") == 0) {
+	numData = 1;
+	if (OPS_GetDouble(&numData, &dData[3]) != 0) {
+	  opserr << "WARNING invalid gamma in MPAcc Series with tag?" << tag << endln;
+                return 0;
+	}
+      } else if (strcmp(argvS,"-nuMP") == 0) {
+	numData = 1;
+            if (OPS_GetDouble(&numData, &dData[4]) != 0) {
+                opserr << "WARNING invalid nu in MPAcc Series with tag?" << tag << endln;
+                return 0;
+            }
+        } else if (strcmp(argvS,"-AFactor") == 0) {
+            numData = 1;
+            if (OPS_GetDouble(&numData, &dData[5]) != 0) {
+                opserr << "WARNING invalid amplitude in MPAcc Series with tag?" << tag << endln;
+                return 0;
+            }
+        } else {
+            opserr << "WARNING unknown option: " << argvS << "  in MPAcc Series with tag?" << tag << endln;      
+            return 0;
+        }
+        numRemainingArgs -= 2;
+    }
+    //double tData = dData[4] * asin(1.0) / 90;
+    //double tF = dData[3] * dData[2];
+    theSeries = new MPAccSeries(tag, dData[0], dData[1], dData[2], dData[3], dData[4], dData[5]);
+
+    if (theSeries == 0) {
+        opserr << "WARNING ran out of memory creating MPAcc Series with tag: " << tag << "\n";
+        return 0;
+    }
+
+    return theSeries;
+}
+
+
+MPAccSeries::MPAccSeries(int tag,
+    double startTime, 
+    double finishTime,
+    double T, 
+    double gamma, 
+    double nu,
+    double A)
+    : TimeSeries(tag, TSERIES_TAG_MPAccSeries),
+    tStart(startTime), tFinish(finishTime),
+    period(T), gammaMP(gamma),
+    nuMP(nu), AFactor(A)
+{
+    if (period == 0.0) {
+        opserr << "MPAccSeries::MPAccSeries -- input period is zero, setting period to PI\n";
+        period = 2*asin(1.0);
+    }
+}
+
+
+MPAccSeries::MPAccSeries()
+    : TimeSeries(TSERIES_TAG_MPAccSeries),
+    tStart(0.0), tFinish(0.0),
+    period(1.0), gammaMP(0.0),
+    nuMP(0.0), AFactor(1.0)
+{
+    // does nothing
+}
+
+
+MPAccSeries::~MPAccSeries()
+{
+    // does nothing
+}
+
+TimeSeries *MPAccSeries::getCopy()
+{
+    return new MPAccSeries(this->getTag(), tStart, tFinish, period,
+        gammaMP, nuMP, AFactor);
+}
+
+
+double MPAccSeries::getFactor(double pseudoTime)
+{
+    static double onepi = 2*asin(1.0);
+
+    if (pseudoTime >= tStart && pseudoTime <= tFinish)  {
+        double part2 = gammaMP * sin((2 * onepi * pseudoTime) / period - onepi * gammaMP + (nuMP * onepi)/180) * (1 - cos((2 * onepi * pseudoTime) / (period * gammaMP)));
+        return ((AFactor * onepi) / (period * gammaMP)) * (sin((2 * onepi * pseudoTime) / (period * gammaMP)) * (cos((2 * onepi * pseudoTime) / period - onepi * gammaMP + (nuMP * onepi)/180)) - part2);
+    }
+    else
+        return 0.0;
+}
+
+
+int MPAccSeries::sendSelf(int commitTag, Channel &theChannel)
+{
+    int dbTag = this->getDbTag();
+    Vector data(6);
+    data(0) = AFactor;
+    data(1) = tStart;
+    data(2) = tFinish;
+    data(3) = period;
+    data(4) = gammaMP;
+    data(5) = nuMP;
+
+    int result = theChannel.sendVector(dbTag,commitTag, data);
+    if (result < 0) {
+        opserr << "MPAccSeries::sendSelf() - channel failed to send data\n";
+        return result;
+    }
+
+    return 0;
+}
+
+
+int MPAccSeries::recvSelf(int commitTag, Channel &theChannel, 
+    FEM_ObjectBroker &theBroker)
+{
+    int dbTag = this->getDbTag();
+    Vector data(6);
+    int result = theChannel.recvVector(dbTag,commitTag, data);
+    if (result < 0) {
+        opserr << "MPAccSeries::recvSelf() - channel failed to receive data\n";
+        AFactor    = 1.0;
+        tStart     = 0.0;
+        tFinish    = 0.0;
+        period     = 1.0;
+        gammaMP = 0.0;
+        nuMP  = 0.0;
+        return result;
+    }
+    AFactor    = data(0);
+    tStart     = data(1);
+    tFinish    = data(2);
+    period     = data(3);
+    gammaMP = data(4);
+    nuMP  = data(5);
+
+    return 0;
+}
+
+
+void MPAccSeries::Print(OPS_Stream &s, int flag)
+{
+    s << "MPAcc Series" << endln;
+    s << "\tAFactor: " << AFactor << endln;
+    s << "\ttStart: " << tStart << endln;
+    s << "\ttFinish: " << tFinish << endln;
+    s << "\tPeriod: " << period << endln;
+    s << "\tgammaMP: " << gammaMP << endln;
+    s << "\tnuMP: " << nuMP << endln;
+}

--- a/SRC/domain/pattern/MPAccSeries.h
+++ b/SRC/domain/pattern/MPAccSeries.h
@@ -1,0 +1,78 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.3 $
+// $Date: 2010-02-04 00:34:29 $
+// $Source: /usr/local/cvs/OpenSees/SRC/domain/pattern/MPAccSeries.h,v $
+
+
+#ifndef MPAccSeries_h
+#define MPAccSeries_h
+
+// Written: Tang.S 
+// Created: 2023-01
+// Revision: A
+
+#include <TimeSeries.h>
+
+class MPAccSeries : public TimeSeries
+{
+public:
+    // constructors
+    MPAccSeries(int tag,
+        double tStart, 
+        double tFinish,
+        double period, 
+        double gammaMP, 
+        double nuMP = 1.0,
+        double AFactor = 1.0);
+
+    MPAccSeries();
+
+    // destructor
+    ~MPAccSeries();
+
+    TimeSeries *getCopy(); 
+
+    // method to get load factor
+    double getFactor(double pseudoTime);
+    double getDuration () {return tFinish-tStart;}
+    double getPeakFactor () {return AFactor;}
+    double getTimeIncr (double pseudoTime) {return tFinish-tStart;}
+
+    // methods for output    
+    int sendSelf(int commitTag, Channel &theChannel);
+    int recvSelf(int commitTag, Channel &theChannel, 
+        FEM_ObjectBroker &theBroker);
+
+    void Print(OPS_Stream &s, int flag = 0);
+
+protected:
+
+private:
+    double tStart;      // start time of time series (sec)
+    double tFinish;     // end time of time series (sec)
+    double period;      // period of MPAcc series (sec)
+    double gammaMP;  // ¦Ã factor in M&P pulse model 
+    double nuMP;     // nu in degree in M&P pulse model
+    double AFactor;   // the M&P velocity amplificarion factor(optional,default=1.0)
+};
+
+#endif

--- a/SRC/domain/pattern/TclPatternCommand.cpp
+++ b/SRC/domain/pattern/TclPatternCommand.cpp
@@ -58,6 +58,7 @@
 #include <GroundMotion.h>
 #include <GroundMotionRecord.h>
 #include <TimeSeriesIntegrator.h>
+#include <MPAccSeries.h>   //Tang.S
 
 #include <FireLoadPattern.h>  //Added by UoE openSees Group
 

--- a/SRC/domain/pattern/TclSeriesCommand.cpp
+++ b/SRC/domain/pattern/TclSeriesCommand.cpp
@@ -45,6 +45,7 @@
 #include <PeerMotion.h>
 #include <PeerNGAMotion.h>
 #include <string.h>
+#include <MPAccSeries.h>   //Tang.S
 
 #ifdef _RELIABILITY
 #include <DiscretizedRandomProcessSeries.h>
@@ -78,6 +79,7 @@ extern void *OPS_RectangularSeries(void);
 extern void *OPS_PulseSeries(void);
 extern void *OPS_PeerMotion(void);
 extern void *OPS_PeerNGAMotion(void);
+extern void* OPS_MPAccSeries(void);   //Tang.S
 
 #include <elementAPI.h>
 extern "C" int OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp * interp, int cArg, int mArg, TCL_Char * *argv, Domain * domain);
@@ -108,6 +110,12 @@ TclTimeSeriesCommand(ClientData clientData,
     void *theResult = OPS_TrigSeries();
     if (theResult != 0)
       theSeries = (TimeSeries *)theResult;
+    //Tang.S
+  } else if ((strcmp(argv[0], "MPAcc") == 0) || (strcmp(argv[0], "MPAccSeries") == 0)) {
+
+      void* theResult = OPS_MPAccSeries();
+      if (theResult != 0)
+          theSeries = (TimeSeries*)theResult;
 
   }	
 

--- a/SRC/interpreter/OpenSeesTimeSeriesCommands.cpp
+++ b/SRC/interpreter/OpenSeesTimeSeriesCommands.cpp
@@ -55,6 +55,7 @@ void* OPS_TrigSeries();
 void* OPS_RampSeries();
 void* OPS_RectangularSeries();
 void* OPS_PulseSeries();
+void* OPS_MPAccSeries();   //Tang.S
 
 namespace {
     
@@ -226,6 +227,8 @@ namespace {
 	functionMap.insert(std::make_pair("TriangleSeries", &OPS_TriangleSeries));
 	functionMap.insert(std::make_pair("Path", &OPS_PathSeries));
 	functionMap.insert(std::make_pair("Series", &OPS_PathSeries));
+	functionMap.insert(std::make_pair("MPAcc", &OPS_MPAccSeries));  //Tang.S
+	functionMap.insert(std::make_pair("MPAccSeries", &OPS_MPAccSeries));
       
 	return 0;
     }

--- a/Win64/proj/domain/domain.vcxproj
+++ b/Win64/proj/domain/domain.vcxproj
@@ -220,6 +220,7 @@
     <ClCompile Include="..\..\..\SRC\domain\domain\single\SingleDomParamIter.cpp" />
     <ClCompile Include="..\..\..\SRC\domain\domain\single\SingleDomSP_Iter.cpp" />
     <ClCompile Include="..\..\..\SRC\domain\pattern\drm\H5DRM.cpp" />
+    <ClCompile Include="..\..\..\SRC\domain\pattern\MPAccSeries.cpp" />
     <ClCompile Include="..\..\..\SRC\domain\pattern\PathTimeSeriesThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\domain\pattern\RampSeries.cpp" />
     <ClCompile Include="..\..\..\SRC\domain\pattern\SimpsonTimeSeriesIntegrator.cpp" />
@@ -322,6 +323,7 @@
     <ClInclude Include="..\..\..\SRC\domain\domain\single\SingleDomParamIter.h" />
     <ClInclude Include="..\..\..\SRC\domain\domain\single\SingleDomSP_Iter.h" />
     <ClInclude Include="..\..\..\SRC\domain\pattern\drm\H5DRM.h" />
+    <ClInclude Include="..\..\..\SRC\domain\pattern\MPAccSeries.h" />
     <ClInclude Include="..\..\..\SRC\domain\pattern\PathTimeSeriesThermal.h" />
     <ClInclude Include="..\..\..\SRC\domain\pattern\RampSeries.h" />
     <ClInclude Include="..\..\..\SRC\domain\pattern\SimpsonTimeSeriesIntegrator.h" />

--- a/Win64/proj/domain/domain.vcxproj.filters
+++ b/Win64/proj/domain/domain.vcxproj.filters
@@ -333,6 +333,9 @@
     <ClCompile Include="..\..\..\SRC\domain\pattern\RampSeries.cpp">
       <Filter>timeSeries</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\domain\pattern\MPAccSeries.cpp">
+      <Filter>timeSeries</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\SRC\domain\node\NodalLoad.h">
@@ -615,6 +618,9 @@
       <Filter>pattern\drm</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\domain\pattern\RampSeries.h">
+      <Filter>timeSeries</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\domain\pattern\MPAccSeries.h">
       <Filter>timeSeries</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Tcl Code：
timeSeries MPAcc $tag $tStart $tEnd $period <-gammaMP $gammaMP> <-nuMP $nuMP> <-AFactor $AFactor>

Python Code：
timeSeries('MPAcc', tag, tStart, tEnd, period, '-gammaMP', -gammaMP, '-nuMP', nuMP, '-AFactor', AFactor)

The new section represents near-field strong ground motion and can simulate the entire set of available near-fault displacement, velocity, and (in many cases) acceleration time histories, as well as the corresponding deformation, velocity, and acceleration response spectra.
Reference:George P. Mavroeidis and Apostolos S. Papageorgiou .A Mathematical Representation of Near-Fault Ground Motions,Bulletin of the Seismological Society of America, Vol. 93, No. 3,1099–1131