### PR TITLE
Adding ReinforcedConcreteLayerMembrane materials

### DIFF
--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -1052,7 +1052,9 @@ MATERIAL_LIBS   =  $(FE)/material/Material.o \
 	$(FE)/material/nD/PlateRebarMaterial.o \
 	$(FE)/material/nD/ASDConcrete3DMaterial.o \
 	$(FE)/material/nD/stressDensityModel/stressDensity.o \
-	$(FE)/material/nD/stressDensityModel/SDM-UC.o
+	$(FE)/material/nD/stressDensityModel/SDM-UC.o \
+	$(FE)/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.o \
+	$(FE)/material/nD/SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.o
 
 FEDEAS_LIBS = $(FE)/material/uniaxial/FedeasMaterial.o \
 	$(FE)/material/uniaxial/fedeas/FedeasHardeningMaterial.o \
@@ -1147,7 +1149,9 @@ SECTION_LIBS = $(FE)/material/section/SectionForceDeformation.o \
 	$(FE)/material/section/yieldSurface/YieldSurfaceSection2d.o \
 	$(FE)/material/section/yieldSurface/YS_Section2D01.o \
 	$(FE)/material/section/yieldSurface/YS_Section2D02.o \
-	$(FE)/material/section/yieldSurface/SoilFootingSection2d.o
+	$(FE)/material/section/yieldSurface/SoilFootingSection2d.o \
+	$(FE)/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.o \
+	$(FE)/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.o
 
 
 SUPER_LU_OBJ = $(FE)/system_of_eqn/linearSOE/sparseGEN/SuperLU.o 

--- a/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
+++ b/SRC/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
@@ -186,6 +186,8 @@
 #include "Elliptical2.h"
 #include "Isolator2spring.h"
 #include "LayeredShellFiberSection.h" // Yuli Huang & Xinzheng Lu 
+#include "ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.h" // M. J. Nunez
+#include "ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.h" // M. J. Nunez
 
 // NDMaterials
 #include "ElasticIsotropicPlaneStrain2D.h"
@@ -250,6 +252,8 @@
 #include "stressDensityModel/stressDensity.h"
 #include "InitStressNDMaterial.h"
 #include "ASDConcrete3DMaterial.h"
+#include "OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.h" // M. J. Nunez
+#include "SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.h" // M. J. Nunez
 
 // Fibers
 #include "fiber/UniaxialFiber2d.h"
@@ -1776,6 +1780,13 @@ FEM_ObjectBrokerAllClasses::getNewSection(int classTag)
     case SEC_TAG_Isolator2spring:
       return new Isolator2spring();
 	
+
+	case SEC_TAG_ReinforcedConcreteLayerMembraneSection01:
+		return new ReinforcedConcreteLayerMembraneSection01();
+
+	case SEC_TAG_ReinforcedConcreteLayerMembraneSection02:
+		return new ReinforcedConcreteLayerMembraneSection02();
+
 	default:
 	     opserr << "FEM_ObjectBrokerAllClasses::getNewSection - ";
 	     opserr << " - no section type exists for class tag ";
@@ -1961,6 +1972,12 @@ FEM_ObjectBrokerAllClasses::getNewNDMaterial(int classTag)
 
   case ND_TAG_ASDConcrete3DMaterial:
       return new ASDConcrete3DMaterial();
+
+  case ND_TAG_OrthotropicRotatingAngleConcreteT2DMaterial01:
+	  return new OrthotropicRotatingAngleConcreteT2DMaterial01();
+
+  case ND_TAG_SmearedSteelDoubleLayerT2DMaterial01:
+	  return new SmearedSteelDoubleLayerT2DMaterial01();
     
   default:
     opserr << "FEM_ObjectBrokerAllClasses::getNewNDMaterial - ";

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -357,6 +357,9 @@
 
 #define SEC_TAG_MCFTFiberSection2d 7601
 
+#define SEC_TAG_ReinforcedConcreteLayerMembraneSection01 7701 // M. J. Nunez - UChile
+#define SEC_TAG_ReinforcedConcreteLayerMembraneSection02 7702 // M. J. Nunez - UChile
+
 #define SECTION_INTEGRATION_TAG_WideFlange 1
 #define SECTION_INTEGRATION_TAG_RC 2
 #define SECTION_INTEGRATION_TAG_RCT 3
@@ -535,6 +538,9 @@
 #define ND_TAG_VonPapaDamage 7016
 
 #define ND_TAG_ASDConcrete3DMaterial 7017 // Massimo Petracca ASDEA Software
+
+#define ND_TAG_OrthotropicRotatingAngleConcreteT2DMaterial01 7018 // M. J. Nunez - UChile
+#define ND_TAG_SmearedSteelDoubleLayerT2DMaterial01 7019		  // M. J. Nunez - UChile
 
 #define FIBER_TAG_Uniaxial2d	1
 #define FIBER_TAG_Uniaxial3d	2

--- a/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
@@ -80,6 +80,8 @@ void* OPS_VonPapaDamage();
 void* OPS_ConcreteMcftNonlinear5();
 void* OPS_ConcreteMcftNonlinear7();
 void* OPS_ASDConcrete3DMaterial();
+void* OPS_OrthotropicRotatingAngleConcreteT2DMaterial01();	// M. J. Nunez - UChile
+void* OPS_SmearedSteelDoubleLayerT2DMaterial01();			// M. J. Nunez - UChile
 
 namespace {
 
@@ -198,6 +200,8 @@ namespace {
 	nDMaterialsMap.insert(std::make_pair("ConcreteMcftNonlinear5", &OPS_ConcreteMcftNonlinear5));
 	nDMaterialsMap.insert(std::make_pair("ConcreteMcftNonlinear7", &OPS_ConcreteMcftNonlinear7));
 	nDMaterialsMap.insert(std::make_pair("ASDConcrete3D", &OPS_ASDConcrete3DMaterial));
+	nDMaterialsMap.insert(std::make_pair("OrthotropicRAConcrete", &OPS_OrthotropicRotatingAngleConcreteT2DMaterial01));
+	nDMaterialsMap.insert(std::make_pair("SmearedSteelDoubleLayer", &OPS_SmearedSteelDoubleLayerT2DMaterial01));
 
 	return 0;
     }

--- a/SRC/interpreter/OpenSeesSectionCommands.cpp
+++ b/SRC/interpreter/OpenSeesSectionCommands.cpp
@@ -101,6 +101,8 @@ void* OPS_RCTunnelSection();
 void* OPS_UniaxialSection();
 void* OPS_RCTBeamSection2d();
 void* OPS_RCTBeamSectionUniMat2d();
+void* OPS_ReinforcedConcreteLayerMembraneSection01();	// M. J. Nunez - UChile
+void* OPS_ReinforcedConcreteLayerMembraneSection02();	// M. J. Nunez - UChile
 
 namespace {
     static FiberSection2d* theActiveFiberSection2d = 0;
@@ -333,6 +335,8 @@ namespace {
 	functionMap.insert(std::make_pair("Isolator2spring", &OPS_Isolator2spring));
 	functionMap.insert(std::make_pair("RCCircularSection", &OPS_RCCircularSection));
 	functionMap.insert(std::make_pair("RCTunnelSection", &OPS_RCTunnelSection));
+	functionMap.insert(std::make_pair("ReinforcedConcreteLayerMembraneSection01", &OPS_ReinforcedConcreteLayerMembraneSection01));
+	functionMap.insert(std::make_pair("ReinforcedConcreteLayerMembraneSection02", &OPS_ReinforcedConcreteLayerMembraneSection02));
 
 	return 0;
     }

--- a/SRC/material/nD/CMakeLists.txt
+++ b/SRC/material/nD/CMakeLists.txt
@@ -165,5 +165,7 @@ add_subdirectory(UWmaterials)
 add_subdirectory(matCMM)
 add_subdirectory(stressDensityModel)
 add_subdirectory(UANDESmaterials)
+add_subdirectory(OrthotropicRotatingAngleConcreteT2DMaterial01)
+add_subdirectory(SmearedSteelDoubleLayerT2DMaterial01)
 
 

--- a/SRC/material/nD/Makefile
+++ b/SRC/material/nD/Makefile
@@ -108,6 +108,8 @@ all: $(OBJS)
 	@$(CD) $(FE)/material/nD/matCMM; $(MAKE);
 	@$(CD) $(FE)/material/nD/stressDensityModel; $(MAKE);
 	@$(CD) $(FE)/material/nD/UANDESmaterials; $(MAKE);
+	@$(CD) $(FE)/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01; $(MAKE);
+	@$(CD) $(FE)/material/nD/SmearedSteelDoubleLayerT2DMaterial01; $(MAKE);
 
 test: $(OBJS) main.o
 	$(LINKER) $(LINKFLAGS) main.o ../../../SRC/api/elementAPI_Dummy.o $(FE_LIBRARY) \
@@ -134,6 +136,9 @@ spotless: clean
 	@$(CD) $(FE)/material/nD/matCMM; $(MAKE) wipe;
 	@$(CD) $(FE)/material/nD/stressDensityModel; $(MAKE) wipe;
 	@$(CD) $(FE)/material/nD/UANDESmaterials; $(MAKE) wipe;
+	@$(CD) $(FE)/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01; $(MAKE) wipe;
+	@$(CD) $(FE)/material/nD/SmearedSteelDoubleLayerT2DMaterial01; $(MAKE) wipe;
+	
 
 wipe: spotless
 

--- a/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/CMakeLists.txt
+++ b/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/CMakeLists.txt
@@ -1,0 +1,14 @@
+#==============================================================================
+# 
+#        OpenSees -- Open System For Earthquake Engineering Simulation
+#                Pacific Earthquake Engineering Research Center
+#
+#==============================================================================
+target_sources(OPS_Material
+    PRIVATE
+      OrthotropicRotatingAngleConcreteT2DMaterial01.cpp
+    PUBLIC
+      OrthotropicRotatingAngleConcreteT2DMaterial01.h
+)
+
+target_include_directories(OPS_Material PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/Makefile
+++ b/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/Makefile
@@ -1,0 +1,22 @@
+include ../../../../Makefile.def
+
+OBJS       = OrthotropicRotatingAngleConcreteT2DMaterial01.o
+
+all:	$(OBJS)
+
+# Miscellaneous
+
+tidy:
+	@$(RM) $(RMFLAGS) Makefile.bak *~ #*# core
+
+clean: tidy
+	@$(RM) $(RMFLAGS) $(OBJS) *.o
+
+spotless: clean
+
+wipe: spotless
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+
+
+

--- a/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.cpp
+++ b/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.cpp
@@ -1,0 +1,944 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 12/2022
+// 
+// Description: This file contains the OrthotropicRotatingAngleConcreteT2DMaterial01 class definition.
+// An OrthotropicRotatingAngleConcreteT2DMaterial01 is a subclass of the class NDMaterial and corresponds to the abstract representation
+// of an Orthotropic Concrete Layer (plane stress) 2D Material with the Rotating Angle and Tangent Formulation for Cycling or Reversed
+// Loading with damage that is used in Finite Element Method or Structural Analysis.
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01
+//
+// Rev: 1.0
+
+#include "OrthotropicRotatingAngleConcreteT2DMaterial01.h"
+#include <UniaxialMaterial.h>
+#include <Vector.h>
+#include <Matrix.h>
+#include <cmath>				
+#include <float.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <stdlib.h>
+#include <MaterialResponse.h>
+#include <DummyStream.h>
+#include <elementAPI.h>
+#include <algorithm>
+#include <iostream>			
+#define OPS_Export
+
+#define dbl_Epsilon 2.22e-16	 // a very small double
+
+#include <string.h>
+using namespace std;
+
+static int numOrthotropicRotatingAngleConcreteT2DMaterials = 0;
+
+// Read input parameters and build the material
+OPS_Export void* OPS_OrthotropicRotatingAngleConcreteT2DMaterial01()
+{
+	if (numOrthotropicRotatingAngleConcreteT2DMaterials == 0) {
+		numOrthotropicRotatingAngleConcreteT2DMaterials++;
+	}
+
+	// Pointer to a ND material that will be returned
+	NDMaterial* theMaterial = 0;
+
+	int numRemainingArgs = OPS_GetNumRemainingInputArgs();
+
+	// Parse the script for material parameters
+	if (numRemainingArgs < 5) {	// total # of input parameters
+		opserr << "Invalid #Args want: nDMaterial OrthotropicRotatingAngleConcreteT2DMaterial01 $matTag $Tag_UniaxialConcrete $epscr $epsc $rho <-damageCte1 $DamageCte1> <-damageCte2 $DamageCte2>\n";
+		return 0;
+	}
+
+	int tag;					// nDMaterial tag
+	int UniaxialMatTag;			// uniaxial material tag
+	double dData[2];			// # of material parameters
+	double rhoNDM;				// nDMaterial density
+	double damageCte1 = 0.14;	// default value for damage constant 1
+	double damageCte2 = 0.6;	// default value for damage constant 2
+	
+	// nDMaterial tag
+	int numData = 1;
+	if (OPS_GetInt(&numData, &tag) != 0) {
+		opserr << "WARNING invalid integer tag for nDMaterial OrthotropicRotatingAngleConcreteT2DMaterial" << endln;
+		return 0;
+	}
+
+	// Material tag of 1 concrete material
+	numData = 1;
+	if (OPS_GetInt(&numData, &UniaxialMatTag) != 0) {
+		opserr << "WARNING invalid uniaxial OrthotropicRotatingAngleConcreteT2DMaterial01 tag" << endln;
+		return 0;
+	}
+
+	// Other OrthotropicRotatingAngleConcreteT2DMaterial01 material parameters
+	numData = 2;
+	if (OPS_GetDouble(&numData, dData) != 0) {
+		opserr << "WARNING invalid OrthotropicRotatingAngleConcreteT2DMaterial01 material parameters" << endln;
+		return 0;
+	}
+
+	// nDMaterial density
+	numData = 1;
+	if (OPS_GetDouble(&numData, &rhoNDM) != 0) {
+		opserr << "Invalid arg rho: nDMaterial OrthotropicRotatingAngleConcreteT2DMaterial01 $matTag $Tag_UniaxialConcrete $epscr $epsc $rho <-damageCte1 $DamageCte1> <-damageCte2 $DamageCte2>" << endln;
+		return 0;
+	}
+
+	// Get pointer to Uniaxial material
+	// Concrete 1
+	UniaxialMaterial* theUniaxialMaterial1 = OPS_getUniaxialMaterial(UniaxialMatTag);
+	if (theUniaxialMaterial1 == 0) {
+		opserr << "WARNING material not found\n";
+		opserr << "Material: " << UniaxialMatTag;
+		opserr << "\nOrthotropicRotatingAngleConcreteT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+
+	// Concrete 2
+	UniaxialMaterial* theUniaxialMaterial2 = OPS_getUniaxialMaterial(UniaxialMatTag);
+	if (theUniaxialMaterial2 == 0) {
+		opserr << "WARNING material not found\n";
+		opserr << "Material: " << UniaxialMatTag;
+		opserr << "\nOrthotropicRotatingAngleConcreteT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+
+	numRemainingArgs -= 5;
+	while (numRemainingArgs > 1) {
+		const char* str = OPS_GetString();
+		if (strcmp(str, "-damageCte1") == 0) {
+			numData = 1;
+			if (OPS_GetDouble(&numData, &damageCte1) != 0) {
+				opserr << "Invalid damageConstant1 for OrthotropicRotatingAngleConcreteT2DMaterial01 " << tag <<
+					" $Tag_UniaxialConcrete $epscr $epsc $rho <-damageCte1 $DamageCte1> <-damageCte2 $DamageCte2>\n";
+				return 0;
+			}
+		}
+		else if (strcmp(str, "-damageCte2") == 0) {
+			numData = 1;
+			if (OPS_GetDouble(&numData, &damageCte2) != 0) {
+				opserr << "Invalid damageConstant1 for OrthotropicRotatingAngleConcreteT2DMaterial01 " << tag <<
+					" $Tag_UniaxialConcrete $epscr $epsc $rho <-damageCte1 $DamageCte1> <-damageCte2 $DamageCte2>\n";
+				return 0;
+			}
+		}
+		else {
+			opserr << "WARNING: Invalid option " << str << " in OrthotropicRotatingAngleConcreteT2DMaterial01 " << tag << 
+				" $Tag_UniaxialConcrete $epscr $epsc $rho <-damageCte1 $DamageCte1> <-damageCte2 $DamageCte2>\n";
+			return 0;
+		}
+		numRemainingArgs -= 2;
+	}
+
+	// Create the OrthotropicRotatingAngleConcreteT2DMaterial01
+	theMaterial = new OrthotropicRotatingAngleConcreteT2DMaterial01(tag, 
+		theUniaxialMaterial1,theUniaxialMaterial2, 
+		dData[0], dData[1], 
+		rhoNDM, damageCte1, damageCte2);
+
+	if (theMaterial == 0) {
+		opserr << "WARNING ran out memory creating material\n";
+		opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+
+	return theMaterial;
+}
+
+// Typical Constructor
+OrthotropicRotatingAngleConcreteT2DMaterial01::OrthotropicRotatingAngleConcreteT2DMaterial01(int tag,			// nDMaterial tag
+	UniaxialMaterial* concreteUniaxialMatObject1,																// concrete in a principal direction
+	UniaxialMaterial* concreteUniaxialMatObject2,																// concrete in the other principal direction 
+	double strainAtFcr,																							// strain at tension cracking of the concrete
+	double strainAtFc,																							// strain at the compression strength of the concrete
+	double rho,																									// density
+	double damageCte1,																							// damage constant 1
+	double damageCte2)																							// damage constant 2
+
+	: NDMaterial(tag, ND_TAG_OrthotropicRotatingAngleConcreteT2DMaterial01),
+	ecr(strainAtFcr), ec(strainAtFc), rhoNDM(rho), damageConstant1(damageCte1), damageConstant2(damageCte2),
+	strain_vec(3), stress_vec(3), tangent_matrix(3,3), initialTangentNDM(3,3), strainPrincipalDirection(3), 
+	poissonRatios(2), Cstrain(3), CMaxMinStrainRec(3), TMaxMinStrainRec(3), pi(3.1415926535)
+{
+	thetaPrincipalDirection = 0.0; 
+	strainPrincipalDirection(0) = 0.0;
+	strainPrincipalDirection(1) = 0.0;
+	strainPrincipalDirection(2) = 0.0;
+	isConcreteCracked = false;		
+
+	poissonRatios(0) = 0.0;
+	poissonRatios(1) = 0.0;
+
+	Cstrain(0) = 0.0;
+	Cstrain(1) = 0.0;
+	Cstrain(2) = 0.0;
+
+	CMaxMinStrainRec(0) = 1.0;
+	TMaxMinStrainRec(0) = 1.0;
+	for (int i = 1; i < 3; i++) {
+		CMaxMinStrainRec(i) = 0.0;
+		TMaxMinStrainRec(i) = 0.0;
+	}
+
+	// Allocate pointers for uniaxial materials........................................................
+	theMaterial = new UniaxialMaterial * [2];
+	if (theMaterial == 0) {
+		opserr << " OrthotropicRotatingAngleConcreteT2DMaterial01::OrthotropicRotatingAngleConcreteT2DMaterial01 - failed allocate material array\n";
+		exit(-1);
+	}
+
+	// We create the copies of the concrete uniaxial material objects that define the behavior at each principal direction 
+	theMaterial[0] = concreteUniaxialMatObject1->getCopy();
+	// Check allocation
+	if (theMaterial[0] == 0) {
+		opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::OrthotropicRotatingAngleConcreteT2DMaterial01 - failed to get a copy for Concrete 1\n";
+		exit(-1);
+	}
+
+	theMaterial[1] = concreteUniaxialMatObject2->getCopy();
+	// Check allocation
+	if (theMaterial[1] == 0) {
+		opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::OrthotropicRotatingAngleConcreteT2DMaterial01 - failed to get a copy for Concrete 2\n";
+		exit(-1);
+	}
+		
+	Eo = theMaterial[0]->getInitialTangent();
+	Gmin = (1.0 / 100) * Eo / (2.0 * (1.0 + 0.2));
+
+	this->revertToStart();
+}
+
+// Blank constructor
+OrthotropicRotatingAngleConcreteT2DMaterial01::OrthotropicRotatingAngleConcreteT2DMaterial01()
+	:NDMaterial(0, ND_TAG_OrthotropicRotatingAngleConcreteT2DMaterial01),
+	strain_vec(3), stress_vec(3), tangent_matrix(3,3), initialTangentNDM(3,3), strainPrincipalDirection(3), 
+	poissonRatios(2), Cstrain(3), CMaxMinStrainRec(3), TMaxMinStrainRec(3), pi(3.1415926535)	
+{
+	theMaterial = 0;
+
+	this->revertToStart();
+}
+
+// Destructor
+OrthotropicRotatingAngleConcreteT2DMaterial01::~OrthotropicRotatingAngleConcreteT2DMaterial01()
+{
+	// Delete the pointers
+	if (theMaterial != 0) {
+		for (int i = 0; i < 2; i++)
+		{
+			if (theMaterial[i])
+				delete theMaterial[i];
+		}
+		delete[] theMaterial;
+	}
+
+}
+
+// Get copy
+NDMaterial* OrthotropicRotatingAngleConcreteT2DMaterial01::getCopy(void)
+{
+	OrthotropicRotatingAngleConcreteT2DMaterial01* theCopy =
+		new OrthotropicRotatingAngleConcreteT2DMaterial01(this->getTag(),
+			theMaterial[0],
+			theMaterial[1],
+			ecr,
+			ec,
+			rhoNDM,
+			damageConstant1,
+			damageConstant2);
+
+	return theCopy;
+}
+
+// Get copy
+NDMaterial* OrthotropicRotatingAngleConcreteT2DMaterial01::getCopy(const char* type)
+{
+	OrthotropicRotatingAngleConcreteT2DMaterial01* theModel =
+		new OrthotropicRotatingAngleConcreteT2DMaterial01(this->getTag(),
+			theMaterial[0],
+			theMaterial[1],
+			ecr,
+			ec,
+			rhoNDM,
+			damageConstant1,
+			damageConstant2);
+
+	return theModel;
+}
+
+// Print
+void OrthotropicRotatingAngleConcreteT2DMaterial01::Print(OPS_Stream& s, int flag)
+{
+	s << "\nOrthotropicRotatingAngleConcreteT2DMaterial01, nDMaterial tag: " << this->getTag() << endln;
+
+	// Input values
+	s << "Strain at Fcr: "<< ecr << endln;
+	s << "Strain at Fc: " << ec << endln;
+	s << "Density: " << rhoNDM << endln;
+
+	s << "Hsu/Shu Poisson Ratios nu12: " << poissonRatios(0) << endln;
+	s << "Hsu/Shu Poisson Ratios nu21: " << poissonRatios(1) << endln;
+
+	if (isConcreteCracked) {
+		s << "Concrete has already Cracked" << endln;
+	}
+	else {
+		s << "Concrete has not Cracked" << endln;
+	}
+	//
+	s << "Strains:" << endln;
+	s << "EpsX = " << strain_vec(0) << ", EpsY = " << strain_vec(1) << ", GammaXY = " << strain_vec(2) << endln;
+	s << "Damage Factor: " << CMaxMinStrainRec(0) << endln;
+	//Strain and stress of the uniaxial materials
+	s << "Strain and stress of Concrete Uniaxial Materials:" << endln;
+	s << "Concrete 1: Strain = " << theMaterial[0]->getStrain() << ", Stress = " << theMaterial[0]->getStress() << endln;
+	s << "Concrete 2: Strain = " << theMaterial[1]->getStrain() << ", Stress = " << theMaterial[1]->getStress() << endln;
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::sendSelf(int commitTag, Channel& theChannel)
+{	
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static Vector data(6);
+
+	data(0) = this->getTag();
+	data(1) = ecr;
+	data(2) = ec;
+	data(3) = rhoNDM;
+	data(4) = damageConstant1;
+	data(5) = damageConstant2;
+
+	res += theChannel.sendVector(dataTag, commitTag,data);
+	if (res < 0) {
+		opserr << "WARNING OrthotropicRotatingAngleConcreteT2DMaterial01::sendself() - " << this->getTag() << " failed to send Vector\n";
+		return res;
+	}
+
+	int matDbTag;
+
+	static ID idData(4);
+	int i;
+	for (i = 0; i < 2; i++) {
+		idData(i) = theMaterial[i]->getClassTag();
+		matDbTag = theMaterial[i]->getDbTag();
+		if (matDbTag == 0) {
+			matDbTag = theChannel.getDbTag();
+			if (matDbTag != 0)
+				theMaterial[i]->setDbTag(matDbTag);
+		}
+		idData(i + 2) = matDbTag;
+	}
+
+	res += theChannel.sendID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING OrthotropicRotatingAngleConcreteT2DMaterial01::sendself() - " << this->getTag() << " failed to send ID\n";
+		return res;
+	}
+
+	for (i = 0; i < 2; i++) {
+		res += theMaterial[i]->sendSelf(commitTag, theChannel);
+		if (res < 0) {
+			opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::sendself() - " << this->getTag() << " failed to send its Material\n";
+			return res;
+		}
+	}
+
+	return res;
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker)
+{
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static Vector data(6);
+	res += theChannel.recvVector(dataTag, commitTag, data);
+	if (res < 0) {
+		opserr << "WARNING OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - failed to receive Vector\n";
+		return res;
+	}
+
+	this->setTag((int)data(0));
+	ecr             = data(1);
+	ec              = data(2);
+	rhoNDM          = data(3);
+	damageConstant1 = data(4);
+	damageConstant2 = data(5);
+
+	static ID idData(4);
+
+	res += theChannel.recvID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - " << this->getTag() << " failed to receive ID\n";
+		return res;
+	}
+
+	if (theMaterial == 0) {
+		theMaterial = new UniaxialMaterial * [2];
+		if (theMaterial == 0) {
+			opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - Could not allocate Uniaxial* array\n";
+			return -1;
+		}
+		for (int i = 0; i < 2; i++) {
+			int matClassTag = idData(i);
+			int matDbTag = idData(i + 2);
+
+			theMaterial[i] = theBroker.getNewUniaxialMaterial(matClassTag);
+			if (theMaterial[i] == 0) {
+				opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::recvself() - Broker could not create Uniaxial of class type " << matClassTag << endln;
+				return -1;
+			}
+			theMaterial[i]->setDbTag(matDbTag);
+			res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - material " << i << " failed to recv itself\n";
+				return res;
+			}
+		}
+	}
+
+	else {
+		for (int i = 0; i < 2; i++) {
+			int matClassTag = idData(i);
+			int matDbTag = idData(i + 2);
+
+			if (theMaterial[i]->getClassTag() != matClassTag) {
+				delete theMaterial[i];
+				theMaterial[i] = theBroker.getNewUniaxialMaterial(matClassTag);
+				if (theMaterial[i] == 0) {
+					opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - material " << i << "failed to create\n";
+					return -1;
+				}
+			}
+			theMaterial[i]->setDbTag(matDbTag);
+			res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::recvSelf() - material " << i << " failed to recv itself\n";
+				return res;
+			}
+		}
+	}
+
+	return res;
+}
+
+// Get density
+double OrthotropicRotatingAngleConcreteT2DMaterial01::getRho(void)
+{
+	return rhoNDM;
+}
+
+// Load strain from the element
+int OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrain(const Vector& v)
+{
+	// Calculate trial stress and tangent partial stiffness
+	setTrialStrainPrincipalDirection(v);
+
+	return 0;
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrain(const Vector& v, const Vector& r)
+{
+	opserr << "YOU SHOULD NOT SEE THIS: OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrain(const Vector& v, const Vector& r)\n";
+	return this->setTrialStrain(v);
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrianIncr(const Vector& v)
+{
+	// Add the increment trial strain to the trial strain
+	Vector newTrialStrain(3);
+
+	for (int i = 0; i < 3; i++) {
+		newTrialStrain(i) = strain_vec(i) + v(i);
+	}
+	return this->setTrialStrain(newTrialStrain);
+ }
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrainIncr(const Vector& v, const Vector& r)
+{
+	opserr << "OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrainIncr(const Vector& v, const Vector& r) -- should not be used!\n";
+	return this->setTrialStrianIncr(v);
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::setTrialStrainPrincipalDirection(const Vector& v)
+{
+	// Set values for strain_vec
+	strain_vec(0) = v(0);
+	strain_vec(1) = v(1);
+	strain_vec(2) = v(2);
+
+	// Calculate the Principal Direction of Strain
+	this->calculateStrainPrincipalDirections01();
+
+	// Calculate the Poisson Ratios
+	this->calculatePoissonRatios(strainPrincipalDirection(0), strainPrincipalDirection(1));
+
+	// Define the Poisson Ratio Matrix V = [1 / (1 - nu12 * nu21) nu12 / (1 - nu12 * nu21) 0; nu21 / (1 - nu12 * nu21) 1 / (1 - nu12 * nu21) 0; 0 0 1]
+	double nu[2]; 
+	nu[0] = poissonRatios(0); nu[1] = poissonRatios(1);
+	double oneOverOneMinusNu12Nu21 = 1.0 / (1.0 - nu[0] * nu[1]);
+
+	double V[3][3] = { {oneOverOneMinusNu12Nu21,nu[0] * oneOverOneMinusNu12Nu21,0.0},{nu[1] * oneOverOneMinusNu12Nu21,oneOverOneMinusNu12Nu21,0.0},{0.0,0.0,1.0} };
+
+	// Calculate newUniaxialStrain in the orientation of the Principal Direction of Strain
+	double newUniaxialStrainPD[3] = { 0.0,0.0,0.0 };
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			newUniaxialStrainPD[i] = newUniaxialStrainPD[i] + (strainPrincipalDirection(j) * V[i][j]);
+		}
+	}
+
+	double e_11 = newUniaxialStrainPD[0];
+	double e_22 = newUniaxialStrainPD[1];
+	
+	theMaterial[0]->setTrialStrain(e_11);
+	theMaterial[1]->setTrialStrain(e_22);
+
+
+	// Define the Max and Min Strains Recorded
+	TMaxMinStrainRec(0) = CMaxMinStrainRec(0);
+	TMaxMinStrainRec(1) = CMaxMinStrainRec(1);
+	TMaxMinStrainRec(2) = CMaxMinStrainRec(2);
+
+	double TMMSR[2];
+	TMMSR[0] = TMaxMinStrainRec(1);
+	TMMSR[1] = TMaxMinStrainRec(2);
+
+	if (TMMSR[0] > min(newUniaxialStrainPD[0], newUniaxialStrainPD[1])) {
+		TMMSR[0] = min(newUniaxialStrainPD[0], newUniaxialStrainPD[1]);
+	}
+	if (TMMSR[1] < max(newUniaxialStrainPD[0], newUniaxialStrainPD[1])) {
+		TMMSR[1] = max(newUniaxialStrainPD[0], newUniaxialStrainPD[1]);
+	}
+	TMaxMinStrainRec(1) = TMMSR[0];
+	TMaxMinStrainRec(2) = TMMSR[1];
+
+	// Update the Damage Factor
+	double TstrainRec = fabs(TMaxMinStrainRec(2) - TMaxMinStrainRec(1));
+	double damageFactor = 1 / (1 + damageConstant1 * (pow(fabs(TstrainRec / ec), damageConstant2)));
+	TMaxMinStrainRec(0) = damageFactor;
+
+	// Calculate the Strain Transformation Matrix that goes from the Local Coord System to the orientation of the Principal Direction of Strain
+	double TthetaPD[3][3], TthetaPDT[3][3], tangentNDM[3][3];;
+	double* pTthetaPD = &TthetaPD[0][0];
+	this->calculateStrainTransformationMatrix(pTthetaPD, thetaPrincipalDirection);
+
+	// Extract the Stress in the Orientation of the Principal Direction
+	double fc1 = theMaterial[0]->getStress();
+	double fc2 = theMaterial[1]->getStress();
+
+	// Aply the damage factor
+	double s1 = damageFactor * fc1;
+	double s2 = damageFactor * fc2;
+
+	// Set the Stresses in the Principal Directions
+	double stressNDMPD[3] = { s1,s2,0.0 }, stressNDM[3] = { 0.0,0.0,0.0 };
+
+	// Calculate the traspose of TthetaPD
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			TthetaPDT[i][j] = TthetaPD[j][i];
+		}
+	}
+
+	// Calculate the Stress in the Local Coord System 
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			stressNDM[i] += TthetaPDT[i][j] * stressNDMPD[j];
+		}
+	}
+	for (int i = 0; i < 3; i++) {
+		stress_vec(i) = stressNDM[i];
+	}
+
+	// Extract the Strain in the Orientation of the Principal Direction
+	double e1 = theMaterial[0]->getStrain();
+	double e2 = theMaterial[1]->getStrain();
+
+	// Calculate the Tangent Matrix in the orientation of the Principal Direction of Strain in the Layer [E1 0 0; 0 E2 0; 0 0 G]
+
+	// Extract the Tangent Stiffness in the Orientation of the Principal Direction 
+	double Ect1 = theMaterial[0]->getTangent();
+	double Ect2 = theMaterial[1]->getTangent();
+
+	// Apply the damage factor
+	double E1 = damageFactor * Ect1;
+	double E2 = damageFactor * Ect2;
+
+	// Calculate the Delta Strain
+	double deltaStrain = e1 - e2;
+	// Calculate the Delta Stress
+	double deltaStress = s1 - s2;
+	// Calculate the Shear Tangent for the Orthotropic Concrete
+	double G;
+	if (fabs(deltaStrain) <= dbl_Epsilon || fabs(deltaStress) <= dbl_Epsilon) {
+		if (fabs(E1) < dbl_Epsilon && fabs(E2) < dbl_Epsilon) {
+			G = 1.0e-5;
+		}
+		else {
+			G = (E1 * E2) / (E1 * (1 + nu[0]) + E2 * (1 + nu[1]));
+		}
+	}
+	else {
+		G = 0.5 * deltaStress / deltaStrain;
+	}
+	if (G < Gmin) {
+		G = Gmin;
+	}
+	// Calculate the Tangent Matrix in the Local Coord System [Tstress(-thetaPD)]*[E1 0  0 ; 0 E2 0 ; 0 0 G]*[V]*[Tstrain(thetaPD)], but Tstress(-thetaPD)] = [Tstrain(thetaPD)]^T
+	double D[3][3] = { {E1,0,0},{0,E2,0},{0,0,G} };		// Material tangent matrix in the Principal Strain Direction
+
+	// Inicializacion de la matriz
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			tangentNDM[i][j] = 0.0;
+		}
+	}
+	// Calculate the Tangent Matrix in the Local Coord System
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				for (int m = 0; m < 3; m++) {
+					for (int n = 0; n < 3; n++) {
+						tangentNDM[m][n] += TthetaPDT[m][i] * (D[i][k] * V[k][j]) * TthetaPD[j][n];
+					}
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			tangent_matrix(i, j) = tangentNDM[i][j];
+		}
+	}
+
+	return 0;
+}
+
+const Matrix& OrthotropicRotatingAngleConcreteT2DMaterial01::getTangent(void)
+{
+	return tangent_matrix;
+}
+
+const Vector& OrthotropicRotatingAngleConcreteT2DMaterial01::getStress(void)
+{
+	return stress_vec;
+}
+
+const Vector& OrthotropicRotatingAngleConcreteT2DMaterial01::getStrain()
+{
+	return strain_vec;
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::revertToStart(void)
+{
+	// Revert to start the values in the Concrete UniaxialMaterial Objects
+	theMaterial[0]->revertToStart();
+	theMaterial[1]->revertToStart();
+
+	// Set stress, strain and tangent to zero
+	strain_vec.Zero();
+	stress_vec.Zero();
+	tangent_matrix.Zero();
+	initialTangentNDM.Zero();
+	
+	// Set to inicial some propierties of the NDMaterial
+	poissonRatios.Zero();
+	thetaPrincipalDirection = 0.0;
+	isConcreteCracked = false;
+	// Trial State Variables
+	TMaxMinStrainRec.Zero();
+	TMaxMinStrainRec(0) = 1.0;
+	// Committed State Variables
+	Cstrain.Zero();
+	CMaxMinStrainRec.Zero();
+	CMaxMinStrainRec(0) = 1.0;
+
+	return 0;
+}
+
+// Calculate initial partial stiffness matrix
+const Matrix& OrthotropicRotatingAngleConcreteT2DMaterial01::getInitialTangent(void)
+{
+	// Calculate the Strain Transformation Matrix
+	double TthetaPD[3][3], TthetaPDT[3][3], tangentNDM[3][3];
+	double* pTthetaPD = &TthetaPD[0][0];
+	this->calculateStrainTransformationMatrix(pTthetaPD, thetaPrincipalDirection);
+
+	// Calculate the Tangent Matrix in the orientation of the Principal Direction of Strain in the Layer [E1 0 0; 0 E2 0; 0 0 G]
+	// Define the Poisson Ratio Matrix V = [ 1/(1-nu12*nu21) nu12/(1-nu12*nu21) 0 ; nu21/(1-nu12*nu21) 1/(1-nu12*nu21) 0 ; 0 0 1 ]
+	double nu = 0.2;
+	double oneOverOneMinusNu12Nu21 = 1.0 / (1.0 - nu * nu);
+	double V[3][3] = { {oneOverOneMinusNu12Nu21,nu * oneOverOneMinusNu12Nu21,0.0},{nu * oneOverOneMinusNu12Nu21,oneOverOneMinusNu12Nu21,0.0},{0.0,0.0,1.0} };
+
+	// Extract the Initial Tangent Stiffness in the Orientation of the Principal Direction 
+	double E1 = theMaterial[0]->getInitialTangent();
+	double E2 = theMaterial[1]->getInitialTangent();
+
+	// Calculate the Initial Shear Tangent for the Orthotropic Concrete
+	double G;
+	G = Gmin * 100.0;
+	// Calculate the Tangent Matrix in the Local Coord System [Tstress(-thetaPD)]*[E1 0  0 ; 0 E2 0 ; 0 0 G]*[V]*[Tstrain(thetaPD)], but Tstress(-thetaPD)] = [Tstrain(thetaPD)]^T
+	double D[3][3] = { {E1,0.0,0.0},{0.0,E2,0.0},{0.0,0.0,G} };		// Material tangent matrix in the Principal Strain Direction
+
+	// Traspose of TthetaPD
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			TthetaPDT[i][j] = TthetaPD[j][i];
+		}
+	}
+
+	// Inicializacion de la matriz
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			tangentNDM[i][j] = 0.0;
+		}
+	}
+	// Calculate the Tangent Matrix in the Local Coord System
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				for (int m = 0; m < 3; m++) {
+					for (int n = 0; n < 3; n++) {
+						tangentNDM[m][n] += TthetaPDT[m][i] * (D[i][k] * V[k][j]) * TthetaPD[j][n];
+					}
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			initialTangentNDM(i, j) = tangentNDM[i][j];
+		}
+	}
+	return initialTangentNDM;
+}
+
+Response* OrthotropicRotatingAngleConcreteT2DMaterial01::setResponse(const char** argv, int argc, OPS_Stream& theOutput)
+{
+	Response* theResponse = 0;
+	if (strcmp(argv[0], "getEc") == 0) {
+		theOutput.tag("NdMaterialOutput");
+		theOutput.attr("matType", this->getClassType());
+		theOutput.attr("matTag", this->getTag());
+		theOutput.tag("ResponseType", "MaterialTag");
+		theOutput.tag("ResponseType", "Ec");
+		theOutput.endTag();
+
+		Vector data1(2);
+		data1.Zero();
+		theResponse = new MaterialResponse(this, 101, data1);
+	}
+	else
+		return this->NDMaterial::setResponse(argv, argc, theOutput);
+
+	return theResponse;
+}
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::getResponse(int responseID, Information& matInformation)
+{
+	if (responseID == 101) {
+		return matInformation.setVector(this->getEc());
+	}
+	else {
+		return 0;
+	}
+}
+
+// Function that returns input parameters (concrete Young's modulus) - added for MEFI3D by Maria Jose Nunez, UChile
+Vector OrthotropicRotatingAngleConcreteT2DMaterial01::getEc(void)
+{
+	Vector input_par(2);
+
+	input_par.Zero();
+
+	input_par(0) = this->getTag();
+	input_par(1) = Eo;
+
+	return input_par;
+}
+
+
+int OrthotropicRotatingAngleConcreteT2DMaterial01::commitState(void)
+{
+	// commit the State in the Concrete UniaxialMaterial Objects
+	theMaterial[0]->commitState();
+	theMaterial[1]->commitState();
+
+	// State Variable
+	Cstrain(0) = strain_vec(0);
+	Cstrain(1) = strain_vec(1);
+	Cstrain(2) = strain_vec(2);
+
+	// update the Damage Factor
+	double TstrainRec = fabs(TMaxMinStrainRec(2) - TMaxMinStrainRec(1));
+	double CstrainRec = fabs(CMaxMinStrainRec(2) - CMaxMinStrainRec(1));
+
+	if (TstrainRec == CstrainRec) {
+		CMaxMinStrainRec(0) = 1 / (1 + damageConstant1 * (pow(fabs(CstrainRec / ec), damageConstant2)));
+		for (int i = 0; i < 3; i++) {
+			TMaxMinStrainRec(i) = CMaxMinStrainRec(i);
+		}
+	}
+	else {
+		for (int i = 0; i < 3; i++) {
+			CMaxMinStrainRec(i) = TMaxMinStrainRec(i);
+		}
+	}
+
+	return 0;
+}
+
+// Revert to previously converged state
+int OrthotropicRotatingAngleConcreteT2DMaterial01::revertToLastCommit(void)
+{
+	// revert to last committed state the values in the Concrete UniaxialMaterial Objects
+	theMaterial[0]->revertToLastCommit();
+	theMaterial[1]->revertToLastCommit();
+	// State Variables
+	for (int i = 0; i < 3; i++) {
+		strain_vec(i) = Cstrain(i);
+		TMaxMinStrainRec(i) = CMaxMinStrainRec(i);
+	}
+	return  0;
+}
+
+void OrthotropicRotatingAngleConcreteT2DMaterial01::calculateStrainPrincipalDirections01(void)
+{
+	double Tstrain[3];		//ex, ey, gamma
+	double doubleThetaPD, cos2Theta, sin2Theta;
+	
+	// Get strain values from strain of element
+	Tstrain[0] = strain_vec(0);		// ex
+	Tstrain[1] = strain_vec(1);		// ey
+	Tstrain[2] = strain_vec(2);		// gxy
+	
+	double averageStrains = 0.5 * (Tstrain[0] + Tstrain[1]);
+	double deltaStrains = Tstrain[0] - Tstrain[1];
+	double constantCS = pow(pow(deltaStrains, 2) + pow(Tstrain[2], 2), 0.5);
+	if (deltaStrains == 0.0 && Tstrain[2] == 0.0) {
+		doubleThetaPD = 0.0;
+	}
+	else {
+		cos2Theta = deltaStrains / constantCS;
+		sin2Theta = Tstrain[2] / constantCS;
+		this->calculateAngle01(cos2Theta, sin2Theta, doubleThetaPD);
+
+	}
+
+	thetaPrincipalDirection = 0.5 * doubleThetaPD;
+	strainPrincipalDirection(0) = averageStrains + 0.5 * constantCS;
+	strainPrincipalDirection(1) = averageStrains - 0.5 * constantCS;
+	strainPrincipalDirection(2) = 0.0;
+
+	return;
+}
+
+void OrthotropicRotatingAngleConcreteT2DMaterial01::calculateAngle01(double cosTheta, double sinTheta, double &theta)
+{
+	double thetaFromCos, thetaFromSin;
+
+	thetaFromCos = acos(cosTheta);
+	thetaFromSin = asin(sinTheta);
+
+	if (thetaFromCos <= pi / 2.0 + 1e-7) {
+		theta = thetaFromSin;
+	}
+	else {
+		if (thetaFromSin >= 0.0) {
+			theta = thetaFromCos;
+		}
+		else {
+			theta = -thetaFromCos;
+		}
+	}
+
+	return;
+}
+
+void OrthotropicRotatingAngleConcreteT2DMaterial01::calculatePoissonRatios(double e1, double e2)
+{
+	double nu[2];
+
+	if (e1 <= ec || e1 >= ecr || e2 <= ec || e2 >= ecr) {
+		isConcreteCracked = true;
+	}
+
+	double Nuo = 0.2;
+
+	if (isConcreteCracked) {
+		nu[0] = 0.0;
+		nu[1] = 0.0;
+	}
+	else {
+		nu[0] = Nuo;
+		nu[1] = Nuo;
+	}
+	if (!isConcreteCracked) {
+		if (e2 <= ec / 2.0) {
+			nu[0] = min(Nuo * (1.0 + 1.5 * (pow(2.0 * e2 / ec - 1.0, 2.0))), 0.5);
+		}
+		if (e1 <= ec / 2.0) {
+			nu[1] = min(Nuo * (1.0 + 1.5 * (pow(2.0 * e1 / ec - 1.0, 2.0))), 0.5);
+		}
+	}
+
+	poissonRatios(0) = nu[0];
+	poissonRatios(1) = nu[1];
+
+	return;
+}
+
+void OrthotropicRotatingAngleConcreteT2DMaterial01::calculateStrainTransformationMatrix(double* pTmatrixStrain, double theta)
+{
+	double cosTheta, sinTheta;
+	int N = 3;
+	cosTheta = cos(theta);
+	sinTheta = sin(theta);
+
+	// Uso de la formula de direccionamiento *(p+i*N+j): Accede al elemento C[i][j] de una matriz C de N columnas
+	*(pTmatrixStrain + 0 * N + 0) = pow(cosTheta, 2);						//TmatrixStrain[0][0]
+	*(pTmatrixStrain + 0 * N + 1) = pow(sinTheta, 2);						//TmatrixStrain[0][1]
+	*(pTmatrixStrain + 0 * N + 2) = sinTheta * cosTheta;				    //TmatrixStrain[0][2]
+	*(pTmatrixStrain + 1 * N + 0) = pow(sinTheta, 2);			    		//TmatrixStrain[1][0]
+	*(pTmatrixStrain + 1 * N + 1) = pow(cosTheta, 2);						//TmatrixStrain[1][1]
+	*(pTmatrixStrain + 1 * N + 2) = -sinTheta * cosTheta;				    //TmatrixStrain[1][2]
+	*(pTmatrixStrain + 2 * N + 0) = -2.0 * sinTheta * cosTheta;				//TmatrixStrain[2][0]
+	*(pTmatrixStrain + 2 * N + 1) = 2.0 * sinTheta * cosTheta;				//TmatrixStrain[2][1]
+	*(pTmatrixStrain + 2 * N + 2) = pow(cosTheta, 2) - pow(sinTheta, 2);	//TmatrixStrain[2][2]
+	return;
+}
+
+void OrthotropicRotatingAngleConcreteT2DMaterial01::calculateStressTransformationMatrix(double* pTmatrixStress, double theta)
+{
+	double cosTheta, sinTheta;
+	int N = 3;
+	cosTheta = cos(theta);
+	sinTheta = sin(theta);		
+
+	// Uso de la formula de direccionamiento *(p+i*N+j): Accede al elemento C[i][j] de una matriz C de N columnas
+	*(pTmatrixStress + 0 * N + 0) = pow(cosTheta, 2);						//TmatrixStress[0][0]
+	*(pTmatrixStress + 0 * N + 1) = pow(sinTheta, 2);						//TmatrixStress[0][1]
+	*(pTmatrixStress + 0 * N + 2) = 2.0 * sinTheta * cosTheta;				//TmatrixStress[0][2]
+	*(pTmatrixStress + 1 * N + 0) = pow(sinTheta, 2);			    		//TmatrixStress[1][0]
+	*(pTmatrixStress + 1 * N + 1) = pow(cosTheta, 2);						//TmatrixStress[1][1]
+	*(pTmatrixStress + 1 * N + 2) = -2.0 * sinTheta * cosTheta;				//TmatrixStress[1][2]
+	*(pTmatrixStress + 2 * N + 0) = -sinTheta * cosTheta;				    //TmatrixStress[2][0]
+	*(pTmatrixStress + 2 * N + 1) = sinTheta * cosTheta;				    //TmatrixStress[2][1]
+	*(pTmatrixStress + 2 * N + 2) = pow(cosTheta, 2) - pow(sinTheta, 2);	//TmatrixStress[2][2]
+	return;
+}

--- a/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.h
+++ b/SRC/material/nD/OrthotropicRotatingAngleConcreteT2DMaterial01/OrthotropicRotatingAngleConcreteT2DMaterial01.h
@@ -1,0 +1,117 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 12/2022
+// 
+// Description: This file contains the OrthotropicRotatingAngleConcreteT2DMaterial01 class definition.
+// An OrthotropicRotatingAngleConcreteT2DMaterial01 is a subclass of the class NDMaterial and corresponds to the abstract representation
+// of an Orthotropic Concrete Layer (plane stress) 2D Material with the Rotating Angle and Tangent Formulation for Cycling or Reversed
+// Loading with damage that is used in Finite Element Method or Structural Analysis.
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01
+//
+// Rev: 1.0
+
+#ifndef OrthotropicRotatingAngleConcreteT2DMaterial01_h
+#define OrthotropicRotatingAngleConcreteT2DMaterial01_h
+
+#include <NDMaterial.h>
+#include <UniaxialMaterial.h>
+
+#include <Matrix.h>
+#include <ID.h>
+
+class OrthotropicRotatingAngleConcreteT2DMaterial01 : public NDMaterial
+{
+public:
+
+	OrthotropicRotatingAngleConcreteT2DMaterial01(int tag,		// nDMaterial tag
+		UniaxialMaterial* concreteUniaxialMatObject1,			// concrete uniaxial material objects in a principal direction
+		UniaxialMaterial* concreteUniaxialMatObject2,			// concrete uniaxial material objects in the other principal direction 
+		double strainAtFcr,										// strain at tension cracking of the concrete
+		double strainAtFc,										// strain at the compresion strength of the concrete
+		double rho,											    // density
+		double damageCte1 = 0.14,								// damage constant 1
+		double damageCte2 = 0.6);								// damage constant 2
+										
+	OrthotropicRotatingAngleConcreteT2DMaterial01();
+
+	~OrthotropicRotatingAngleConcreteT2DMaterial01();
+
+	double getRho(void);
+
+	int setTrialStrain(const Vector& v);
+	int setTrialStrain(const Vector& v, const Vector& r);
+	int setTrialStrianIncr(const Vector& v);
+	int setTrialStrainIncr(const Vector& v, const Vector& r);
+	const Matrix& getTangent(void);
+	const Matrix& getInitialTangent(void);
+
+	Response* setResponse(const char** argv, int argc, OPS_Stream& theOutputStream);
+	int getResponse(int responseID, Information& matInformation);
+
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	NDMaterial* getCopy(void);
+	NDMaterial* getCopy(const char* type);
+
+	void Print(OPS_Stream& s, int flag = 0);
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker);
+
+	const char* getType(void) const { return "PlaneStress"; };
+	int getOrder(void) const { return 3; };
+
+	const Vector& getStress(void);
+	const Vector& getStrain(void);
+
+protected:
+
+private:
+
+	int setTrialStrainPrincipalDirection(const Vector& v);									// calculate trial stress and tangent
+	void calculateStrainPrincipalDirections01(void);										// calculate the principal direction for the strains (11, 22, 12) using the calculateAngle01 method
+	void calculateAngle01(double cosTheta, double sinTheta, double& theta);					// calculate the theta angle [-pi,pi] from the cos(theta) and sin(theta)
+	void calculatePoissonRatios(double e1, double e2);										// calculate the Vecchio Poisson Ratios
+	void calculateStrainTransformationMatrix(double* pTmatrixStrain, double theta);			// calculate the Strain Transformation Matrix that goes from the Local Coord System to the orientation of the Principal Direction of strain
+	void calculateStressTransformationMatrix(double* pTmatrixStress, double theta);			// calculate the Stress Transformation Matrix that goes from the orientation of the Principal Direction T(-thetaPD) to the Local Coord System
+
+	// Function added for MEFI3D
+	Vector getEc(void);		                // return input parameters
+
+	// Pointers to material arrays
+	UniaxialMaterial** theMaterial;         // pointer of the materials
+
+	Vector poissonRatios;					// store the Poisson Ratio (nu12 and nu21) of the Orthotropic Concrete Layer
+	double thetaPrincipalDirection;			// store the orientation of the Principal Direction in the material
+	Vector strainPrincipalDirection;		// store the principal strains
+	double ecr;								// store the strain at the tension cracking of the concrete
+	double ec;								// store the strain at the compresion strength of the concrete
+	bool isConcreteCracked;					// store a flag indicating if the concrete has cracking
+	double rhoNDM;							// density
+
+	// Committed Sate Variables........................................................
+	Vector Cstrain;							// store the committed strain vector in the orthotropic concrete layer
+	Vector CMaxMinStrainRec;				// store the maximun and minimun strain recorded in the concrete layer
+
+	// Trial State Variables...........................................................
+	Vector strain_vec;					    // store the strain vector at the current trial in the Orthotropic Concrete Layer
+	Vector stress_vec;						// store the stress vector in the Orthotropic Concrete Layer
+	Matrix tangent_matrix;					// store the tangent matrix in the Orthotropic Concrete Layer
+	Matrix initialTangentNDM;				// store the initial tangent matrix in the Orthotropic Concrete Layer
+	Vector TMaxMinStrainRec;				// store the maximun and minimun strain recorded in the concrete layer
+	double Eo;								// store the concrete Young's modulus
+	double Gmin;							// store the minimun shear tangent in the concrete layer 
+	double damageConstant1;					// store the constant to determinate the damage factor
+	double damageConstant2;					// store the constant to determinate the damage factor
+
+	const double pi;
+};
+
+#endif 

--- a/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/CMakeLists.txt
+++ b/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/CMakeLists.txt
@@ -1,0 +1,14 @@
+#==============================================================================
+# 
+#        OpenSees -- Open System For Earthquake Engineering Simulation
+#                Pacific Earthquake Engineering Research Center
+#
+#==============================================================================
+target_sources(OPS_Material
+    PRIVATE
+      SmearedSteelDoubleLayerT2DMaterial01.cpp
+    PUBLIC
+      SmearedSteelDoubleLayerT2DMaterial01.h
+)
+
+target_include_directories(OPS_Material PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/Makefile
+++ b/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/Makefile
@@ -1,0 +1,22 @@
+include ../../../../Makefile.def
+
+OBJS       = SmearedSteelDoubleLayerT2DMaterial01.o
+
+all:	$(OBJS)
+
+# Miscellaneous
+
+tidy:
+	@$(RM) $(RMFLAGS) Makefile.bak *~ #*# core
+
+clean: tidy
+	@$(RM) $(RMFLAGS) $(OBJS) *.o
+
+spotless: clean
+
+wipe: spotless
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+
+
+

--- a/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.cpp
+++ b/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.cpp
@@ -1,0 +1,684 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 03/2023
+// 
+// Description: This file contains the class definition for SmearedSteelDoubleLayerT2DMaterial01. 
+// A SmearedSteelDoubleLayerT2DMaterial01 is a subclass of the class NDMaterial and corresponds to the abstract representation
+// of a double perpendicular Smeared Steel layers (plane stress) 2D Material with a tangent formulation. Each layer works only 
+// in the direction of the bars, so a uniaxial constitutive model is used to represent the behavior of reinforcing steel bars in each direction.
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01
+//
+// Rev: 1.0
+
+#include <SmearedSteelDoubleLayerT2DMaterial01.h>
+#include <UniaxialMaterial.h>
+#include <Vector.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <Information.h>
+#include <Parameter.h>
+#include <FEM_ObjectBroker.h>
+#include <DummyStream.h>
+#include <elementAPI.h>
+
+// Read input parameters and build the material
+void* OPS_SmearedSteelDoubleLayerT2DMaterial01()
+{
+	// Pointer to a ND material that will be returned
+	NDMaterial* theMaterial = 0;
+
+	int numArgs = OPS_GetNumRemainingInputArgs();
+	
+	// Parse the script for material parameters
+	if (numArgs != 6) {			// total # of input parameters
+		opserr << "Invalid #Args want: nDMaterial SmearedSteelDoubleLayerT2DMaterial01 $tag $s1 $s2 $ratioSteelLayer1 $ratioSteelLayer2 $OrientationEmbeddedSteel" << endln;
+		return 0;
+	}
+
+	int tag;					// nDMaterial tag
+	int iData[2];				// # of uniaxial materials
+	double dData[3];			// # of material parameters
+
+	// nDMaterial tag
+	int numData = 1;
+	if (OPS_GetInt(&numData, &tag) != 0) {
+		opserr << "WARNING invalid integer tag: nDMaterial SmearedSteelDoubleLayerT2DMaterial01" << endln; 
+		return 0;
+	}
+
+	// Material tags of 2 steel layers
+	numData = 2;
+	if (OPS_GetInt(&numData, iData) != 0) {
+		opserr << "WARNING: Invalid uniaxialMaterial tags: nDMaterial SmearedSteelDoubleLayerT2DMaterial01: " << tag << "\n";
+		return 0;
+	}
+
+	// Material parameters
+	numData = 3;
+	if (OPS_GetDouble(&numData, dData) != 0) {
+		opserr << "WARNING invalid data: nDMaterial SmearedSteelDoubleLayerT2DMaterial01: " << tag << "\n";
+		return 0;
+	}
+
+	// Get pointers to Uniaxial material
+	// Steel Layer 1
+	UniaxialMaterial* theUniaxialMaterial1 = OPS_getUniaxialMaterial(iData[0]);
+	if (theUniaxialMaterial1 == 0) {
+		opserr << "WARNING material not found\n";
+		opserr << "Material: " << iData[0];
+		opserr << "\nSmearedSteelDoubleLayerT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+
+	// Steel Layer 2
+	UniaxialMaterial* theUniaxialMaterial2 = OPS_getUniaxialMaterial(iData[1]);
+	if (theUniaxialMaterial2 == 0) {
+		opserr << "WARNING material not found\n";
+		opserr << "Material: " << iData[1];
+		opserr << "\nSmearedSteelDoubleLayerT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+	// Create the SmearedSteelDoubleLayerT2DMaterial01
+	theMaterial = new SmearedSteelDoubleLayerT2DMaterial01(tag, theUniaxialMaterial1 , theUniaxialMaterial2 ,dData[0], dData[1], dData[2]);
+	
+	if (theMaterial == 0) {
+		opserr << "WARNING ran out of memory creating material\n";
+		opserr << "SmearedSteelDoubleLayerT2DMaterial01: " << tag << endln;
+		return 0;
+	}
+
+	return theMaterial;
+}
+
+// Typical Constructor
+SmearedSteelDoubleLayerT2DMaterial01::SmearedSteelDoubleLayerT2DMaterial01(int tag,			// nDMaterial tag
+	UniaxialMaterial* steelULayer1Obj,														// steel Layer 1
+	UniaxialMaterial* steelULayer2Obj,														// steel Layer 2
+	double ratioSteelLayer1,																// ratio of smeared steel layer 1
+	double ratioSteelLayer2,																// ratio of smeared steel layer 2
+	double OrientationEmbeddedSteel)														// orientation of the smeared steel layer
+	: NDMaterial(tag, ND_TAG_SmearedSteelDoubleLayerT2DMaterial01),
+	ratioLayer1(ratioSteelLayer1), ratioLayer2(ratioSteelLayer2), thetaSmearedSteel(OrientationEmbeddedSteel),
+	Tstrain(2), Tstress(2), Ttangent(2), TstrainLayer(3), strainPrincipalDirection(3),
+	Cstrain(2), Cstress(2), Ctangent(2), CstrainLayer(3), stressNDM(3), tangentNDM(3,3), initialTangentNDM(3,3), pi(3.1415926535)
+{
+
+	// Allocate pointers for uniaxial materials 
+	theMaterial = new UniaxialMaterial * [2];
+	if (theMaterial == 0) {
+		opserr << " SmearedSteelDoubleLayerT2DMaterial01::SmearedSteelDoubleLayerT2DMaterial01 - failed allocate material array\n";
+		exit(-1);
+	}
+
+	// Get the copy for steelLayer1
+	theMaterial[0] = steelULayer1Obj->getCopy();
+	// Check allocation
+	if (theMaterial[0] == 0) {
+		opserr << " SmearedSteelDoubleLayerT2DMaterial01::SmearedSteelDoubleLayerT2DMaterial01 - failed to get a copy for SteelLayer1\n";
+		exit(-1);
+	}
+
+	// Get the copy for steelLayer2
+	theMaterial[1] = steelULayer2Obj->getCopy();
+	// Check allocation
+	if (theMaterial[1] == 0) {
+		opserr << " SmearedSteelDoubleLayerT2DMaterial01::SmearedSteelDoubleLayerT2DMaterial01 - failed to get a copy for SteelLayer2\n";
+		exit(-1);
+	}
+
+	// Set initial values
+	thetaPrincipalDirection = 0.0;
+	strainPrincipalDirection(0) = 0.0;
+	strainPrincipalDirection(1) = 0.0;
+	strainPrincipalDirection(2) = 0.0;
+
+	for (int i = 0; i < 2; i++) {
+		Ctangent(i) = theMaterial[i]->getInitialTangent();
+	}
+
+	for (int i = 0; i < 2; i++) {
+		Cstrain(i) = 0.0;
+		Cstress(i) = 0.0;
+		Tstrain(i) = Cstrain(i);
+		Tstress(i) = Cstress(i);
+		Ttangent(i) = Ctangent(i);
+	}
+
+	for (int i = 0; i < 3; i++) {
+		CstrainLayer(i) = 0.0;
+		TstrainLayer(i) = CstrainLayer(i);
+	}
+
+	// Set stress, strain and tangent to zero
+	stressNDM.Zero();
+	tangentNDM.Zero();
+	initialTangentNDM.Zero();
+}
+
+// Blanck constructor 
+SmearedSteelDoubleLayerT2DMaterial01::SmearedSteelDoubleLayerT2DMaterial01()
+	:NDMaterial(0, ND_TAG_SmearedSteelDoubleLayerT2DMaterial01),
+	Tstrain(2), Tstress(2), Ttangent(2), TstrainLayer(3), strainPrincipalDirection(3),
+	Cstrain(2), Cstress(2), Ctangent(2), CstrainLayer(3), stressNDM(3), tangentNDM(3, 3), initialTangentNDM(3, 3), pi(3.1415926535)
+{
+	theMaterial = 0;
+	this->revertToStart();
+}
+
+// Destructor
+SmearedSteelDoubleLayerT2DMaterial01::~SmearedSteelDoubleLayerT2DMaterial01()
+{
+	// Delete the pointers
+	if (theMaterial != 0) {
+		for (int i = 0; i < 2; i++)
+		{
+			if (theMaterial[i])
+				delete theMaterial[i];
+		}
+		delete[] theMaterial;
+	}
+}
+
+// Get copy
+NDMaterial* SmearedSteelDoubleLayerT2DMaterial01::getCopy(void)
+{
+	SmearedSteelDoubleLayerT2DMaterial01* theCopy =
+		new SmearedSteelDoubleLayerT2DMaterial01(this->getTag(),
+			theMaterial[0],
+			theMaterial[1],
+			ratioLayer1,
+			ratioLayer2,
+			thetaSmearedSteel);
+
+	return theCopy;
+}
+
+// Get copy
+NDMaterial* SmearedSteelDoubleLayerT2DMaterial01::getCopy(const char* type)
+{
+	SmearedSteelDoubleLayerT2DMaterial01* theCopy =
+		new SmearedSteelDoubleLayerT2DMaterial01(this->getTag(),
+			theMaterial[0],
+			theMaterial[1],
+			ratioLayer1,
+			ratioLayer2,
+			thetaSmearedSteel);
+
+	return theCopy;
+}
+
+// Print
+void SmearedSteelDoubleLayerT2DMaterial01::Print(OPS_Stream& s, int flag)
+{
+	s << "\n SmearedSteelDoubleLayerT2DMaterial01, nDMaterial tag: " << this->getTag() << endln;
+
+	// Input values
+	s << "Orientation of the smeared steel layers: " << thetaSmearedSteel << endln;
+	s << "Reinforcing ratio of the smeared steel layer 1: " << ratioLayer1 << endln;
+	s << "Reinforcing ratio of the smeared steel layer 2: " << ratioLayer2 << endln;
+
+	s << "Strain:" << endln;
+	s << "EpsX = " << Tstrain(0) << ", EpsY = " << Tstrain(1) << ", GammaXY = " << Tstrain(2) << endln;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::sendSelf(int commitTag, Channel& theChannel)
+{
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static Vector data(4);
+
+	data(0) = this->getTag();
+	data(1) = ratioLayer1;
+	data(2) = ratioLayer2;
+	data(3) = thetaSmearedSteel;
+
+	res += theChannel.sendVector(dataTag, commitTag, data);
+	if (res < 0) {
+		opserr << "WARNING SmearedSteelDoubleLayerT2DMaterial01::sendSelf() - " << this->getTag() << " failed to send Vector\n";
+		return res;
+	}
+
+	int matDbTag;
+
+	static ID idData(4);
+
+	int i;
+	for (i = 0; i < 2; i++)
+	{
+		idData(i) = theMaterial[i]->getClassTag();
+		matDbTag = theMaterial[i]->getDbTag();
+		if (matDbTag == 0) {
+			matDbTag = theChannel.getDbTag();
+			if (matDbTag != 0)
+				theMaterial[i]->setDbTag(matDbTag);
+		}
+		idData(i + 2) = matDbTag;
+	}
+
+	res += theChannel.sendID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING SmearedSteelDoubleLayerT2DMaterial01::sendSelf() - " << this - getTag() << " failed to send ID\n";
+		return res;
+	}
+
+	for (i = 0; i < 2; i++) {
+		res += theMaterial[i]->sendSelf(commitTag, theChannel);
+		if (res < 0) {
+			opserr << "SmearedSteelDoubleLayerT2DMaterial01::sendSelf() - " << this - getTag() << " failed to send its Material\n";
+			return res;
+		}
+	}
+
+	return res;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker)
+{
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static Vector data(4);
+	res += theChannel.recvVector(dataTag, commitTag, data);
+	if (res < 0) {
+		opserr << "WARNING SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - failed to receive Vector\n";
+		return res;
+	}
+
+	this->setTag((int)data(0));
+	ratioLayer1       = data(1);
+	ratioLayer2       = data(2);
+	thetaSmearedSteel = data(3);
+
+	static ID idData(4);
+	res += theChannel.recvID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - " << this->getTag() << " failed to receive ID\n";
+		return res;
+	}
+
+	if (theMaterial == 0) {
+		theMaterial = new UniaxialMaterial * [2];
+		if (theMaterial == 0) {
+			opserr << "SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - Could not allocate Uniaxial* array\n";
+			return -1;
+		}
+		for (int i = 0; i < 2; i++) {
+			int matClassTag = idData(i);
+			int matDbTag = idData(i + 2);
+			theMaterial[i] = theBroker.getNewUniaxialMaterial(matClassTag);
+			if (theMaterial[i] == 0) {
+				opserr << "SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - Broker could not create Uniaxial of class type " << matClassTag << endln;
+				return -1;
+			}
+			theMaterial[i]->setDbTag(matDbTag);
+			res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - material " << i << " failed to receive itself\n";
+				return res;
+			}
+		}
+	}
+
+	else {
+		for (int i = 0; i < 2; i++) {
+			int matClassTag = idData(i);
+			int matDbTag = idData(i + 2);
+
+			if (theMaterial[i]->getClassTag() != matClassTag) {
+				delete theMaterial[i];
+				theMaterial[i] = theBroker.getNewUniaxialMaterial(matClassTag);
+				if (theMaterial[i] == 0) {
+					opserr << "SmearedSteelDoubleLayerT2DMaterial01::recvself() - material " << i << " failed to create\n";
+					return -1;
+				}
+			}
+			theMaterial[i]->setDbTag(matDbTag);
+			res += theMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "SmearedSteelDoubleLayerT2DMaterial01::recvSelf() - material " << i << " failed to receive itself\n";
+				return res;
+			}
+		}
+	}
+
+	return res;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::setTrialStrain(const Vector& v)
+{
+	// Calculate trial stress and tangent partial stiffness
+	setTrialStrainPrincipalDirection(v);
+
+	return 0;
+}
+
+// Unused trial strain functions
+int SmearedSteelDoubleLayerT2DMaterial01::setTrialStrain(const Vector& v, const Vector& r)
+{
+	opserr << "SmearedSteelDoubleLayerT2DMaterial01 :: setTrialStrain(const Vector& v, const Vector& r) -- should not be used! \n";
+	return this->setTrialStrain(v);
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::setTrialStrainIncr(const Vector& v)
+{
+	// Add the increment trial strain to the trial strain
+	Vector newTrialStrain(3);
+
+	for (int i = 0; i < 3; i++) {
+		newTrialStrain(i) = TstrainLayer(i) + v(i);
+	}
+	return this->setTrialStrain(newTrialStrain);
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::setTrialStrainIncr(const Vector& v, const Vector& r)
+{
+	opserr << "SmearedSteelDoubleLayerT2DMaterial01::setTrialStrainIncr(const Vector& v, const Vector& r) -- should not be used!\n";
+	return this->setTrialStrainIncr(v);
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::setTrialStrainPrincipalDirection(const Vector& v)
+{
+	TstrainLayer(0) = v(0);
+	TstrainLayer(1) = v(1);
+	TstrainLayer(2) = v(2);
+
+	// Define the Principal Direction of Strain
+	this->calculateStrainPrincipalDirections01();
+
+	// Calculate the Transformation Matrix that go from the Principal Direction of Strain to the orientation of the Steel Layer T(thetaES - thetaPD)
+	double TthetaESMinusthetaPD[3][3];
+	double* pTthetaESMinusthetaPD = &TthetaESMinusthetaPD[0][0];
+
+	double theta = thetaSmearedSteel - thetaPrincipalDirection;
+
+	this->calculateStrainTransformationMatrix(pTthetaESMinusthetaPD, theta);
+
+	// Calculate the newUniaxialStrain in the in the Orientation of the Smeared Embedded Steel Layer 
+	double newTrialStrain[3] = { 0,0,0 };
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			newTrialStrain[i] = newTrialStrain[i] + (TthetaESMinusthetaPD[i][j]* strainPrincipalDirection(j));
+		}
+	}
+
+	Tstrain(0) = newTrialStrain[0];
+	Tstrain(1) = newTrialStrain[1];
+
+	theMaterial[0]->setTrialStrain(newTrialStrain[0]);
+	theMaterial[1]->setTrialStrain(newTrialStrain[1]);
+
+	// Calculate the Strain Transformation Matrix that go from the Local Coordinate System to the orientation of the Steel Layer T(thetaES)
+	double TthetaES[3][3], TthetaEST[3][3];
+	double* pTthetaES = &TthetaES[0][0];
+
+	this->calculateStrainTransformationMatrix(pTthetaES, thetaSmearedSteel);
+
+	// Calculate the Stress in the Local Coord System
+	double fs1, fs2;
+	fs1 = theMaterial[0]->getStress();
+	fs2 = theMaterial[1]->getStress();
+
+	double stressES[3] = { ratioLayer1 * fs1, ratioLayer2 * fs2, 0.0 };
+	
+	// traspose of TthetaES
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			TthetaEST[i][j] = TthetaES[j][i];
+		}
+	}
+
+	stressNDM.Zero();
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			stressNDM(i) += TthetaEST[i][j] * stressES[j];
+		}
+	}
+
+	// Calculate the Tangent Matrix in the Local Coord System
+	double Es1, Es2;
+	Es1 = theMaterial[0]->getTangent();
+	Es2 = theMaterial[1]->getTangent();
+
+	double Ds[3][3] = { {ratioLayer1 * Es1,0.0,0.0},{0.0,ratioLayer2 * Es2,0.0},{0.0,0.0,0.0} };
+
+	tangentNDM.Zero();
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				for (int l = 0; l < 3; l++) {
+					tangentNDM(i, l) += TthetaEST[i][j] * Ds[j][k] * TthetaES[k][l];
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+const Vector& SmearedSteelDoubleLayerT2DMaterial01::getStrain(void)
+{
+	return Tstrain;
+}
+
+const Vector& SmearedSteelDoubleLayerT2DMaterial01::getStress(void)
+{
+	return stressNDM;
+}
+
+const Matrix& SmearedSteelDoubleLayerT2DMaterial01::getTangent(void)
+{
+	return tangentNDM;
+}
+
+const Matrix& SmearedSteelDoubleLayerT2DMaterial01::getInitialTangent(void)
+{
+	// Calculate the Strain Transformation Matrix that go from the Local Coordinate System to the orientation of the Steel Layer T(thetaES)
+	double TthetaES[3][3], TthetaEST[3][3];
+	double* pTthetaES = &TthetaES[0][0];
+
+	this->calculateStrainTransformationMatrix(pTthetaES, thetaSmearedSteel);
+
+	// Calculate the Tangent Matrix in the Orientation of the Smeared Embedded Steel Layer 
+	double E0s1, E0s2;
+	E0s1 = theMaterial[0]->getInitialTangent();
+	E0s2 = theMaterial[1]->getInitialTangent();
+
+	double D0s[3][3] = { {ratioLayer1 * E0s1,0.0,0.0},{0.0,ratioLayer2 * E0s2,0.0},{0.0,0.0,0.0} };
+	
+	// Calculate the Tangent Matrix in the Local Coord System
+	// Traspose of TthetaES
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			TthetaEST[i][j] = TthetaES[j][i];
+		}
+	}
+
+	initialTangentNDM.Zero();
+	
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				for (int l = 0; l < 3; l++) {
+					initialTangentNDM(i, l) += TthetaEST[i][j] * D0s[j][k] * TthetaES[k][l];
+				}
+			}
+		}
+	}
+
+	// Add a small value int he 3,3 component of the stiffness Matrix to avoid inestability in the analysis
+	initialTangentNDM(2, 2) = initialTangentNDM(2, 2) + 1e-5;
+
+
+	return initialTangentNDM;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::commitState(void)
+{
+	theMaterial[0]->commitState();
+	theMaterial[1]->commitState();
+
+	// Commit the state values
+	CstrainLayer(0) = TstrainLayer(0);
+	CstrainLayer(1) = TstrainLayer(1);
+	CstrainLayer(2) = TstrainLayer(2);
+
+	Cstrain(0) = Tstrain(0);
+	Cstrain(1) = Tstrain(1);
+
+	Cstress(0) = theMaterial[0]->getStress();
+	Cstress(1) = theMaterial[1]->getStress();
+
+	Ctangent(0) = theMaterial[0]->getTangent();
+	Ctangent(1) = theMaterial[1]->getTangent();
+
+	return 0;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::revertToLastCommit(void)
+{
+	// Revert to last committed values
+	TstrainLayer(0) = CstrainLayer(0);
+	TstrainLayer(1) = CstrainLayer(1);
+	TstrainLayer(2) = CstrainLayer(2);
+
+	for (int i = 0; i < 2; i++) {
+		Tstrain(i) = Cstrain(i);
+		Tstress(i) = Cstress(i);
+		Ttangent(i) = Ctangent(i);
+	}
+
+	theMaterial[0]->revertToLastCommit();
+	theMaterial[1]->revertToLastCommit();
+
+	return 0;
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::revertToStart(void)
+{
+	// Set to the initial values some of the propierties
+	thetaPrincipalDirection = 0.0;
+
+	// State Variables
+	CstrainLayer.Zero();
+	Cstrain.Zero();
+	Cstress.Zero();
+	Ctangent(0) = theMaterial[0]->getInitialTangent();
+	Ctangent(1) = theMaterial[1]->getInitialTangent();
+
+	// Set stress, strain and tangent to zero
+	stressNDM.Zero();
+	tangentNDM.Zero();
+	initialTangentNDM.Zero();
+
+	// Revert all uniaxial materials to start
+	theMaterial[0]->revertToStart();
+	theMaterial[1]->revertToStart();
+
+	// Set Initial Trial Values
+	TstrainLayer(0) = CstrainLayer(0);
+	TstrainLayer(1) = CstrainLayer(1);
+	TstrainLayer(2) = CstrainLayer(2);
+
+	for (int i = 0; i < 2; i++) {
+		Tstrain(i) = Cstrain(i);
+		Tstress(i) = Cstress(i);
+		Ttangent(i) = Ctangent(i);
+	}
+
+	return 0;
+}
+
+Response* SmearedSteelDoubleLayerT2DMaterial01::setResponse(const char** argv, int argc, OPS_Stream& theOutput)
+{
+	return NDMaterial::setResponse(argv, argc, theOutput);
+}
+
+int SmearedSteelDoubleLayerT2DMaterial01::getResponse(int responseID, Information& matInformation)
+{
+	return NDMaterial::getResponse(responseID, matInformation);
+}
+
+void SmearedSteelDoubleLayerT2DMaterial01::calculateStrainPrincipalDirections01(void)
+{
+	double strain_vec[3];					// ex, ey, gamma
+	double doubleThetaPD, cos2Theta, sin2Theta;
+
+	// Get strain values from strain of element
+	strain_vec[0] = TstrainLayer(0);		// ex
+	strain_vec[1] = TstrainLayer(1);		// ey
+	strain_vec[2] = TstrainLayer(2);		// gxy
+
+	double averageStrains = 0.5 * (strain_vec[0] + strain_vec[1]);
+	double deltaStrains = strain_vec[0] - strain_vec[1];
+	double constantCS = pow(pow(deltaStrains, 2) + pow(strain_vec[2], 2), 0.5);
+	if (deltaStrains == 0.0 && strain_vec[2] == 0.0) {
+		doubleThetaPD = 0.0;
+	}
+	else {
+		cos2Theta = deltaStrains / constantCS;
+		sin2Theta = strain_vec[2] / constantCS;
+		this->calculateAngle01(cos2Theta, sin2Theta, doubleThetaPD);
+
+	}
+	thetaPrincipalDirection = 0.5 * doubleThetaPD;
+
+	strainPrincipalDirection(0) = averageStrains + 0.5 * constantCS;
+	strainPrincipalDirection(1) = averageStrains - 0.5 * constantCS;
+	strainPrincipalDirection(2) = 0.0;
+
+	return;
+}
+
+void SmearedSteelDoubleLayerT2DMaterial01::calculateAngle01(double cosTheta, double sinTheta, double& theta)
+{
+	double thetaFromCos, thetaFromSin;
+
+	thetaFromCos = acos(cosTheta);
+	thetaFromSin = asin(sinTheta);
+
+	if (thetaFromCos <= pi / 2.0 + 1e-7) {
+		theta = thetaFromSin;
+	}
+	else {
+		if (thetaFromSin >= 0.0) {
+			theta = thetaFromCos;
+		}
+		else {
+			theta = -thetaFromCos;
+		}
+	}
+
+	return;
+}
+
+void SmearedSteelDoubleLayerT2DMaterial01::calculateStrainTransformationMatrix(double* pTmatrixStrain, double theta)
+{
+	double cosTheta, sinTheta;
+	int N = 3;
+	cosTheta = cos(theta);
+	sinTheta = sin(theta);
+
+	// Uso de la formula de direccionamiento *(p+i*N+j): Accede al elemento C[i][j] de una matriz C de N columnas
+	*(pTmatrixStrain + 0 * N + 0) = pow(cosTheta, 2);						//TmatrixStrain[0][0]
+	*(pTmatrixStrain + 0 * N + 1) = pow(sinTheta, 2);						//TmatrixStrain[0][1]
+	*(pTmatrixStrain + 0 * N + 2) = sinTheta * cosTheta;				    //TmatrixStrain[0][2]
+	*(pTmatrixStrain + 1 * N + 0) = pow(sinTheta, 2);			    		//TmatrixStrain[1][0]
+	*(pTmatrixStrain + 1 * N + 1) = pow(cosTheta, 2);						//TmatrixStrain[1][1]
+	*(pTmatrixStrain + 1 * N + 2) = -sinTheta * cosTheta;				    //TmatrixStrain[1][2]
+	*(pTmatrixStrain + 2 * N + 0) = -2.0 * sinTheta * cosTheta;				//TmatrixStrain[2][0]
+	*(pTmatrixStrain + 2 * N + 1) = 2.0 * sinTheta * cosTheta;				//TmatrixStrain[2][1]
+	*(pTmatrixStrain + 2 * N + 2) = pow(cosTheta, 2) - pow(sinTheta, 2);	//TmatrixStrain[2][2]
+	return;
+}

--- a/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.h
+++ b/SRC/material/nD/SmearedSteelDoubleLayerT2DMaterial01/SmearedSteelDoubleLayerT2DMaterial01.h
@@ -1,0 +1,113 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 03/2023
+// 
+// Description: This file contains the class definition for SmearedSteelDoubleLayerT2DMaterial01. 
+// A SmearedSteelDoubleLayerT2DMaterial01 is a subclass of the class NDMaterial and corresponds to the abstract representation
+// of a double perpendicular Smeared Steel layers (plane stress) 2D Material with a tangent formulation. Each layer works only 
+// in the direction of the bars, so a uniaxial constitutive model is used to represent the behavior of reinforcing steel bars in each direction.
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01
+//
+// Rev: 1.0
+
+#ifndef SmearedSteelDoubleLayerT2DMaterial01_h
+#define SmearedSteelDoubleLayerT2DMaterial01_h
+
+#include <NDMaterial.h>
+#include <UniaxialMaterial.h>
+
+#include <Matrix.h>
+#include <Vector.h>
+#include <ID.h>
+
+class SmearedSteelDoubleLayerT2DMaterial01 : public NDMaterial
+{
+  public:
+
+	  SmearedSteelDoubleLayerT2DMaterial01(int tag,					// nDMaterial tag
+		  UniaxialMaterial* steelULayer1Obj,						// steel layer 1
+		  UniaxialMaterial* steelULayer2Obj,						// steel layer 2
+		  double ratioSteelLayer1,									// ratio of smeared steel layer 1
+		  double ratioSteelLayer2,									// ratio of smeared steel layer 2
+		  double OrientationEmbeddedSteel);							// orientation of the smeared steel layer
+
+	  SmearedSteelDoubleLayerT2DMaterial01();
+
+	  ~SmearedSteelDoubleLayerT2DMaterial01();
+
+	  const char* getClassType(void) const { return "SmearedSteelDoubleLayerT2DMaterial01";};
+	  int setTrialStrain(const Vector& v);
+	  int setTrialStrain(const Vector& v, const Vector& r);
+	  int setTrialStrainIncr(const Vector& v);
+	  int setTrialStrainIncr(const Vector& v, const Vector& r);
+	  const Matrix& getTangent(void);
+	  const Matrix& getInitialTangent(void);
+
+	  Response* setResponse(const char** argv, int argc, OPS_Stream& theOutputStream);
+	  int getResponse(int responseID, Information& matInformation);
+
+	  const Vector& getStress(void);
+	  const Vector& getStrain(void);
+
+	  // public methods to set the state of the material
+	  int commitState(void);
+	  int revertToLastCommit(void);
+	  int revertToStart(void);
+
+	  // Create a copy of material parameters and state variables
+	  NDMaterial* getCopy(void);
+	  // Create a copy of just the material parameters
+	  NDMaterial* getCopy(const char* type);
+	  
+	  // Return a string indicating the type of material model
+	  const char* getType(void) const { return "PlaneStress"; };
+	  int getOrder(void) const { return 3; };
+
+	  int sendSelf(int commitTag, Channel& theChannel);
+	  int recvSelf(int commitTag, Channel& theChannel,
+		  FEM_ObjectBroker& theBroker);
+
+	  void Print(OPS_Stream& s, int flag = 0);
+
+  protected:
+
+  private:
+	  
+	  int setTrialStrainPrincipalDirection(const Vector& v);									// calculate trial stress and tangent 
+	  void calculateStrainPrincipalDirections01(void);											// calculate the principal direction for the strains (11, 22, 12) using the calculateAngle01 method
+	  void calculateAngle01(double cosTheta, double sinTheta, double& theta);					// calculate the theta angle [-pi,pi] from the cos(theta) and sin(theta)
+	  void calculateStrainTransformationMatrix(double* pTmatrixStrain, double theta);			// calculate the Strain Transformation Matrix that goes from the Local Coord System to the orientation of the Principal Direction of strain
+
+	  UniaxialMaterial** theMaterial;		// pointer to a material
+
+	  double ratioLayer1;					// store the reinforcing ratio of the smeared steel layer 1
+	  double ratioLayer2;					// store the reinforcing ratio of the smeared steel layer 1
+	  double thetaSmearedSteel;				// store the orientation of the smeared steel layers
+	  // Material history variables..............................................................................
+	  double thetaPrincipalDirection;	    // store the orientation of the principal direction in the material
+	  Vector strainPrincipalDirection;	    // store the principal strains
+	  // Committed state variables...............................................................................
+	  Vector CstrainLayer;					// store the Committed Strain for the Layer
+	  Vector Cstrain;						// store the Committed Strain
+	  Vector Cstress;						// store the Committed Stress
+	  Vector Ctangent;						// store the Committed Tangent 
+	  // Trial state variables...................................................................................
+	  Vector stressNDM;				        // store the Trial Stress
+	  Matrix tangentNDM;			        // store the Trial Tangent
+	  Matrix initialTangentNDM;		
+
+	  Vector TstrainLayer;			        // store the Trial Strain for the Layer
+	  Vector Tstrain;				        // store the Trial Strain
+	  Vector Tstress;				        // store the Trial Stress
+	  Vector Ttangent;				        // store the Trial Tangent
+
+	  const double pi;
+};
+
+#endif

--- a/SRC/material/nD/TclModelBuilderNDMaterialCommand.cpp
+++ b/SRC/material/nD/TclModelBuilderNDMaterialCommand.cpp
@@ -132,6 +132,8 @@ extern void *OPS_NewConcreteMaterial(void);
 #endif
 
 extern  void *OPS_FSAMMaterial(void); // K Kolozvari      
+extern void *OPS_OrthotropicRotatingAngleConcreteT2DMaterial01(void); // M. J. Nunez - UChile
+extern void *OPS_SmearedSteelDoubleLayerT2DMaterial01(void);		  // M. J. Nunez - UChile
 
 #ifdef _HAVE_Damage2p
 extern void *OPS_Damage2p(void);
@@ -586,6 +588,22 @@ TclModelBuilderNDMaterialCommand (ClientData clientData, Tcl_Interp *interp, int
       else 
 	return TCL_ERROR;
     }
+
+	else if ((strcmp(argv[1], "OrthotropicRotatingAngleConcreteT2DMaterial01") == 0) || (strcmp(argv[1], "OrthotropicRAConcrete") == 0)) {
+		void* theMat = OPS_OrthotropicRotatingAngleConcreteT2DMaterial01();
+		if (theMat != 0)
+			theMaterial = (NDMaterial*)theMat;
+		else
+			return TCL_ERROR;
+	}
+
+	else if ((strcmp(argv[1], "SmearedSteelDoubleLayerT2DMaterial01") == 0) || (strcmp(argv[1], "SmearedSteelDoubleLayer") == 0)) {
+		void* theMat = OPS_SmearedSteelDoubleLayerT2DMaterial01();
+		if (theMat != 0)
+			theMaterial = (NDMaterial*)theMat;
+		else
+			return TCL_ERROR;
+	}
 
     // Check argv[1] for J2PlaneStrain material type
     else if ((strcmp(argv[1],"J2Plasticity") == 0)  ||

--- a/SRC/material/section/CMakeLists.txt
+++ b/SRC/material/section/CMakeLists.txt
@@ -85,4 +85,4 @@ add_subdirectory(fiber)
 add_subdirectory(repres)
 add_subdirectory(yieldSurface)
 add_subdirectory(integration)
-
+add_subdirectory(ReinforcedConcreteLayerMembraneSection)

--- a/SRC/material/section/Makefile
+++ b/SRC/material/section/Makefile
@@ -40,6 +40,7 @@ all:         $(OBJS)
 	@$(CD) $(FE)/material/section/fiber; $(MAKE);
 	@$(CD) $(FE)/material/section/yieldSurface; $(MAKE);
 	@$(CD) $(FE)/material/section/integration; $(MAKE);
+	@$(CD) $(FE)/material/section/ReinforcedConcreteLayerMembraneSection; $(MAKE);
 
 test: main.o
 	@$(LINKER) $(LINKFLAGS) main.o $(INTERPRETER_LIBS_MPI) \
@@ -62,5 +63,6 @@ wipe: spotless
 	@$(CD) $(FE)/material/section/fiber; $(MAKE) wipe;
 	@$(CD) $(FE)/material/section/yieldSurface; $(MAKE) wipe;
 	@$(CD) $(FE)/material/section/integration; $(MAKE) wipe;
+	@$(CD) $(FE)/material/section/ReinforcedConcreteLayerMembraneSection; $(MAKE) wipe;
 
 # DO NOT DELETE THIS LINE -- make depends on it.

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/CMakeLists.txt
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/CMakeLists.txt
@@ -1,0 +1,17 @@
+#==============================================================================
+# 
+#        OpenSees -- Open System For Earthquake Engineering Simulation
+#                Pacific Earthquake Engineering Research Center
+#
+#==============================================================================
+target_sources(OPS_Material
+    PRIVATE
+    ReinforcedConcreteLayerMembraneSection01.cpp
+    ReinforcedConcreteLayerMembraneSection02.cpp
+    PUBLIC
+    ReinforcedConcreteLayerMembraneSection01.h
+    ReinforcedConcreteLayerMembraneSection02.h
+)
+
+target_include_directories(OPS_Material PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/Makefile
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/Makefile
@@ -1,0 +1,27 @@
+include ../../../../Makefile.def
+
+OBJS       = ReinforcedConcreteLayerMembraneSection01.o\
+             ReinforcedConcreteLayerMembraneSection02.o
+
+all:         $(OBJS)
+
+# Miscellaneous
+tidy:	
+	@$(RM) $(RMFLAGS) Makefile.bak *~ #*# core
+
+clean: tidy
+	@$(RM) $(RMFLAGS) $(OBJS) *.o
+
+spotless: clean
+
+wipe: spotless
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+
+
+
+
+
+
+
+

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.cpp
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.cpp
@@ -1,0 +1,1045 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 04/2023
+// 
+// Description: This file contains the ReinforcedConcreteLayerMembraneSection01 class definition
+// A ReinforcedConcreteLayerMembraneSection01 is a subclass of the sectionForceDeformation class and corresponds to the abstract representation
+// for the stress-strain behavior for a Reinforced Concrete Layer Membrane Element in the Finite Element Method or Structural Analysis. 
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\section\ReinforcedConcreteLayerMembraneSection
+//
+// Rev: 1.0
+
+#include <ReinforcedConcreteLayerMembraneSection01.h>
+#include <NDMaterial.h>
+#include <Vector.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <elementAPI.h>
+#include <Parameter.h>
+#include <MaterialResponse.h>
+#include <algorithm>				/*min, max*/
+#include <DummyStream.h>
+
+using namespace std;
+
+// Read input parameters and build the section
+void* OPS_ReinforcedConcreteLayerMembraneSection01()
+{
+	int numArgs = OPS_GetNumRemainingInputArgs();
+
+	// Parse the script for material parameters
+	if (numArgs < 9) {
+		opserr << "Want: ReinforcedConcreteLayerMembraneSection01 $secTag $nSteelLayer $nConcLayer -reinfSteel {$RSteelAtEachLayer} -conc {$concAtEachLayer} -concThick {$concThicknessAtEachLayer} <-epscr $epscr> <-epsc $epsc>" << endln;
+		return 0;
+	}
+
+	int tag, nClayers, nSlayers;
+	int* concMatTags, * steelMatTags;
+	double* cThickness;
+	const char* str;
+	NDMaterial** theConcMats;
+	NDMaterial** theSteelMats;
+	double strainAtFcr = 0.00008;            // default value for strain at tension cracking of the concrete
+	double strainAtFc = -0.002;              // default value for strain at the compresion strength of the concrete
+
+	int numdata = 1;
+	if (OPS_GetIntInput(&numdata, &tag) < 0) {
+		opserr << "WARNING invalid section ReinforcedConcreteLayerMembraneSection01 tag" << endln;
+		return 0;
+	}
+	
+	if (OPS_GetIntInput(&numdata, &nSlayers) < 0) {
+		opserr << "WARNING invalid nSlayers" << endln;
+		opserr << "ReinforcedConcreteLayerMembraneSection01 section: " << tag << endln;
+		return 0;
+	}
+	
+	if (OPS_GetIntInput(&numdata, &nClayers) < 0) {
+		opserr << "WARNING invalid nClayers" << endln;
+		opserr << "ReinforcedConcreteLayerMembraneSection01 section: " << tag << endln;
+		return 0;
+	}
+
+	theConcMats = new NDMaterial * [nClayers];
+	theSteelMats = new NDMaterial * [nSlayers];
+	cThickness = new double[nClayers];
+	concMatTags = new int[nClayers];
+	steelMatTags = new int[nSlayers];
+
+	numArgs = OPS_GetNumRemainingInputArgs();
+
+	while (numArgs > 0) {
+		str = OPS_GetString();
+		if (strcmp(str, "-reinfSteel") == 0) {
+			numdata = nSlayers;
+			if (OPS_GetIntInput(&numdata, steelMatTags) != 0) {
+				opserr << "Invalid nDMaterial reinforced steel tag for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+				return 0;
+			}
+			for (int i = 0; i < nSlayers; i++) {
+				theSteelMats[i] = 0;
+				theSteelMats[i] = OPS_getNDMaterial(steelMatTags[i]);
+				if (theSteelMats[i] == 0) {
+					opserr << "Invalid nDMaterial reinforced steel tag " << steelMatTags[i] << " for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+					return 0;
+				}
+			}
+		}
+		else if (strcmp(str, "-conc") == 0) {
+			numdata = nClayers;
+			if (OPS_GetIntInput(&numdata, concMatTags) != 0) {
+				opserr << "Invalid nDMaterial concrete tag for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+				return 0;
+			}
+			for (int i = 0; i < nClayers; i++) {
+				theConcMats[i] = 0;
+				theConcMats[i] = OPS_getNDMaterial(concMatTags[i]);
+				if (theConcMats[i] == 0) {
+					opserr << "Invalid nDMaterial concrete tag " << concMatTags[i] << " for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+					return 0;
+				}
+			}
+		}
+		else if (strcmp(str, "-concThick") == 0) {
+			numdata = nClayers;
+			if (OPS_GetDoubleInput(&numdata, cThickness) != 0) {
+				opserr << "Invalid thick parameter for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+				return 0;
+			}
+		}
+		else if (strcmp(str, "-epscr") == 0) {
+			numdata = 1;
+			if (OPS_GetDouble(&numdata, &strainAtFcr) != 0) {
+				opserr << "Invalid epscr parameter for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+				return 0;
+			}
+		}
+		else if (strcmp(str, "-epsc") == 0) {
+			numdata = 1;
+			if (OPS_GetDouble(&numdata, &strainAtFc) != 0) {
+				opserr << "Invalid epsc parameter for ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+				return 0;
+			}
+		}
+		else {
+			opserr << "WARNING: Invalid option " << str << " in ReinforcedConcreteLayerMembraneSection01 " << tag << endln;
+			return 0;
+		}
+		
+		numArgs = OPS_GetNumRemainingInputArgs();
+    
+	}
+
+	SectionForceDeformation* theSection = new ReinforcedConcreteLayerMembraneSection01(tag, nSlayers, nClayers, theSteelMats, theConcMats, cThickness, strainAtFcr, strainAtFc);
+
+	// Clean up dynamic memory
+	if (theSteelMats != 0)
+		delete[] theSteelMats;
+	if (theConcMats != 0)
+		delete[] theConcMats;
+	if (steelMatTags != 0)
+		delete[] steelMatTags;
+	if (concMatTags != 0)
+		delete[] concMatTags;
+	if (cThickness != 0)
+		delete[] cThickness;
+
+	return theSection;
+}
+
+//static vector and matrices
+ID ReinforcedConcreteLayerMembraneSection01::array(8);
+
+// Full constructor
+ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01(int tag,							// section tag
+	int nSteelLayer,																								// number of reinforced steel layers
+	int nConcLayer,																									// number of concrete layers
+	NDMaterial** reinforcedSteelMaterialObjects,																	// array of nDMaterial reinforced steel tags for each layer
+	NDMaterial** concrete2DMaterialObjects,																			// array of nDMaterial concrete tags for each layer
+	double* concThickness,																							// array of concrete layers thickness
+	double strainAtFcr,																								// strain at tension cracking of the concrete
+	double strainAtFc)																								// strain at the compresion strength of the concrete
+
+	:SectionForceDeformation(tag, SEC_TAG_ReinforcedConcreteLayerMembraneSection01),
+	numberReinforcedSteelLayers(nSteelLayer), numberConcreteLayers(nConcLayer), ecr(strainAtFcr), ec(strainAtFc), 
+	CSectionStrain(3), CSectionStress(3), CSectionTangent(3, 3),
+	TSectionStrain(3), TSectionStress(3), TSectionTangent(3, 3), InitialTangent(3, 3),
+	strainPrincipalDirection(3), poissonRatios(2), crackPattern(6), pi(3.1415926535)
+{
+
+	// Set initial values
+	thetaPrincipalDirection = 0.0;
+	strainPrincipalDirection(0) = 0.0;
+	strainPrincipalDirection(1) = 0.0;
+	strainPrincipalDirection(2) = 0.0;
+	isConcreteCracked = false;
+
+	poissonRatios(0) = 0.0;
+	poissonRatios(1) = 0.0;
+
+	crackPattern.Zero();
+
+	for (int i = 0; i < 3; i++) {
+		CSectionStrain(i) = 0.0;
+		CSectionStress(i) = 0.0;
+		TSectionStrain(i) = 0.0;
+		TSectionStress(i) = 0.0;
+	}
+
+	// Check concrete layers thickness input
+	if (concThickness == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01 - Null concrete layers thickness array passed.\n";
+		exit(-1);
+	}
+
+	// Check materials input
+	if (reinforcedSteelMaterialObjects == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Null nDMaterial reinforced steel array passed.\n";
+		exit(-1);
+	}
+	if (concrete2DMaterialObjects == 0) {
+		opserr <<"ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Null nDMaterial concrete array passed.\n";
+		exit(-1);
+	}
+
+	// Allocate memory for concrete layers thickness
+	t = new double[numberConcreteLayers];
+	h = 0.0;
+
+	for (int i = 0; i < numberConcreteLayers; i++) {
+		t[i] = concThickness[i];
+		h += t[i];		// Total thickness of the section
+	}
+
+	// Allocate memory for the NDMaterials
+	TheReinforcedSteel2DMaterial = new NDMaterial * [numberReinforcedSteelLayers];
+	TheConcrete2DMaterial = new NDMaterial * [numberConcreteLayers];
+
+	if (TheReinforcedSteel2DMaterial == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Failed to allocate pointers for ND reinforced steel materials.\n";
+		exit(-1);
+	}
+	if (TheConcrete2DMaterial == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Failed to allocate pointers for ND concrete materials.\n";
+		exit(-1);
+	}
+
+	// Get copies of the ND reinforced steel materials 
+	for (int i = 0; i < numberReinforcedSteelLayers; i++) {
+		if (reinforcedSteelMaterialObjects[i] == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Null ND reinforced steel material pointer passed.\n";
+			exit(-1);
+		}
+
+		TheReinforcedSteel2DMaterial[i] = reinforcedSteelMaterialObjects[i]->getCopy("PlaneStress2D");
+
+		if (TheReinforcedSteel2DMaterial[i] == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Failed to copy ND reinforced steel material.\n";
+			exit(-1);
+		}
+	}
+
+	// Get copies of the ND concrete materials 
+	for (int i = 0; i < numberConcreteLayers; i++) {
+		if (concrete2DMaterialObjects[i] == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Null ND concrete material pointer passed.\n";
+			exit(-1);
+		}
+
+		TheConcrete2DMaterial[i] = concrete2DMaterialObjects[i]->getCopy("PlaneStress2D");
+
+		if (TheConcrete2DMaterial[i] == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() - Failed to copy ND concrete material.\n";
+			exit(-1);
+		}
+	}
+
+}
+
+// Blank constructor (constructor for blank object that recvSelf needs to be invoked upon) (constructor which should be invoked by an FEM_ObjectBroker only)
+ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01() :
+	SectionForceDeformation(0, SEC_TAG_ReinforcedConcreteLayerMembraneSection01),
+	numberReinforcedSteelLayers(0), numberConcreteLayers(0),
+	CSectionStrain(3), CSectionStress(3), CSectionTangent(3, 3),
+	TSectionStrain(3), TSectionStress(3), TSectionTangent(3, 3), InitialTangent(3, 3),
+	strainPrincipalDirection(3), poissonRatios(2), pi(3.1415926535)
+{
+	TheConcrete2DMaterial = 0;
+	TheReinforcedSteel2DMaterial = 0;
+
+	this->revertToStart();
+}
+
+// Destructor (clean up memory the ReinforcedConcreteLayerMembraneSection01 objects allocates)
+ReinforcedConcreteLayerMembraneSection01::~ReinforcedConcreteLayerMembraneSection01()
+{
+	if (t != 0) delete []t;
+
+	if (TheReinforcedSteel2DMaterial != 0) {
+		for (int i = 0; i < numberReinforcedSteelLayers; i++)
+			if (TheReinforcedSteel2DMaterial[i] != 0)
+				delete TheReinforcedSteel2DMaterial[i];
+		delete[] TheReinforcedSteel2DMaterial;
+	}
+
+	if (TheConcrete2DMaterial != 0) {
+		for (int i = 0; i < numberConcreteLayers; i++)
+			if (TheConcrete2DMaterial[i] != 0)
+				delete TheConcrete2DMaterial[i];
+		delete[] TheConcrete2DMaterial;
+	}
+}
+
+int ReinforcedConcreteLayerMembraneSection01::setTrialSectionDeformation(const Vector& newTrialSectionStrain)
+{
+	// Set the membrane strain (e11,e22,e12) in the section
+	TSectionStrain(0) = newTrialSectionStrain(0);
+	TSectionStrain(1) = newTrialSectionStrain(1);
+	TSectionStrain(2) = newTrialSectionStrain(2);
+
+	double sectionResultantStress[3];		// section resultant stress: {N11 ; N22 ; N12 } = Sum(Stress_ic(zTop_ic - zBottom_ic)) + Sum(Stress_is(t_is))
+	sectionResultantStress[0] = 0.0; sectionResultantStress[1] = 0.0; sectionResultantStress[2] = 0.0;
+
+	double sectionTangent[3][3];			// membrane section stiffness: [Dm] = h*[MaterialTangent] is the membrane stiffness Tangent = Sum(Tangent_ic(zTop_ic - zBottom_ic)) + Sum(Tangent_is(t_is))
+	sectionTangent[0][0] = 0.0; sectionTangent[0][1] = 0.0;	sectionTangent[0][2] = 0.0;
+	sectionTangent[1][0] = 0.0; sectionTangent[1][1] = 0.0;	sectionTangent[1][2] = 0.0;
+	sectionTangent[2][0] = 0.0; sectionTangent[2][1] = 0.0;	sectionTangent[2][2] = 0.0;
+
+	// Set the strain at each concrete layer
+	for (int ic = 0; ic < numberConcreteLayers; ic++) {
+		// Get concrete stress and tangent stiffness
+		TheConcrete2DMaterial[ic]->setTrialStrain(newTrialSectionStrain);
+		const Vector& stressNDM = TheConcrete2DMaterial[ic]->getStress();
+		const Matrix& tangentNDM = TheConcrete2DMaterial[ic]->getTangent();
+
+		double fc11 = stressNDM(0);
+		double fc22 = stressNDM(1);
+		double fc12 = stressNDM(2);
+		// Calculate the concrete contribution to section resultant stress
+		sectionResultantStress[0] += t[ic] * fc11;
+		sectionResultantStress[1] += t[ic] * fc22;
+		sectionResultantStress[2] += t[ic] * fc12;
+
+		double Ec00 = tangentNDM(0, 0); double Ec01 = tangentNDM(0, 1); double Ec02 = tangentNDM(0, 2);
+		double Ec10 = tangentNDM(1, 0); double Ec11 = tangentNDM(1, 1); double Ec12 = tangentNDM(1, 2);
+		double Ec20 = tangentNDM(2, 0); double Ec21 = tangentNDM(2, 1); double Ec22 = tangentNDM(2, 2);
+		// Calculate the concrete contribution to section tangent
+		sectionTangent[0][0] += t[ic] * Ec00; sectionTangent[0][1] += t[ic] * Ec01;	sectionTangent[0][2] += t[ic] * Ec02;
+		sectionTangent[1][0] += t[ic] * Ec10; sectionTangent[1][1] += t[ic] * Ec11;	sectionTangent[1][2] += t[ic] * Ec12;
+		sectionTangent[2][0] += t[ic] * Ec20; sectionTangent[2][1] += t[ic] * Ec21;	sectionTangent[2][2] += t[ic] * Ec22;
+	}
+
+	// Set the strain at each reinforced steel layer
+	for (int iRs = 0; iRs < numberReinforcedSteelLayers; iRs++) {
+		// Get reinforced steel stress and tangent stiffness
+		TheReinforcedSteel2DMaterial[iRs]->setTrialStrain(newTrialSectionStrain);
+		const Vector& stressNDM = TheReinforcedSteel2DMaterial[iRs]->getStress();
+		const Matrix& tangentNDM = TheReinforcedSteel2DMaterial[iRs]->getTangent();
+
+		double fs11 = stressNDM(0);
+		double fs22 = stressNDM(1);
+		double fs12 = stressNDM(2);
+		// Calculate the reinforced steel contribution to section resultant stress
+		sectionResultantStress[0] += h * fs11;
+		sectionResultantStress[1] += h * fs22;
+		sectionResultantStress[2] += h * fs12;
+
+		double Es00 = tangentNDM(0, 0); double Es01 = tangentNDM(0, 1); double Es02 = tangentNDM(0, 2);
+		double Es10 = tangentNDM(1, 0); double Es11 = tangentNDM(1, 1); double Es12 = tangentNDM(1, 2);
+		double Es20 = tangentNDM(2, 0); double Es21 = tangentNDM(2, 1); double Es22 = tangentNDM(2, 2);
+		// Calculate the reinforced steel contribution to section tangent
+		sectionTangent[0][0] += h * Es00; sectionTangent[0][1] += h * Es01; sectionTangent[0][2] += h * Es02;
+		sectionTangent[1][0] += h * Es10; sectionTangent[1][1] += h * Es11; sectionTangent[1][2] += h * Es12;
+		sectionTangent[2][0] += h * Es20; sectionTangent[2][1] += h * Es21; sectionTangent[2][2] += h * Es22;
+	}
+	// Set the stress and tangent
+	TSectionStress(0) = sectionResultantStress[0]; TSectionStress(1) = sectionResultantStress[1]; TSectionStress(2) = sectionResultantStress[2];
+
+	TSectionTangent(0, 0) = sectionTangent[0][0]; TSectionTangent(0, 1) = sectionTangent[0][1]; TSectionTangent(0, 2) = sectionTangent[0][2];
+	TSectionTangent(1, 0) = sectionTangent[1][0]; TSectionTangent(1, 1) = sectionTangent[1][1]; TSectionTangent(1, 2) = sectionTangent[1][2];
+	TSectionTangent(2, 0) = sectionTangent[2][0]; TSectionTangent(2, 1) = sectionTangent[2][1]; TSectionTangent(2, 2) = sectionTangent[2][2];
+
+	return 0;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection01::getSectionDeformation(void)
+{
+	return TSectionStrain;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection01::getStressResultant(void)
+{
+	return TSectionStress;
+}
+
+const Matrix& ReinforcedConcreteLayerMembraneSection01::getSectionTangent(void)
+{
+	return TSectionTangent;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection01::getCommittedStrain(void)
+{
+	return CSectionStrain;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection01::getCommittedStress(void)
+{
+	return CSectionStress;
+}
+
+double ReinforcedConcreteLayerMembraneSection01::getRho(void)
+{
+	double rhoH = 0.0;
+
+	for (int ic = 0; ic < numberConcreteLayers; ic++) {
+		rhoH += (TheConcrete2DMaterial[ic]->getRho()) * t[ic];
+	}
+
+	return rhoH;
+}
+
+double ReinforcedConcreteLayerMembraneSection01::getEcAvg(void)
+{
+	DummyStream theDummyStream;
+
+	char aa[80] = "getEc";
+	const char* argv[1];
+	argv[0] = aa;
+
+	double EcAvg = 0.0;
+
+	for (int ic = 0; ic < numberConcreteLayers; ic++) {
+		
+		Response* theResponse = TheConcrete2DMaterial[ic]->setResponse(argv, 1, theDummyStream);
+
+		if (theResponse == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01 - failed to get input parameters for OrthotropicRotatingAngleConcreteT2DMaterial01 with tag: " << this->getTag() << "\n";
+			exit(-1);
+		}
+
+		// Get OrthotropicRotatingAngleConcreteT2DMaterial01 input variables
+		theResponse->getResponse();
+		Information& theInfoInput = theResponse->getInformation();
+		const Vector& InputNDMat = theInfoInput.getData();
+
+		// Get concrete young's modulus and multiplied by the thickness of each layer
+		EcAvg += (InputNDMat[1]) * t[ic];
+
+		delete theResponse;
+	}
+
+	EcAvg = EcAvg / h;
+
+	return EcAvg;
+}
+
+const Matrix& ReinforcedConcreteLayerMembraneSection01::getInitialTangent(void)
+{
+	// Get the initial membrane section stiffness
+	double initialSectionTangent[3][3];			// membrane section stiffness: [Dm] = h*[MaterialTangent] is the membrane stiffness Tangent = Sum(Tangent_ic(zTop_ic - zBottom_ic)) + Sum(Tangent_is(t_is))
+	initialSectionTangent[0][0] = 0.0; initialSectionTangent[0][1] = 0.0;	initialSectionTangent[0][2] = 0.0;
+	initialSectionTangent[1][0] = 0.0; initialSectionTangent[1][1] = 0.0;	initialSectionTangent[1][2] = 0.0;
+	initialSectionTangent[2][0] = 0.0; initialSectionTangent[2][1] = 0.0;	initialSectionTangent[2][2] = 0.0;
+
+	InitialTangent.Zero();
+
+	// Add the section stiffness contribution from each concrete layer
+	for (int ic = 0; ic < numberConcreteLayers; ic++) {
+		// Get concrete initial tangent stiffness
+		const Matrix& layerConcreteTangent = TheConcrete2DMaterial[ic]->getInitialTangent();
+
+		double Eco00 = layerConcreteTangent(0, 0); double Eco01 = layerConcreteTangent(0, 1); double Eco02 = layerConcreteTangent(0, 2);
+		double Eco10 = layerConcreteTangent(1, 0); double Eco11 = layerConcreteTangent(1, 1); double Eco12 = layerConcreteTangent(1, 2);
+		double Eco20 = layerConcreteTangent(2, 0); double Eco21 = layerConcreteTangent(2, 1); double Eco22 = layerConcreteTangent(2, 2);
+
+		// Calculate the concrete contribution to section tangent
+		initialSectionTangent[0][0] += t[ic] * Eco00; initialSectionTangent[0][1] += t[ic] * Eco01;	initialSectionTangent[0][2] += t[ic] * Eco02;
+		initialSectionTangent[1][0] += t[ic] * Eco10; initialSectionTangent[1][1] += t[ic] * Eco11;	initialSectionTangent[1][2] += t[ic] * Eco12;
+		initialSectionTangent[2][0] += t[ic] * Eco20; initialSectionTangent[2][1] += t[ic] * Eco21;	initialSectionTangent[2][2] += t[ic] * Eco22;
+	}
+
+	// Add the section stiffness contribution from each reinforced steel layer
+	for (int iRs = 0; iRs < numberReinforcedSteelLayers; iRs++) {
+		// Get reinforced steel initial tangent stiffness
+		const Matrix& layerReinforcedSteelTangent = TheReinforcedSteel2DMaterial[iRs]->getInitialTangent();
+
+		double Eso00 = layerReinforcedSteelTangent(0, 0); double Eso01 = layerReinforcedSteelTangent(0, 1); double Eso02 = layerReinforcedSteelTangent(0, 2);
+		double Eso10 = layerReinforcedSteelTangent(1, 0); double Eso11 = layerReinforcedSteelTangent(1, 1); double Eso12 = layerReinforcedSteelTangent(1, 2);
+		double Eso20 = layerReinforcedSteelTangent(2, 0); double Eso21 = layerReinforcedSteelTangent(2, 1); double Eso22 = layerReinforcedSteelTangent(2, 2);
+		// Calculate the reinforced steel contribution to section tangent
+		initialSectionTangent[0][0] += h * Eso00; initialSectionTangent[0][1] += h * Eso01; initialSectionTangent[0][2] += h * Eso02;
+		initialSectionTangent[1][0] += h * Eso10; initialSectionTangent[1][1] += h * Eso11; initialSectionTangent[1][2] += h * Eso12;
+		initialSectionTangent[2][0] += h * Eso20; initialSectionTangent[2][1] += h * Eso21; initialSectionTangent[2][2] += h * Eso22;
+	}
+	
+	InitialTangent(0, 0) = initialSectionTangent[0][0]; InitialTangent(0, 1) = initialSectionTangent[0][1]; InitialTangent(0, 2) = initialSectionTangent[0][2];
+	InitialTangent(1, 0) = initialSectionTangent[1][0]; InitialTangent(1, 1) = initialSectionTangent[1][1]; InitialTangent(1, 2) = initialSectionTangent[1][2];
+	InitialTangent(2, 0) = initialSectionTangent[2][0]; InitialTangent(2, 1) = initialSectionTangent[2][1]; InitialTangent(2, 2) = initialSectionTangent[2][2];
+
+	return InitialTangent;
+}
+
+SectionForceDeformation* ReinforcedConcreteLayerMembraneSection01::getCopy(void)
+{
+	ReinforcedConcreteLayerMembraneSection01* theCopy = new ReinforcedConcreteLayerMembraneSection01(this->getTag(),
+		numberReinforcedSteelLayers,
+		numberConcreteLayers,
+		TheReinforcedSteel2DMaterial,
+		TheConcrete2DMaterial,
+		t,
+		ecr,
+		ec);
+
+	return theCopy;
+}
+
+const ID& ReinforcedConcreteLayerMembraneSection01::getType(void)
+{
+	static bool initialized = false;
+	if (!initialized) {
+		array(0) = SECTION_RESPONSE_FXX;
+		array(1) = SECTION_RESPONSE_FYY;
+		array(2) = SECTION_RESPONSE_FXY;
+		array(3) = SECTION_RESPONSE_MXX;
+		array(4) = SECTION_RESPONSE_MYY;
+		array(5) = SECTION_RESPONSE_MXY;
+		array(6) = SECTION_RESPONSE_VXZ;
+		array(7) = SECTION_RESPONSE_VYZ;
+		initialized = true;
+	}
+	return array;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::getOrder(void) const
+{
+	return 3;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::commitState(void)
+{
+	int success = 0;
+
+	// Commit the state for each concrete layer 
+	for (int iC = 0; iC < numberConcreteLayers; iC++)
+		success += TheConcrete2DMaterial[iC]->commitState();
+
+	// Commit the state for each reinforced steel layer
+	for (int iRS = 0; iRS < numberReinforcedSteelLayers; iRS++)
+		success += TheReinforcedSteel2DMaterial[iRS]->commitState();
+
+	// Commit the history variables
+	CSectionStrain = TSectionStrain;
+	CSectionStress = TSectionStress;
+	CSectionTangent = TSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::revertToLastCommit(void)
+{
+	int success = 0;
+
+	// Revert to last commit the state of each concrete layer
+	for (int iC = 0; iC < numberConcreteLayers; iC++)
+		success += TheConcrete2DMaterial[iC]->revertToLastCommit();
+
+	// Revert to last commit the state of each reinforced steel layer
+	for (int iRS = 0; iRS < numberReinforcedSteelLayers; iRS++)
+		success += TheReinforcedSteel2DMaterial[iRS]->revertToLastCommit();
+
+	// Revert the history variables to last commit
+	TSectionStrain = CSectionStrain;
+	TSectionStress = CSectionStress;
+	TSectionTangent = TSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::revertToStart(void)
+{
+	int success = 0;
+
+	// Revert to start the state of each concrete layer
+	for (int iC = 0; iC < numberConcreteLayers; iC++)
+		success += TheConcrete2DMaterial[iC]->revertToStart();
+
+	// Revert to start the state of each reinforced steel layer
+	for (int iRS = 0; iRS < numberReinforcedSteelLayers; iRS++)
+		success += TheReinforcedSteel2DMaterial[iRS]->revertToStart();
+
+	// Revert the state variables to start
+	crackPattern.Zero();
+	//// Committed state variables
+	CSectionStrain.Zero();
+	CSectionStress.Zero();
+	CSectionTangent = this->getInitialTangent();
+	//// Trial state variables
+	TSectionStrain.Zero();
+	TSectionStress.Zero();
+	TSectionTangent = CSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::sendSelf(int commitTag, Channel& theChannel)
+{
+	int res = 0;
+	int dataTag = this->getDbTag();
+
+	static ID iData(5);
+	iData(0) = this->getTag();
+	iData(1) = numberReinforcedSteelLayers;
+	iData(2) = numberConcreteLayers;
+	iData(3) = ecr;
+	iData(4) = ec;
+
+	res += theChannel.sendID(dataTag, commitTag, iData);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::sendSelf() - " << this->getTag() << " failed to send ID data" << endln;
+		return res;
+	}
+
+	if (numberReinforcedSteelLayers > 0)
+	{
+		Vector vecDataRS(2 * numberReinforcedSteelLayers);
+		int counter = 0;
+		int i;
+		int matDbTag;
+		for (i = 0; i < numberReinforcedSteelLayers; i++)
+		{
+			vecDataRS(counter++) = (double)TheReinforcedSteel2DMaterial[i]->getClassTag();
+			matDbTag = TheReinforcedSteel2DMaterial[i]->getDbTag();
+			if (matDbTag == 0) {
+				matDbTag = theChannel.getDbTag();
+				if (matDbTag != 0)
+					TheReinforcedSteel2DMaterial[i]->setDbTag(matDbTag);
+			}
+			vecDataRS(counter++) = (double)matDbTag;
+		}
+
+		res += theChannel.sendVector(dataTag, commitTag, vecDataRS);
+		if (res < 0) {
+			opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::sendSelf() - " << this->getTag() << " failed to send Vector data" << endln;
+			return res;
+		}
+
+		for (i = 0; i < numberReinforcedSteelLayers; i++) {
+			res += TheReinforcedSteel2DMaterial[i]->sendSelf(commitTag, theChannel);
+			if (res < 0) {
+				opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::sendSelf() - " << this->getTag() << " failed to send its Material" << endln;
+				return res;
+			}
+		}
+	}
+
+	if (numberConcreteLayers > 0)
+	{
+		Vector vecDataC(3 * numberConcreteLayers);
+		int counter = 0;
+		int i;
+
+		for (i = 0; i < numberConcreteLayers; i++) {
+			vecDataC(counter++) = t[i];
+		}
+
+		int matDbTag;
+		for (i = 0; i < numberConcreteLayers; i++)
+		{
+			vecDataC(counter++) = (double)TheConcrete2DMaterial[i]->getClassTag();
+			matDbTag = TheConcrete2DMaterial[i]->getDbTag();
+			if (matDbTag == 0) {
+				matDbTag = theChannel.getDbTag();
+				if (matDbTag != 0)
+					TheConcrete2DMaterial[i]->setDbTag(matDbTag);
+			}
+			vecDataC(counter++) = (double)matDbTag;
+		}
+
+		res += theChannel.sendVector(dataTag, commitTag, vecDataC);
+		if (res < 0) {
+			opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::sendSelf() - " << this->getTag() << " failed to send Vector data" << endln;
+			return res;
+		}
+
+		for (i = 0; i < numberConcreteLayers; i++) {
+			res += TheConcrete2DMaterial[i]->sendSelf(commitTag, theChannel);
+			if (res < 0) {
+				opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::sendSelf() - " << this->getTag() << " failed to send its Material" << endln;
+				return res;
+			}
+		}
+	}
+
+	return res;
+}
+
+int ReinforcedConcreteLayerMembraneSection01::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker)
+{
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static ID iData(5);
+	res += theChannel.recvID(dataTag, commitTag, iData);
+
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::recvSelf() - " << this->getTag() << " failed to receive ID data" << endln;
+		return res;
+	}
+
+	this->setTag(iData(0));
+
+	int i;
+	if (numberReinforcedSteelLayers != iData(1));
+	{
+		numberReinforcedSteelLayers = iData(1);
+		if (TheReinforcedSteel2DMaterial != 0)
+		{
+			for (i = 0; i < numberReinforcedSteelLayers; i++)
+			{
+				if (TheReinforcedSteel2DMaterial[i] != 0) delete TheReinforcedSteel2DMaterial[i];
+			}
+			delete[] TheReinforcedSteel2DMaterial;
+		}
+		TheReinforcedSteel2DMaterial = new NDMaterial * [numberReinforcedSteelLayers];
+		for (i = 0; i < numberReinforcedSteelLayers; i++)
+			TheReinforcedSteel2DMaterial[i] = nullptr;
+	}
+
+	if (numberConcreteLayers != iData(2))
+	{
+		numberConcreteLayers = iData(2);
+		if (t != 0) delete[] t;
+		t = new double[numberConcreteLayers];
+		if (TheConcrete2DMaterial != 0)
+		{
+			for (i = 0; i < numberConcreteLayers; i++)
+			{
+				if (TheConcrete2DMaterial[i] != 0) delete TheConcrete2DMaterial[i];
+			}
+			delete[] TheConcrete2DMaterial;
+		}
+		TheConcrete2DMaterial = new NDMaterial * [numberConcreteLayers];
+		for (i = 0; i < numberConcreteLayers; i++)
+			TheConcrete2DMaterial[i] = nullptr;
+	}
+	
+	ecr                         = iData(3);
+	ec                          = iData(4);
+
+	if (numberReinforcedSteelLayers)
+	{
+		Vector vecDataRS(2 * numberReinforcedSteelLayers);
+		res += theChannel.recvVector(dataTag, commitTag, vecDataRS);
+		if (res < 0) {
+			opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::recvSelf() - " << this->getTag() << " failed to receive Vector data" << endln;
+			return res;
+		}
+		int counter = 0;
+		for (i = 0; i < numberReinforcedSteelLayers; i++) {
+			int matClassTag = (int)vecDataRS(counter++);
+			if (TheReinforcedSteel2DMaterial[i] == nullptr || TheReinforcedSteel2DMaterial[i]->getClassTag() != matClassTag) {
+				if (TheReinforcedSteel2DMaterial[i]) delete TheReinforcedSteel2DMaterial[i];
+				TheReinforcedSteel2DMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+				if (TheReinforcedSteel2DMaterial[i] == nullptr) {
+					opserr << "ReinforcedConcreteLayerMembraneSection01::recvSelf() - Broker could no create NDMaterial of class type " << matClassTag << endln;
+					return -1;
+				}
+			}
+			TheReinforcedSteel2DMaterial[i]->setDbTag((int)vecDataRS(counter++));
+			res += TheReinforcedSteel2DMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "ReinforcedConcreteLayerMembraneSection01::recvSelf() - material " << i << " failed to recv itself" << endln;
+				return res;
+			}
+		}
+	}
+
+	if (numberConcreteLayers > 0)
+	{
+		Vector vecDataC(3 * numberConcreteLayers);
+		res += theChannel.recvVector(dataTag, commitTag, vecDataC);
+		if (res < 0) {
+			opserr << "WARNING ReinforcedConcreteLayerMembraneSection01::recvSelf() - " << this->getTag() << " failed to receive Vector data" << endln;
+			return res;
+		}
+		int counter = 0;
+		for (i = 0; i < numberConcreteLayers; i++)
+		{
+			t[i] = vecDataC[counter++];
+		}
+		for (i = 0; i < numberConcreteLayers; i++) {
+			int matClassTag = (int)vecDataC(counter++);
+			if (TheConcrete2DMaterial[i] == nullptr || TheConcrete2DMaterial[i]->getClassTag() != matClassTag) {
+				if (TheConcrete2DMaterial[i]) delete TheConcrete2DMaterial[i];
+				TheConcrete2DMaterial[i] = theBroker.getNewNDMaterial(matClassTag);
+				if (TheConcrete2DMaterial[i] == nullptr) {
+					opserr << "ReinforcedConcreteLayerMembraneSection01::recvSelf() - Broker could not create NDMaterial of class type " << matClassTag << endln;
+					return -1;
+				}
+			}
+			TheConcrete2DMaterial[i]->setDbTag((int)vecDataC(counter++));
+			res += TheConcrete2DMaterial[i]->recvSelf(commitTag, theChannel, theBroker);
+			if (res < 0) {
+				opserr << "ReinforcedConcreteLayerMembraneSection01:recvSelf() - material " << i << " failed to recv itself" << endln;
+				return res;
+			}
+		}
+	}
+
+	return res;
+}
+
+void ReinforcedConcreteLayerMembraneSection01::Print(OPS_Stream& s, int flag)
+{
+	s << "ReinforcedConcreteLayerMembraneSection01 tag: " << this->getTag() << endln;
+	s << "Total thickness h = " << h << endln;
+
+	for (int iC = 0; iC < numberConcreteLayers; iC++) {
+		s << "Concrete layer " << iC + 1 << ", thickness t = " << t[iC] << endln;
+		TheConcrete2DMaterial[iC]->Print(s, flag);
+		s << endln;
+	}
+
+	for (int iRS = 0; iRS < numberReinforcedSteelLayers; iRS++) {
+		s << "Reinforced Steel layer " << iRS + 1 << endln;
+		TheReinforcedSteel2DMaterial[iRS]->Print(s, flag);
+		s << endln;
+	}
+
+}
+
+Response* ReinforcedConcreteLayerMembraneSection01::setResponse(const char** argv, int argc, OPS_Stream& s)
+{
+	Response* theResponse = 0;
+	if (strcmp(argv[0], "panel_strain") == 0 || strcmp(argv[0], "Panel_strain") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection01");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "eps11");
+		s.tag("ResponseType", "eps22");
+		s.tag("ResponseType", "eps12");
+		s.endTag();
+
+		Vector data1(3);
+		data1.Zero();
+
+		theResponse = new MaterialResponse(this, 1, data1);
+
+	}
+	else if (strcmp(argv[0], "panel_stress") == 0 || strcmp(argv[0], "Panel_Stress") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection01");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "sigma11");
+		s.tag("ResponseType", "sigma22");
+		s.tag("ResponseType", "sigma12");
+		s.endTag();
+
+		Vector data2(3);
+		data2.Zero();
+
+		theResponse = new MaterialResponse(this, 2, data2);
+
+	}
+	else if (strcmp(argv[0], "getBendingParameters") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection01");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "Eave");
+		s.tag("ResponseType", "Tave");
+		s.endTag();
+
+		Vector data3(2);
+		data3.Zero();
+
+		theResponse = new MaterialResponse(this, 3, data3);
+	}
+	else {
+
+		return this->SectionForceDeformation::setResponse(argv, argc, s);
+	}
+
+	return theResponse;
+}
+
+
+int ReinforcedConcreteLayerMembraneSection01::getResponse(int responseID, Information& info)
+{
+	if (responseID == 1) {
+		return info.setVector(this->getCommittedStrain());
+	}
+	else if (responseID == 2) {
+		return info.setVector(this->getCommittedStress());
+	}
+	else if (responseID == 3) {
+		return info.setVector(this->getBendingParameters());
+	}
+	else {
+		return 0;
+	}
+}
+
+// Function that returns bending parameters - added for MEFI3D by Maria Jose Nunez, UChile
+Vector ReinforcedConcreteLayerMembraneSection01::getBendingParameters(void)
+{
+	Vector input_par(2);
+
+	input_par.Zero();
+
+	input_par(0) = this->getEcAvg();
+	input_par(1) = h;
+
+	return input_par;
+}
+
+void ReinforcedConcreteLayerMembraneSection01::setCrackPattern(void)
+{
+	// Calculate the Principal Direction of Strain
+	this->calculateStrainPrincipalDirections01();
+
+	// Calculate the Poisson Ratios
+	if (crackPattern(0) == 1 || crackPattern(3) == 1) {
+		isConcreteCracked = true;
+	}
+	else {
+		isConcreteCracked = false;
+	}
+
+	this->calculatePoissonRatios(strainPrincipalDirection(0), strainPrincipalDirection(1));
+
+	// Define the Poisson Ratio Matrix V = [ 1/(1-nu12*nu21) nu12/(1-nu12*nu21) 0 ; nu21/(1-nu12*nu21) 1/(1-nu12*nu21) 0 ; 0 0 1 ]
+	double nu[2];
+	nu[0] = poissonRatios(0); nu[1] = poissonRatios(1);
+	double oneOverOneMinusNu12Nu21 = 1.0 / (1.0 - nu[0] * nu[1]);
+
+	double V[3][3] = { {oneOverOneMinusNu12Nu21,nu[0] * oneOverOneMinusNu12Nu21,0.0},{nu[1] * oneOverOneMinusNu12Nu21,oneOverOneMinusNu12Nu21,0.0},{0.0,0.0,1.0} };
+
+	// Calculate the newUniaxialStrain in the orientation of the Principal Direction of Strain
+	double newUniaxialStrainPD[3] = { 0.0,0.0,0.0 };
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			newUniaxialStrainPD[i] = newUniaxialStrainPD[i] + (strainPrincipalDirection(j) * V[i][j]);
+		}
+	}
+
+	// Set the CrackPattern Propierties
+	// Check if the Concrete has crushing
+	// Select the minimal strain in the principal direction
+	double minStrain = min(newUniaxialStrainPD[0], newUniaxialStrainPD[1]);
+	int factorWidthComp = 10;
+	if (minStrain <= ec || (crackPattern(3) == 1 && minStrain < 0)) {
+		crackPattern(3) = 1;
+		crackPattern(4) = thetaPrincipalDirection;
+		crackPattern(5) = minStrain / ec / factorWidthComp;
+	}
+	else {
+		crackPattern(5) = 0;
+	}
+	int factorWidthTension = 1000;
+	// Check if the concrete has been cracked in the direction 1
+	if (newUniaxialStrainPD[0] >= ecr || (crackPattern(0) == 1 && newUniaxialStrainPD[0] >= 0)) {
+		crackPattern(0) = 1;
+		crackPattern(1) = thetaPrincipalDirection;
+		crackPattern(2) = newUniaxialStrainPD[0] / ecr / factorWidthTension;
+	}
+	else {
+		crackPattern(2) = 0;
+	}
+
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection01::getCrackPattern(void)
+{
+	return crackPattern;
+}
+
+void ReinforcedConcreteLayerMembraneSection01::calculateStrainPrincipalDirections01(void)
+{
+	double strain_vec[3];		//ex, ey, gamma
+	double doubleThetaPD, cos2Theta, sin2Theta;
+
+	// Get strain values from strain of element
+	strain_vec[0] = TSectionStrain(0);		// ex
+	strain_vec[1] = TSectionStrain(1);		// ey
+	strain_vec[2] = TSectionStrain(2);		// gxy
+
+	double averageStrains = 0.5 * (strain_vec[0] + strain_vec[1]);
+	double deltaStrains = strain_vec[0] - strain_vec[1];
+	double constantCS = pow(pow(deltaStrains, 2) + pow(strain_vec[2], 2), 0.5);
+	if (deltaStrains == 0.0 && strain_vec[2] == 0.0) {
+		doubleThetaPD = 0.0;
+	}
+	else {
+		cos2Theta = deltaStrains / constantCS;
+		sin2Theta = strain_vec[2] / constantCS;
+		this->calculateAngle01(cos2Theta, sin2Theta, doubleThetaPD);
+
+	}
+	thetaPrincipalDirection = 0.5 * doubleThetaPD;
+
+	strainPrincipalDirection(0) = averageStrains + 0.5 * constantCS;
+	strainPrincipalDirection(1) = averageStrains - 0.5 * constantCS;
+	strainPrincipalDirection(2) = 0.0;
+
+	return;
+}
+
+void ReinforcedConcreteLayerMembraneSection01::calculateAngle01(double cosTheta, double sinTheta, double& theta)
+{
+	double thetaFromCos, thetaFromSin;
+
+	thetaFromCos = acos(cosTheta);
+	thetaFromSin = asin(sinTheta);
+
+	if (thetaFromCos <= pi / 2.0 + 1e-7) {
+		theta = thetaFromSin;
+	}
+	else {
+		if (thetaFromSin >= 0.0) {
+			theta = thetaFromCos;
+		}
+		else {
+			theta = -thetaFromCos;
+		}
+	}
+
+	return;
+}
+
+void ReinforcedConcreteLayerMembraneSection01::calculatePoissonRatios(double e1, double e2)
+{
+	double nu[2];
+
+	double Nuo = 0.2;
+
+	if (isConcreteCracked) {
+		nu[0] = 0.0;
+		nu[1] = 0.0;
+	}
+	else {
+		nu[0] = Nuo;
+		nu[1] = Nuo;
+	}
+	if (!isConcreteCracked) {
+		if (e2 <= ec / 2.0) {
+			nu[0] = min(Nuo * (1.0 + 1.5 * (pow(2.0 * e2 / ec - 1.0, 2.0))), 0.5);
+		}
+		if (e1 <= ec / 2.0) {
+			nu[1] = min(Nuo * (1.0 + 1.5 * (pow(2.0 * e1 / ec - 1.0, 2.0))), 0.5);
+		}
+	}
+
+	poissonRatios(0) = nu[0];
+	poissonRatios(1) = nu[1];
+
+	return;
+}

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.h
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection01.h
@@ -1,0 +1,131 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 04/2023
+// 
+// Description: This file contains the ReinforcedConcreteLayerMembraneSection01 class definition
+// A ReinforcedConcreteLayerMembraneSection01 is a subclass of the sectionForceDeformation class and corresponds to the abstract representation
+// for the stress-strain behavior for a Reinforced Concrete Layer Membrane Element in the Finite Element Method or Structural Analysis. 
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\section\ReinforcedConcreteLayerMembraneSection
+//
+// Rev: 1.0
+
+#ifndef ReinforcedConcreteLayerMembraneSection01_h
+#define ReinforcedConcreteLayerMembraneSection01_h
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <Vector.h>
+#include <Matrix.h>
+#include <ID.h>
+#include <NDMaterial.h>
+
+#include <SectionForceDeformation.h>
+
+class ReinforcedConcreteLayerMembraneSection01 : public SectionForceDeformation {
+public:
+
+	ReinforcedConcreteLayerMembraneSection01(int tag,			// section tag
+		int nSteelLayer,										// number of reinforced steel layers
+		int nConcLayer,											// number of concrete layers
+		NDMaterial** reinforcedSteelMaterialObjects,			// array of nDMaterial reinforced steel tags for each layer
+		NDMaterial** concrete2DMaterialObjects,					// array of nDMaterial concrete tags for each layer
+		double* concThickness,									// array of concrete layers thickness
+		double strainAtFcr = 0.00008,							// strain at tension cracking of the concrete
+		double strainAtFc = -0.002);							// strain at the compresion strength of the concrete
+
+	ReinforcedConcreteLayerMembraneSection01();
+
+	~ReinforcedConcreteLayerMembraneSection01();
+
+	int setTrialSectionDeformation(const Vector& newTrialSectionStrain);
+
+	// Public methods to obtain strain, stress, tangent and residual information
+	const Vector& getSectionDeformation(void);
+	const Vector& getStressResultant(void);
+	const Matrix& getSectionTangent(void);
+	const Matrix& getInitialTangent(void);
+
+	// Public methods to obtain a copy of section and other information
+	SectionForceDeformation* getCopy(void);
+	const char* getClassType(void) const { return "ReinforcedConcreteLayerMembrane"; };
+	const ID& getType(void);
+	int getOrder(void) const;
+	
+	// Public methods to set the state of the section
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	// Public methods for output
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag);
+	Response* setResponse(const char** argv, int argc, OPS_Stream& s);
+	int getResponse(int responseID, Information& info);
+
+	// Functions used for recorders
+	const Vector& getCommittedStrain(void);
+	const Vector& getCommittedStress(void);
+
+	// Function used by MEFI3D
+	double getRho(void);															// Return the concrete density
+
+private:
+	
+	void setCrackPattern(void);														// Obtain the crack pattern for the PlaneElementSection
+	const Vector& getCrackPattern(void);											// Return the crack pattern
+	void calculateStrainPrincipalDirections01(void);								// Calculate the principal direction for the strains (11, 22, 12) using the calculateAngle01 method
+	void calculateAngle01(double cosTheta, double sinTheta, double& theta);			// Calculate the theta angle [-pi,pi] from the cos(theta) and sin(theta)
+	void calculatePoissonRatios(double e1, double e2);								// Calculate the Vecchio Poisson Ratios
+	// Function used by MEFI3D
+	double getEcAvg(void);															// Return the average young's modulus of concrete
+	Vector getBendingParameters(void);												// Return input parameters
+
+	// Private attributes
+	NDMaterial** TheConcrete2DMaterial;												// Array of ND concrete materials
+	NDMaterial** TheReinforcedSteel2DMaterial;										// Array of ND reinforced steel materials
+
+	double thetaPrincipalDirection;													// Store the orientation of the Principal Direction in the material
+	Vector strainPrincipalDirection;												// Store the principal strains
+	Vector poissonRatios;															// Store the Poisson Ratios (nu12 and nu21) 
+	double ecr;																		// Store the strain at the tension cracking of the concrete
+	double ec;																		// Store the strain at the compresion strength of the concrete
+	bool isConcreteCracked;															// Store a flag indicating if the concrete has cracking
+
+	int numberConcreteLayers;														// Store the number of Concrete layers
+	int numberReinforcedSteelLayers;												// Store the number of Reinforced Steel layers
+	
+	// Material History Variables
+	Vector crackPattern;															// Store the propierties of the Crack Pattern
+	
+	// Committed State Variables
+	Vector CSectionStrain;															// Store the commit strains of the membrane section
+	Vector CSectionStress;															// Store the commit stress of the membrane section
+	Matrix CSectionTangent;															// Store the commit tangent of the membrane section
+	// Trial State Variables
+	Vector TSectionStrain;															// Store the trial strains of the membrane section
+	Vector TSectionStress;															// Store the trial stress of the membrane section
+	Matrix TSectionTangent;															// Store the trial tangent of the membrane section
+	Matrix InitialTangent;															// Store the initial tangent of the membrane section
+
+	// Section array
+	double* t;																		// Concrete layer thickness
+
+	// Calculated section parameters
+	double h;																		// Store the total thickness of the section 
+
+	const double pi;
+
+	static ID array;
+};
+
+#endif // !ReinforcedConcreteLayerMembraneSection01_h

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.cpp
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.cpp
@@ -1,0 +1,521 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 07/2023
+// 
+// Description: This file contains the ReinforcedConcreteLayerMembraneSection02 class definition
+// A ReinforcedConcreteLayerMembraneSection02 is a subclass of the sectionForceDeformation class and corresponds to the abstract representation
+// for the stress-strain behavior for a Reinforced Concrete Layer Membrane Element in the Finite Element Method or Structural Analysis. 
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\section\ReinforcedConcreteLayerMembraneSection
+//
+// Rev: 1.0
+
+#include <ReinforcedConcreteLayerMembraneSection02.h>
+#include <NDMaterial.h>
+#include <Vector.h>
+#include <Matrix.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <elementAPI.h>
+#include <Parameter.h>
+#include <MaterialResponse.h>
+#include <algorithm>				/*min, max*/
+#include <DummyStream.h>
+
+using namespace std;
+
+// Read input parameters and build the section
+void* OPS_ReinforcedConcreteLayerMembraneSection02()
+{
+	int numArgs = OPS_GetNumRemainingInputArgs();
+
+	// Parse the script for material parameters
+	if (numArgs != 3) {
+		opserr << "Want: ReinforcedConcreteLayerMembraneSection02 $secTag $matTag $Thickness" << endln;
+		return 0;
+	}
+
+	int tag;						// section tag
+	int matTag;						// nDMaterial tag
+	double thickness;				// macro-fiber thickness
+
+	// section tag
+	int numdata = 1;
+	if (OPS_GetIntInput(&numdata, &tag) < 0) {
+		opserr << "WARNING invalid section ReinforcedConcreteLayerMembraneSection02 tag" << endln;
+		return 0;
+	}
+	
+	// nDMaterial tag
+	numdata = 1;
+	if (OPS_GetIntInput(&numdata, &matTag) < 0) {
+		opserr << "WARNING invalid nDMaterial tag" << endln;
+		return 0;
+	}
+	
+	// thickness
+	numdata = 1;
+	if (OPS_GetDoubleInput(&numdata, &thickness) < 0) {
+		opserr << "Invalid thick parameter for ReinforcedConcreteLayerMembraneSection02 " << tag << endln;
+		return 0;
+	}
+
+	// Get pointer to nDMaterial
+	NDMaterial* theNDMaterial = OPS_getNDMaterial(matTag);
+	if (theNDMaterial == 0) {
+		opserr << "WARNING material not found\n";
+		opserr << "Material: " << matTag;
+		opserr << "\nReinforcedConcreteLayerMembraneSection02: " << tag << endln;
+		return 0;
+	}
+
+	SectionForceDeformation* theSection = new ReinforcedConcreteLayerMembraneSection02(tag, theNDMaterial, thickness);
+
+	return theSection;
+}
+
+//static vector and matrices
+ID ReinforcedConcreteLayerMembraneSection02::array(8);
+
+// Full constructor
+ReinforcedConcreteLayerMembraneSection02::ReinforcedConcreteLayerMembraneSection02(int tag,		// section tag
+	NDMaterial* RCMaterialObject,																// reinforced concrete nDMaterial tag
+	double Thickness)																			//macro-fiber thickness
+
+	:SectionForceDeformation(tag, SEC_TAG_ReinforcedConcreteLayerMembraneSection02),
+	t(Thickness), CSectionStrain(3), CSectionStress(3), CSectionTangent(3,3),
+	TSectionStrain(3), TSectionStress(3), TSectionTangent(3,3), InitialTangent(3,3)
+{
+	// Set initial values
+	for (int i = 0; i < 3; i++) {
+		CSectionStrain(i) = 0.0;
+		CSectionStress(i) = 0.0;
+		TSectionStrain(i) = 0.0;
+		TSectionStress(i) = 0.0;
+	}
+
+	// Get a copy of the RC material
+	TheRCMaterial = RCMaterialObject->getCopy();
+	// Check allocation
+	if (TheRCMaterial == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection02::ReinforcedConcreteLayerMembraneSection02() - Failed to get a copy for RCMaterial\n";
+		exit(-1);
+	}
+
+}
+
+// Blank constructor (constructor for blank object that recvSelf needs to be invoked upon) (constructor which should be invoked by an FEM_ObjectBroker only)
+ReinforcedConcreteLayerMembraneSection02::ReinforcedConcreteLayerMembraneSection02() :
+	SectionForceDeformation(0, SEC_TAG_ReinforcedConcreteLayerMembraneSection02),
+	CSectionStrain(3), CSectionStress(3), CSectionTangent(3, 3),
+	TSectionStrain(3), TSectionStress(3), TSectionTangent(3, 3), InitialTangent(3, 3)
+{
+	this->revertToStart();
+}
+
+// Destructor (clean up memory the ReinforcedConcreteLayerMembraneSection02 objects allocates)
+ReinforcedConcreteLayerMembraneSection02::~ReinforcedConcreteLayerMembraneSection02()
+{
+	if (TheRCMaterial != 0)
+		delete TheRCMaterial;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::setTrialSectionDeformation(const Vector& newTrialSectionStrain)
+{
+	// Set the membrane strain (e11,e22,e12) in the section
+	TSectionStrain(0) = newTrialSectionStrain(0);
+	TSectionStrain(1) = newTrialSectionStrain(1);
+	TSectionStrain(2) = newTrialSectionStrain(2);
+
+	double sectionResultantStress[3];		// section resultant stress: {N11 ; N22 ; N12 } = Sum(Stress_ic(zTop_ic - zBottom_ic)) + Sum(Stress_is(t_is))
+	sectionResultantStress[0] = 0.0; sectionResultantStress[1] = 0.0; sectionResultantStress[2] = 0.0;
+
+	double sectionTangent[3][3];			// membrane section stiffness: [Dm] = h*[MaterialTangent] is the membrane stiffness Tangent = Sum(Tangent_ic(zTop_ic - zBottom_ic)) + Sum(Tangent_is(t_is))
+	sectionTangent[0][0] = 0.0; sectionTangent[0][1] = 0.0;	sectionTangent[0][2] = 0.0;
+	sectionTangent[1][0] = 0.0; sectionTangent[1][1] = 0.0;	sectionTangent[1][2] = 0.0;
+	sectionTangent[2][0] = 0.0; sectionTangent[2][1] = 0.0;	sectionTangent[2][2] = 0.0;
+
+	// Set the strain
+	TheRCMaterial->setTrialStrain(newTrialSectionStrain);
+	const Vector& stressNDM = TheRCMaterial->getStress();
+	const Matrix& tangentNDM = TheRCMaterial->getTangent();
+
+	double fc11 = stressNDM(0);
+	double fc22 = stressNDM(1);
+	double fc12 = stressNDM(2);
+
+	sectionResultantStress[0] = t * fc11;
+	sectionResultantStress[1] = t * fc22;
+	sectionResultantStress[2] = t * fc12;
+
+	double Ec00 = tangentNDM(0, 0); double Ec01 = tangentNDM(0, 1); double Ec02 = tangentNDM(0, 2);
+	double Ec10 = tangentNDM(1, 0); double Ec11 = tangentNDM(1, 1); double Ec12 = tangentNDM(1, 2);
+	double Ec20 = tangentNDM(2, 0); double Ec21 = tangentNDM(2, 1); double Ec22 = tangentNDM(2, 2);
+
+	sectionTangent[0][0] = t * Ec00; sectionTangent[0][1] = t * Ec01;	sectionTangent[0][2] = t * Ec02;
+	sectionTangent[1][0] = t * Ec10; sectionTangent[1][1] = t * Ec11;	sectionTangent[1][2] = t * Ec12;
+	sectionTangent[2][0] = t * Ec20; sectionTangent[2][1] = t * Ec21;	sectionTangent[2][2] = t * Ec22;
+	
+	// Set the stress and tangent
+	TSectionStress(0) = sectionResultantStress[0]; TSectionStress(1) = sectionResultantStress[1]; TSectionStress(2) = sectionResultantStress[2];
+
+	TSectionTangent(0, 0) = sectionTangent[0][0]; TSectionTangent(0, 1) = sectionTangent[0][1]; TSectionTangent(0, 2) = sectionTangent[0][2];
+	TSectionTangent(1, 0) = sectionTangent[1][0]; TSectionTangent(1, 1) = sectionTangent[1][1]; TSectionTangent(1, 2) = sectionTangent[1][2];
+	TSectionTangent(2, 0) = sectionTangent[2][0]; TSectionTangent(2, 1) = sectionTangent[2][1]; TSectionTangent(2, 2) = sectionTangent[2][2];
+
+	return 0;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection02::getSectionDeformation(void)
+{
+	return TSectionStrain;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection02::getStressResultant(void)
+{
+	return TSectionStress;
+}
+
+const Matrix& ReinforcedConcreteLayerMembraneSection02::getSectionTangent(void)
+{
+	return TSectionTangent;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection02::getCommittedStrain(void)
+{
+	return CSectionStrain;
+}
+
+const Vector& ReinforcedConcreteLayerMembraneSection02::getCommittedStress(void)
+{
+	return CSectionStress;
+}
+
+double ReinforcedConcreteLayerMembraneSection02::getRho(void)
+{
+	double rhoH = 0.0;
+
+	rhoH = (TheRCMaterial->getRho()) * t;
+
+	return rhoH;
+}
+
+double ReinforcedConcreteLayerMembraneSection02::getEcAvg(void)
+{
+	DummyStream theDummyStream;
+	char aa[80] = "getInputParameters";
+	const char* argv[1];
+	argv[0] = aa;
+
+	double EcAvg = 0.0;
+
+	Response* theResponse = TheRCMaterial->setResponse(argv, 1, theDummyStream);
+
+	if (theResponse == 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection01::ReinforcedConcreteLayerMembraneSection01 - failed to get input parameters for OrthotropicRotatingAngleConcreteT2DMaterial01 with tag : " << this->getTag() << "\n";
+		exit(-1);
+	}
+	theResponse->getResponse();
+	Information& theInfoInput = theResponse->getInformation();
+	const Vector& InputNDMat = theInfoInput.getData();
+
+	EcAvg = InputNDMat[9];
+
+	return EcAvg;
+}
+
+const Matrix& ReinforcedConcreteLayerMembraneSection02::getInitialTangent(void)
+{
+	// Get the initial membrane section stiffness
+	double initialSectionTangent[3][3];			// membrane section stiffness: [Dm] = h*[MaterialTangent] is the membrane stiffness Tangent = Sum(Tangent_ic(zTop_ic - zBottom_ic)) + Sum(Tangent_is(t_is))
+	initialSectionTangent[0][0] = 0.0; initialSectionTangent[0][1] = 0.0;	initialSectionTangent[0][2] = 0.0;
+	initialSectionTangent[1][0] = 0.0; initialSectionTangent[1][1] = 0.0;	initialSectionTangent[1][2] = 0.0;
+	initialSectionTangent[2][0] = 0.0; initialSectionTangent[2][1] = 0.0;	initialSectionTangent[2][2] = 0.0;
+
+	InitialTangent.Zero();
+
+	const Matrix& RCTangent = TheRCMaterial->getInitialTangent();
+
+	double Eco00 = RCTangent(0, 0); double Eco01 = RCTangent(0, 1); double Eco02 = RCTangent(0, 2);
+	double Eco10 = RCTangent(1, 0); double Eco11 = RCTangent(1, 1); double Eco12 = RCTangent(1, 2);
+	double Eco20 = RCTangent(2, 0); double Eco21 = RCTangent(2, 1); double Eco22 = RCTangent(2, 2);
+
+	initialSectionTangent[0][0] = t * Eco00; initialSectionTangent[0][1] = t * Eco01;	initialSectionTangent[0][2] = t * Eco02;
+	initialSectionTangent[1][0] = t * Eco10; initialSectionTangent[1][1] = t * Eco11;	initialSectionTangent[1][2] = t * Eco12;
+	initialSectionTangent[2][0] = t * Eco20; initialSectionTangent[2][1] = t * Eco21;	initialSectionTangent[2][2] = t * Eco22;
+	
+	InitialTangent(0, 0) = initialSectionTangent[0][0]; InitialTangent(0, 1) = initialSectionTangent[0][1]; InitialTangent(0, 2) = initialSectionTangent[0][2];
+	InitialTangent(1, 0) = initialSectionTangent[1][0]; InitialTangent(1, 1) = initialSectionTangent[1][1]; InitialTangent(1, 2) = initialSectionTangent[1][2];
+	InitialTangent(2, 0) = initialSectionTangent[2][0]; InitialTangent(2, 1) = initialSectionTangent[2][1]; InitialTangent(2, 2) = initialSectionTangent[2][2];
+
+	return InitialTangent;
+}
+
+SectionForceDeformation* ReinforcedConcreteLayerMembraneSection02::getCopy(void)
+{
+	ReinforcedConcreteLayerMembraneSection02* theCopy = new ReinforcedConcreteLayerMembraneSection02(this->getTag(),
+		TheRCMaterial,
+		t);
+
+	return theCopy;
+}
+
+const ID& ReinforcedConcreteLayerMembraneSection02::getType(void)
+{
+	static bool initialized = false;
+	if (!initialized) {
+		array(0) = SECTION_RESPONSE_FXX;
+		array(1) = SECTION_RESPONSE_FYY;
+		array(2) = SECTION_RESPONSE_FXY;
+		array(3) = SECTION_RESPONSE_MXX;
+		array(4) = SECTION_RESPONSE_MYY;
+		array(5) = SECTION_RESPONSE_MXY;
+		array(6) = SECTION_RESPONSE_VXZ;
+		array(7) = SECTION_RESPONSE_VYZ;
+		initialized = true;
+	}
+	return array;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::getOrder(void) const
+{
+	return 3;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::commitState(void)
+{
+	int success = 0;
+
+	success = TheRCMaterial->commitState();
+
+	// Commit the history variables
+	CSectionStrain = TSectionStrain;
+	CSectionStress = TSectionStress;
+	CSectionTangent = TSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::revertToLastCommit(void)
+{
+	int success = 0;
+
+	success = TheRCMaterial->revertToLastCommit();
+
+	// Revert the history variables to last commit
+	TSectionStrain = CSectionStrain;
+	TSectionStress = CSectionStress;
+	TSectionTangent = TSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::revertToStart(void)
+{
+	int success = 0;
+
+	success = TheRCMaterial->revertToStart();
+
+	// Revert the state variables to start
+	//// Committed state variables
+	CSectionStrain.Zero();
+	CSectionStress.Zero();
+	CSectionTangent = this->getInitialTangent();
+	//// Trial state variables
+	TSectionStrain.Zero();
+	TSectionStress.Zero();
+	TSectionTangent = CSectionTangent;
+
+	return success;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::sendSelf(int commitTag, Channel& theChannel)
+{
+	int res = 0;
+	int dataTag = this->getDbTag();
+
+	static Vector data(2);
+	data(0) = this->getTag();
+	data(1) = t;
+
+	res += theChannel.sendVector(dataTag, commitTag, data);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection02::sendself() - " << this->getTag() << " failed to send Vector\n";
+		return res;
+	}
+
+	int matDbTag;
+	static ID idData(2);
+	idData(0) = TheRCMaterial->getClassTag();
+	matDbTag = TheRCMaterial->getDbTag();
+	if (matDbTag == 0) {
+		matDbTag = theChannel.getDbTag();
+		if (matDbTag != 0)
+			TheRCMaterial->setDbTag(matDbTag);
+	}
+	idData(1) = matDbTag;
+
+	res += theChannel.sendID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection02::sendself() - " << this->getTag() << " failed to send ID\n";
+		return res;
+	}
+
+	res += TheRCMaterial->sendSelf(commitTag, theChannel);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection02::sendself() - " << this->getTag() << " failed to send its Material\n";
+		return res;
+	}
+
+	return res;
+}
+
+int ReinforcedConcreteLayerMembraneSection02::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker)
+{
+	int res = 0;
+
+	int dataTag = this->getDbTag();
+
+	static Vector data(2);
+	res += theChannel.recvVector(dataTag, commitTag, data);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection02::recvSelf() - failed to receive Vector\n";
+		return res;
+	}
+	this->setTag((int)data(0));
+	t = data(1);
+
+	static ID idData(2);
+
+	res += theChannel.recvID(dataTag, commitTag, idData);
+	if (res < 0) {
+		opserr << "WARNING ReinforcedConcreteLayerMembraneSection02::recvSelf() - "<<this->getTag()<<" failed to receive ID\n";
+		return res;
+	}
+
+	int matClassTag = idData(0);
+	if (TheRCMaterial != 0) {
+		if (matClassTag != TheRCMaterial->getClassTag()) {
+			delete TheRCMaterial;
+			TheRCMaterial = 0;
+		}
+	}
+
+	if (TheRCMaterial == 0) {
+		TheRCMaterial = theBroker.getNewNDMaterial(matClassTag);
+		if (TheRCMaterial == 0) {
+			opserr << "ReinforcedConcreteLayerMembraneSection02::recvSelf() - failed to get a NDMaterial of type " << matClassTag << endln;
+			return -1;
+		}
+	}
+
+	TheRCMaterial->setDbTag(idData(1));
+
+	res += TheRCMaterial->recvSelf(commitTag, theChannel, theBroker);
+	if (res < 0) {
+		opserr << "ReinforcedConcreteLayerMembraneSection02::recvSelf() - the material failed in recvSelf()\n";
+		return res;
+	}
+
+	return res;
+}
+
+void ReinforcedConcreteLayerMembraneSection02::Print(OPS_Stream& s, int flag)
+{
+	s << "ReinforcedConcreteLayerMembraneSection02 tag: " << this->getTag() << endln;
+	s << "Thickness t = " << t << endln;
+	
+	s << "Reinforced Concrete section: " << endln;
+	TheRCMaterial->Print(s, flag);
+	s << endln;
+
+}
+
+Response* ReinforcedConcreteLayerMembraneSection02::setResponse(const char** argv, int argc, OPS_Stream& s)
+{
+	Response* theResponse = 0;
+	if (strcmp(argv[0], "panel_strain") == 0 || strcmp(argv[0], "Panel_strain") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection02");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "eps11");
+		s.tag("ResponseType", "eps22");
+		s.tag("ResponseType", "eps12");
+		s.endTag();
+
+		Vector data1(3);
+		data1.Zero();
+
+		theResponse = new MaterialResponse(this, 1,data1);
+
+	}
+	else if (strcmp(argv[0], "panel_stress") == 0 || strcmp(argv[0], "Panel_Stress") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection02");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "sigma11");
+		s.tag("ResponseType", "sigma22");
+		s.tag("ResponseType", "sigma12");
+		s.endTag();
+
+		Vector data2(3);
+		data2.Zero();
+
+		theResponse = new MaterialResponse(this,2,data2);
+
+	}
+	else if (strcmp(argv[0], "getBendingParameters") == 0) {
+		s.tag("SectionOutput");
+		s.attr("secType", "ReinforcedConcreteLayerMembraneSection02");
+		s.attr("secTag", this->getTag());
+		s.tag("ResponseType", "Eave");
+		s.tag("ResponseType", "Tave");
+		s.endTag();
+
+		Vector data3(2);
+		data3.Zero();
+
+		theResponse = new MaterialResponse(this, 3, data3);
+	}
+	else {
+
+		return this->SectionForceDeformation::setResponse(argv, argc, s);
+	}
+
+	return theResponse;
+}
+
+
+int ReinforcedConcreteLayerMembraneSection02::getResponse(int responseID, Information& info)
+{
+	if (responseID == 1) {
+		return info.setVector(this->getCommittedStrain());
+	}
+	else if (responseID == 2) {
+		return info.setVector(this->getCommittedStress());
+	}
+	else if (responseID == 3) {
+		return info.setVector(this->getBendingParameters());
+	}
+	else {
+		return 0;
+	}
+}
+
+// Function that returns bending parameters - added for MEFI3D by Maria Jose Nunez, UChile
+Vector ReinforcedConcreteLayerMembraneSection02::getBendingParameters(void)
+{
+	Vector input_par(2);
+
+	input_par.Zero();
+
+	input_par(0) = this->getEcAvg();
+	input_par(1) = t;
+
+	return input_par;
+}

--- a/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.h
+++ b/SRC/material/section/ReinforcedConcreteLayerMembraneSection/ReinforcedConcreteLayerMembraneSection02.h
@@ -1,0 +1,101 @@
+// Code written/implemented by: Fabian Rojas B.
+//								Maria Jose Nunez
+//
+// Created: 07/2023
+// 
+// Description: This file contains the ReinforcedConcreteLayerMembraneSection02 class definition
+// A ReinforcedConcreteLayerMembraneSection02 is a subclass of the sectionForceDeformation class and corresponds to the abstract representation
+// for the stress-strain behavior for a Reinforced Concrete Layer Membrane Element in the Finite Element Method or Structural Analysis. 
+//
+// Reference:
+// 1. Rojas, F., Anderson, J. C., Massones, L. M. (2016). A nonlinear quadrilateral layered membrane with drilling degrees of freedom for 
+// the modeling of reinforced concrete walls. Engineering Structures, 124, 521-538.
+//
+// Source: \OpenSees\SRC\material\section\ReinforcedConcreteLayerMembraneSection
+//
+// Rev: 1.0
+
+#ifndef ReinforcedConcreteLayerMembraneSection02_h
+#define ReinforcedConcreteLayerMembraneSection02_h
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <Vector.h>
+#include <Matrix.h>
+#include <ID.h>
+#include <NDMaterial.h>
+
+#include <SectionForceDeformation.h>
+
+class ReinforcedConcreteLayerMembraneSection02 : public SectionForceDeformation {
+public:
+
+	ReinforcedConcreteLayerMembraneSection02(int tag,			// section tag
+		NDMaterial* RCMaterialObject,							// reinforced concrete nDMaterial tag
+		double Thickness);										// section thickness
+
+	ReinforcedConcreteLayerMembraneSection02();
+
+	~ReinforcedConcreteLayerMembraneSection02();
+
+	int setTrialSectionDeformation(const Vector& newTrialSectionStrain);
+
+	// Public methods to obtain strain, stress, tangent and residual information
+	const Vector& getSectionDeformation(void);
+	const Vector& getStressResultant(void);
+	const Matrix& getSectionTangent(void);
+	const Matrix& getInitialTangent(void);
+
+	// Public methods to obtain a copy of section and other information
+	SectionForceDeformation* getCopy(void);
+	const char* getClassType(void) const { return "ReinforcedConcreteLayerMembrane"; };
+	const ID& getType(void);
+	int getOrder(void) const;
+	
+	// Public methods to set the state of the section
+	int commitState(void);
+	int revertToLastCommit(void);
+	int revertToStart(void);
+
+	// Public methods for output
+	int sendSelf(int commitTag, Channel& theChannel);
+	int recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker);
+
+	void Print(OPS_Stream& s, int flag);
+	Response* setResponse(const char** argv, int argc, OPS_Stream& s);
+	int getResponse(int responseID, Information& info);
+
+	// Functions used for recorders
+	const Vector& getCommittedStrain(void);
+	const Vector& getCommittedStress(void);
+
+	// Function used by MEFI3D
+	double getRho(void);															// Return the concrete density
+
+private:
+
+	// Function used by MEFI3D
+	double getEcAvg(void);															// Return the average young's modulus of RC material
+	Vector getBendingParameters(void);												// Return input parameters
+
+	// Private attributes
+	NDMaterial* TheRCMaterial;														// Pointer to a nd material
+	
+	// Committed State Variables
+	Vector CSectionStrain;															// Store the commit strains of the membrane section
+	Vector CSectionStress;															// Store the commit stress of the membrane section
+	Matrix CSectionTangent;															// Store the commit tangent of the membrane section
+	// Trial State Variables
+	Vector TSectionStrain;															// Store the trial strains of the membrane section
+	Vector TSectionStress;															// Store the trial stress of the membrane section
+	Matrix TSectionTangent;															// Store the trial tangent of the membrane section
+	Matrix InitialTangent;															// Store the initial tangent of the membrane section
+
+	double t;																		// Store the thickness of the section 
+
+	static ID array;
+};
+
+#endif // !ReinforcedConcreteLayerMembraneSection02_h

--- a/SRC/material/section/TclModelBuilderSectionCommand.cpp
+++ b/SRC/material/section/TclModelBuilderSectionCommand.cpp
@@ -111,6 +111,8 @@ extern void *OPS_DoubleMembranePlateFiberSection(void);
 extern void *OPS_Isolator2spring(void);
 extern void *OPS_ElasticMembranePlateSection(void);
 extern void *OPS_ElasticPlateSection(void);
+extern void *OPS_ReinforcedConcreteLayerMembraneSection01(void); // M. J. Nunez - UChile
+extern void *OPS_ReinforcedConcreteLayerMembraneSection02(void); // M. J. Nunez - UChile
 
 int
 TclCommand_addFiberSection (ClientData clientData, Tcl_Interp *interp, int argc,
@@ -430,6 +432,22 @@ TclModelBuilderSectionCommand (ClientData clientData, Tcl_Interp *interp, int ar
 	}
 	//end L.Jiang [SIF] added based on LayeredShellFiberSectionThermal section created by Yuli Huang & Xinzheng Lu ----
     
+    else if ((strcmp(argv[1], "ReinforcedConcreteLayerMembraneSection01") == 0) || (strcmp(argv[1], "RCLayerMembraneSection01") == 0) || (strcmp(argv[1], "RCLMS01") == 0)) {
+        void* theMat = OPS_ReinforcedConcreteLayerMembraneSection01();
+        if (theMat != 0)
+            theSection = (SectionForceDeformation*)theMat;
+        else
+            return TCL_ERROR;
+    }
+
+    else if ((strcmp(argv[1], "ReinforcedConcreteLayerMembraneSection02") == 0) || (strcmp(argv[1], "RCLayerMembraneSection02") == 0) || (strcmp(argv[1], "RCLMS02") == 0)) {
+        void* theMat = OPS_ReinforcedConcreteLayerMembraneSection02();
+        if (theMat != 0)
+            theSection = (SectionForceDeformation*)theMat;
+        else
+            return TCL_ERROR;
+    }
+
     else if (strcmp(argv[1],"Bidirectional") == 0) {
       void *theMat = OPS_Bidirectional();
       if (theMat != 0) 

--- a/Win64/proj/material/material.vcxproj
+++ b/Win64/proj/material/material.vcxproj
@@ -135,7 +135,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\..\src\damping;..\..\..\src\material\nD/UANDESmaterials;..\..\..\src\material\uniaxial\stiffness;..\..\..\src\material\uniaxial\strength;..\..\..\src\material\uniaxial\unloading;..\..\..\src\material\nD\stressDensityModel;..\..\..\src\element\UWelements;..\..\..\src\material\nD\UWmaterials;..\..\..\src\domain\pattern;..\..\..\src\coordTransformation;..\..\..\SRC\api;..\..\..\SRC\element\UP-ucsd;..\..\..\src\material\uniaxial\backbone;..\..\..\src\element\dispBeamColumnInt;..\..\..\src\material\section\integration;..\..\..\SRC\material\nD\NewTemplate3Dep;..\..\..\SRC\tagged\storage;..\..\..\SRC\domain\node;..\..\..\SRC\material\uniaxial\limitState\limitCurve;..\..\..\SRC\material\uniaxial\limitState;..\..\..\SRC\package;..\..\..\src\material\nd\cyclicSoil;..\..\..\src\damage;..\..\..\src\material\nd\FiniteDeformation\fdEvolution;..\..\..\src\material\nd\FiniteDeformation\fdFlow;..\..\..\src\material\nd\FiniteDeformation\fdYield;..\..\..\src\material\nd\finitedeformation;..\..\..\src\element\fournodequad;..\..\..\src\material\uniaxial\fedeas;..\..\..\src\material\uniaxial\drain;..\..\..\src\domain\domain;..\..\..\src\renderer;..\..\..\src\material\nD\soil;..\..\..\src\material\nD\template3dep;..\..\..\src\recorder\response;..\..\..\src\material\backbone;..\..\..\src\material\state;..\..\..\src\material\state\strength;..\..\..\src\material\state\deformation;..\..\..\src\material\state\stiffness;..\..\..\src\material\section\repres\section;..\..\..\src\material\section\repres\cell;..\..\..\src\material\section\repres\patch;..\..\..\src\material\section\repres\reinfBar;..\..\..\src\material\section\repres\reinfLayer;..\..\..\src\material\section\fiber;..\..\..\src\element\nonlinearBeamColumn\fiber;..\..\..\src\element\nonlinearBeamColumn\matrixutil;..\..\..\src\material\section;..\..\..\src\handler;..\..\..\src\material\uniaxial;..\..\..\src\material\nD;..\..\..\src\element;..\..\..\src\actor\channel;..\..\..\src\actor\objectBroker;..\..\..\src\matrix;..\..\..\src;..\..\..\src\actor\actor;..\..\..\src\tagged;..\..\..\src\modelbuilder;..\..\..\src\domain\component;..\..\..\src\material;..\..\..\src\modelbuilder\tcl;..\..\..\src\material\nd\template3dep;..\..\..\src\nDarray;..\..\..\src\material\uniaxial\py;..\..\..\src\material\uniaxial\snap;..\..\..\src\material\yieldSurface\yieldSurfaceBC;..\..\..\src\material\yieldSurface\evolution;..\..\..\src\material\yieldSurface\plasticHardeningMaterial;..\..\..\src\material\section\yieldSurface;..\..\..\src\material\nd\feap;c:\Program Files\tcl;c:\Program Files\tcl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src\material\section\ReinforcedConcreteLayerMembraneSection;..\..\..\src\material\nD\SmearedSteelDoubleLayerT2DMaterial01;..\..\..\src\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01;..\..\..\src\damping;..\..\..\src\material\nD/UANDESmaterials;..\..\..\src\material\uniaxial\stiffness;..\..\..\src\material\uniaxial\strength;..\..\..\src\material\uniaxial\unloading;..\..\..\src\material\nD\stressDensityModel;..\..\..\src\element\UWelements;..\..\..\src\material\nD\UWmaterials;..\..\..\src\domain\pattern;..\..\..\src\coordTransformation;..\..\..\SRC\api;..\..\..\SRC\element\UP-ucsd;..\..\..\src\material\uniaxial\backbone;..\..\..\src\element\dispBeamColumnInt;..\..\..\src\material\section\integration;..\..\..\SRC\material\nD\NewTemplate3Dep;..\..\..\SRC\tagged\storage;..\..\..\SRC\domain\node;..\..\..\SRC\material\uniaxial\limitState\limitCurve;..\..\..\SRC\material\uniaxial\limitState;..\..\..\SRC\package;..\..\..\src\material\nd\cyclicSoil;..\..\..\src\damage;..\..\..\src\material\nd\FiniteDeformation\fdEvolution;..\..\..\src\material\nd\FiniteDeformation\fdFlow;..\..\..\src\material\nd\FiniteDeformation\fdYield;..\..\..\src\material\nd\finitedeformation;..\..\..\src\element\fournodequad;..\..\..\src\material\uniaxial\fedeas;..\..\..\src\material\uniaxial\drain;..\..\..\src\domain\domain;..\..\..\src\renderer;..\..\..\src\material\nD\soil;..\..\..\src\material\nD\template3dep;..\..\..\src\recorder\response;..\..\..\src\material\backbone;..\..\..\src\material\state;..\..\..\src\material\state\strength;..\..\..\src\material\state\deformation;..\..\..\src\material\state\stiffness;..\..\..\src\material\section\repres\section;..\..\..\src\material\section\repres\cell;..\..\..\src\material\section\repres\patch;..\..\..\src\material\section\repres\reinfBar;..\..\..\src\material\section\repres\reinfLayer;..\..\..\src\material\section\fiber;..\..\..\src\element\nonlinearBeamColumn\fiber;..\..\..\src\element\nonlinearBeamColumn\matrixutil;..\..\..\src\material\section;..\..\..\src\handler;..\..\..\src\material\uniaxial;..\..\..\src\material\nD;..\..\..\src\element;..\..\..\src\actor\channel;..\..\..\src\actor\objectBroker;..\..\..\src\matrix;..\..\..\src;..\..\..\src\actor\actor;..\..\..\src\tagged;..\..\..\src\modelbuilder;..\..\..\src\domain\component;..\..\..\src\material;..\..\..\src\modelbuilder\tcl;..\..\..\src\material\nd\template3dep;..\..\..\src\nDarray;..\..\..\src\material\uniaxial\py;..\..\..\src\material\uniaxial\snap;..\..\..\src\material\yieldSurface\yieldSurfaceBC;..\..\..\src\material\yieldSurface\evolution;..\..\..\src\material\yieldSurface\plasticHardeningMaterial;..\..\..\src\material\section\yieldSurface;..\..\..\src\material\nd\feap;c:\Program Files\tcl;c:\Program Files\tcl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_TCL85;_LIMITSTATEMATERIAL;_NO_NEW_RESTREPO;_HAVE_PSUMAT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -210,6 +210,7 @@
     <ClCompile Include="..\..\..\SRC\material\nD\J2ThreeDimensionalThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\LinearCap.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\matCMM\MaterialCMM.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01\OrthotropicRotatingAngleConcreteT2DMaterial01.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\PlaneStressLayeredMaterial.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\PlaneStressRebarMaterial.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\PlaneStressSimplifiedJ2.cpp" />
@@ -221,6 +222,7 @@
     <ClCompile Include="..\..\..\SRC\material\nD\PlateFromPlaneStressMaterialThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\PlateRebarMaterial.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\PlateRebarMaterialThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01\SmearedSteelDoubleLayerT2DMaterial01.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\soil\PressureDependMultiYield03.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\stressDensityModel\stressDensity.cpp" />
     <ClCompile Include="..\..\..\SRC\material\nD\UANDESmaterials\SAniSandMS.cpp" />
@@ -253,6 +255,8 @@
     <ClCompile Include="..\..\..\SRC\material\section\LayeredShellFiberSectionThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\material\section\MembranePlateFiberSectionThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\material\section\NDFiberSectionWarping2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection01.cpp" />
+    <ClCompile Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection02.cpp" />
     <ClCompile Include="..\..\..\SRC\material\section\TimoshenkoSection3d.cpp" />
     <ClCompile Include="..\..\..\SRC\material\section\WFFiberSection2d.cpp" />
     <ClCompile Include="..\..\..\SRC\material\section\WSection2d.cpp" />
@@ -674,6 +678,7 @@
     <ClInclude Include="..\..\..\SRC\material\nD\J2ThreeDimensionalThermal.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\LinearCap.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\matCMM\MaterialCMM.h" />
+    <ClInclude Include="..\..\..\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01\OrthotropicRotatingAngleConcreteT2DMaterial01.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\PlaneStressLayeredMaterial.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\PlaneStressRebarMaterial.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\PlaneStressSimplifiedJ2.h" />
@@ -685,6 +690,7 @@
     <ClInclude Include="..\..\..\SRC\material\nD\PlateFromPlaneStressMaterialThermal.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\PlateRebarMaterial.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\PlateRebarMaterialThermal.h" />
+    <ClInclude Include="..\..\..\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01\SmearedSteelDoubleLayerT2DMaterial01.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\soil\PressureDependMultiYield03.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\stressDensityModel\stressDensity.h" />
     <ClInclude Include="..\..\..\SRC\material\nD\UVCmultiaxial.h" />
@@ -713,6 +719,8 @@
     <ClInclude Include="..\..\..\SRC\material\section\LayeredShellFiberSectionThermal.h" />
     <ClInclude Include="..\..\..\SRC\material\section\MembranePlateFiberSectionThermal.h" />
     <ClInclude Include="..\..\..\SRC\material\section\NDFiberSectionWarping2d.h" />
+    <ClInclude Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection01.h" />
+    <ClInclude Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection02.h" />
     <ClInclude Include="..\..\..\SRC\material\section\TimoshenkoSection3d.h" />
     <ClInclude Include="..\..\..\SRC\material\section\WFFiberSection2d.h" />
     <ClInclude Include="..\..\..\SRC\material\section\WSection2d.h" />

--- a/Win64/proj/material/material.vcxproj.filters
+++ b/Win64/proj/material/material.vcxproj.filters
@@ -110,6 +110,15 @@
     <Filter Include="nD\UWmaterials">
       <UniqueIdentifier>{be456511-844e-4f02-b923-14685753222d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="nD\OrthotropicRotatingAngleConcreteT2DMaterial01">
+      <UniqueIdentifier>{a05c9bf6-42c1-4381-a867-44ccee02fc48}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="nD\SmearedSteelDoubleLayerT2DMaterial01">
+      <UniqueIdentifier>{fd8d83ef-3398-4382-a13d-a44c90db022b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="section\ReinforcedConcreteLayerMembraneSection">
+      <UniqueIdentifier>{a0bc02f9-c404-4c54-9cbe-323f4389efc2}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\AxialSp.cpp">
@@ -1499,6 +1508,18 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\CreepMaterial.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01\OrthotropicRotatingAngleConcreteT2DMaterial01.cpp">
+      <Filter>nD\OrthotropicRotatingAngleConcreteT2DMaterial01</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01\SmearedSteelDoubleLayerT2DMaterial01.cpp">
+      <Filter>nD\SmearedSteelDoubleLayerT2DMaterial01</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection01.cpp">
+      <Filter>section\ReinforcedConcreteLayerMembraneSection</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection02.cpp">
+      <Filter>section\ReinforcedConcreteLayerMembraneSection</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\AxialSp.h">
@@ -2743,6 +2764,18 @@
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\TDConcreteNL.h">
       <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\nD\OrthotropicRotatingAngleConcreteT2DMaterial01\OrthotropicRotatingAngleConcreteT2DMaterial01.h">
+      <Filter>nD\OrthotropicRotatingAngleConcreteT2DMaterial01</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\nD\SmearedSteelDoubleLayerT2DMaterial01\SmearedSteelDoubleLayerT2DMaterial01.h">
+      <Filter>nD\SmearedSteelDoubleLayerT2DMaterial01</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection01.h">
+      <Filter>section\ReinforcedConcreteLayerMembraneSection</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\section\ReinforcedConcreteLayerMembraneSection\ReinforcedConcreteLayerMembraneSection02.h">
+      <Filter>section\ReinforcedConcreteLayerMembraneSection</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds the following nDmaterials and sections:

- OrthotropicRotatingAngleConcreteT2DMaterial01
- SmearedSteelDoubleLayerT2DMaterial01
- ReinforcedConcreteLayerMembraneSection01
- ReinforcedConcreteLayerMembraneSection02

The RCLMS01 and RCLMS02 correspond to abstract representations of the stress-strain behavior for a reinforced concrete layered membrane section. The first section works in conjunction with nDMaterials OrthotropicRotatingAngleConcreteT2DMaterial01 and SmearedSteelDoubleLayerT2DMaterial01, which represent a smeared orthotropic concrete layer with a rotating angle formulation and a stiffness tangent approach, and a double smeared steel reinforcement layer, respectively. RCLMS02 is included in this PR to allow the use of the nDMaterial FSAM as an RC layer.

Both sections are intended to be used in a MEFI element (https://github.com/OpenSees/OpenSees/pull/1315).

More information about material constitutive models and layered section formulation and validation can be found here:
https://www.sciencedirect.com/science/article/pii/S0141029616302954

