### PR TITLE
Correct term in coefficient series expansion for corotational shells.

### DIFF
--- a/SRC/element/shell/ASDEICR.h
+++ b/SRC/element/shell/ASDEICR.h
@@ -378,13 +378,14 @@ public:
 
 			if (angle >= 2.0 * M_PI)
 				angle = std::fmod(angle, 2.0 * M_PI);
-
+			
+                        // compute eta from Felippa et al 2005, Equation (101)
 			double eta;
 			if (angle < 0.05) {
 				double angle2 = angle * angle;
 				double angle4 = angle2 * angle2;
 				double angle6 = angle4 * angle2;
-				eta = 1.0 / 12.0 + 1.0 / 270.0 * angle2 + 1.0 / 30240.0 * angle4 + 1.0 / 1209600.0 * angle6;
+				eta = 1.0 / 12.0 + 1.0 / 720.0 * angle2 + 1.0 / 30240.0 * angle4 + 1.0 / 1209600.0 * angle6;
 			}
 			else {
 				eta = (1.0 - 0.5 * angle * std::tan(0.5 * M_PI - 0.5 * angle)) / (angle * angle);
@@ -447,7 +448,9 @@ public:
 			double eta;
 			double mu;
 			if (angle < 0.05) {
-				eta = 1.0 / 12.0 + angle2 / 270.0 + angle4 / 30240.0 + angle6 / 1209600.0;
+				// Equation (101) from Felippa et al 2005.
+				eta = 1.0 / 12.0 + angle2 / 720.0 + angle4 / 30240.0 + angle6 / 1209600.0;
+				// Equation (103) from Felippa et al 2005.
 				mu = 1.0 / 360.0 + angle2 / 7560.0 + angle4 / 201600.0 + angle6 / 5987520.0;
 			}
 			else {


### PR DESCRIPTION
It appears the factor $\frac{1}{270}$ in the modified lines is wrong. I believe the relevant expression is Equation (101) in https://doi.org/10.1016/j.cma.2004.07.035:

$$
\begin{aligned}
\mathbf{H}(\boldsymbol{\theta}) & =\frac{\partial \boldsymbol{\theta}}{\partial \boldsymbol{\omega}}=\mathbf{I}-\frac{1}{2} \boldsymbol{\Theta}+\eta \boldsymbol{\Theta}^2 \quad \text { with } \eta=\frac{1-\frac{1}{2} \theta \cot \left(\frac{1}{2} \theta\right)}{\theta^2}  =\frac{1}{12}+\frac{1}{720} \theta^2+\frac{1}{30240} \theta^4+\frac{1}{1209600} \theta^6+\cdots
\end{aligned}
$$

Here is a short Python script that shows using $\frac{1}{720}$ is indeed closer to the closed form expression:
```python
import numpy as np
from numpy import tan

cot = lambda x: 1/tan(x)

def test(theta):
  closed_a = (1-0.5*theta*cot(0.5*theta))/theta**2;
  closed_b = (1.0 - 0.5 * theta * tan(0.5 * np.pi - 0.5 * theta)) / (theta * theta)
  
  # expression used in pull request:
  series_a = 1/12 + theta**2/720 + theta**4/30240 + theta**6/1209600;
  # expression currently in use:
  series_b = 1/12 + theta**2/270 + theta**4/30240 + theta**6/1209600;
  
  print(f"{closed_a - series_a = }")
  print(f"{closed_a - series_b = }")

  print(f"{closed_b - series_a = }")
  print(f"{closed_b - series_b = }")


test(0.1)
# closed_a - series_a = 1.096345236817342e-15
# closed_a - series_b = -2.3148148147064673e-05
# closed_b - series_a = 2.1203871991559708e-13
# closed_b - series_b = -2.31481479361223e-05

test(0.01)
# closed_a - series_a = 2.267352972040726e-13
# closed_a - series_b = -2.3148125474770076e-07
# closed_b - series_a = -9.081155272205876e-11
# closed_b - series_b = -2.3157229303572002e-07
```