### PR TITLE
Adding files for ModElasticBeam3D to VS solution.

### DIFF
--- a/Win32/proj/element/element.vcxproj
+++ b/Win32/proj/element/element.vcxproj
@@ -119,6 +119,7 @@
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\Element.cpp" />
@@ -143,7 +144,7 @@
     <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.cpp" />
     <ClCompile Include="..\..\..\SRC\element\mvlem\MVLEM_3D.cpp" />
     <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.cpp" />
-	<ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp" />
     <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.cpp" />
     <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.cpp" />
     <ClCompile Include="..\..\..\SRC\element\PFEMElement\HigherOrder.cpp" />
@@ -177,7 +178,6 @@
     <ClCompile Include="..\..\..\SRC\element\PML\PML2D_5.cpp" />
     <ClCompile Include="..\..\..\SRC\element\PML\PML2D_12.cpp" />
     <ClCompile Include="..\..\..\SRC\element\PML\PML2DVISCOUS.cpp" />
-
     <ClCompile Include="..\..\..\SRC\element\RockingBC\RockingBC.cpp" />
     <ClCompile Include="..\..\..\SRC\element\shell\ShellANDeS.cpp" />
     <ClCompile Include="..\..\..\SRC\element\shell\ShellDKGT.cpp" />
@@ -403,6 +403,7 @@
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.h" />
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h" />
     <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.h" />
     <ClInclude Include="..\..\..\SRC\element\Element.h" />
@@ -426,7 +427,7 @@
     <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.h" />
     <ClInclude Include="..\..\..\SRC\element\mvlem\MVLEM_3D.h" />
     <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.h" />
-	<ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h" />
     <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.h" />
     <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.h" />
     <ClInclude Include="..\..\..\SRC\element\PFEMElement\HigherOrder.h" />

--- a/Win32/proj/element/element.vcxproj.filters
+++ b/Win32/proj/element/element.vcxproj.filters
@@ -710,7 +710,7 @@
     <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.cpp">
       <Filter>mvlem</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp">
+    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp">
       <Filter>mvlem</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\componentElement\ComponentElement2d.cpp">
@@ -951,7 +951,7 @@
       <Filter>PML</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\PML\PML2D_3.cpp">
-      <Filter>PML</Filter>  
+      <Filter>PML</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\PML\PML2D_5.cpp">
       <Filter>PML</Filter>
@@ -964,6 +964,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI.cpp">
       <Filter>mvlem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp">
+      <Filter>elasticBeamColumn</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1474,7 +1477,7 @@
     <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.h">
       <Filter>mvlem</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h">
+    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h">
       <Filter>mvlem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\componentElement\ComponentElement2d.h">
@@ -1719,7 +1722,7 @@
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\PML\PML2D_5.h">
       <Filter>PML</Filter>
-    </ClInclude>    
+    </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\PML\PML2D_12.h">
       <Filter>PML</Filter>
     </ClInclude>
@@ -1728,6 +1731,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI.h">
       <Filter>mvlem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h">
+      <Filter>elasticBeamColumn</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Win64/proj/element/element.vcxproj
+++ b/Win64/proj/element/element.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp" />
     <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\Element.cpp" />
@@ -519,6 +520,7 @@
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h" />
     <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h" />
     <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h" />
     <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.h" />
     <ClInclude Include="..\..\..\SRC\element\Element.h" />

--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -1058,6 +1058,9 @@
     <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp">
       <Filter>mvlem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp">
+      <Filter>elasticBeamColumn</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\SRC\element\Element.h">
@@ -1798,9 +1801,6 @@
     <ClInclude Include="..\..\..\SRC\element\PML\PML2D_5.h">
       <Filter>PML</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_7.h">
-      <Filter>PML</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\PML\PML2DVISCOUS.h">
       <Filter>PML</Filter>
     </ClInclude>
@@ -1857,6 +1857,12 @@
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h">
       <Filter>mvlem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_12.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h">
+      <Filter>elasticBeamColumn</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request performs a modification for the Visual Studio solution. Specifically, it adds the existing files for the `ModElasticBeam3D` element to the 'element -> elasticBeamColumn' inside the solution files (both 32 and 64 bits).

This addition is necessary because otherwise 'LNK2019' type of errors appear in Visual Studio when compiling the solution.

The `ModElasticBeam3D` element was added by @ioannis-vm via pull request #1346. 

