### PR TITLE
`LineSearch` leak in `NewtonLineSearch` ?

### DIFF
--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
@@ -65,6 +65,8 @@ NewtonLineSearch::~NewtonLineSearch()
 {
   if (theOtherTest != 0)
     delete theOtherTest;
+  if (theLineSearch != 0)
+    delete theLineSearch;
 }
 
 int


### PR DESCRIPTION
It looks like the `NewtonLineSearch` algorithm is leaking its line search but I'm not sure. With the proposed change, the leak is gone and things seem to work well.