### PR TITLE
Missing include in `HystereticSMMaterial.cpp`

### DIFF
--- a/SRC/material/uniaxial/HystereticSMMaterial.cpp
+++ b/SRC/material/uniaxial/HystereticSMMaterial.cpp
@@ -43,6 +43,7 @@
 #include <math.h>
 #include <float.h>
 #include <vector>
+#include <map>
 
 #include <HystereticSMMaterial.h>
 #include <Channel.h>


### PR DESCRIPTION
This material did not compile for me, `map` was not included.