### PR TITLE
TriSurfaceLoad - add to Python interpreter, update normalization

### DIFF
--- a/SRC/element/surfaceLoad/TriSurfaceLoad.cpp
+++ b/SRC/element/surfaceLoad/TriSurfaceLoad.cpp
@@ -244,7 +244,7 @@ TriSurfaceLoad::UpdateBase(double Xi, double Eta)
 
     // Normalize
     // double norm = myNhat.Norm();
-    myNhat = myNhat / 2;
+    myNhat = myNhat / 3;
 
     return 0;
 }

--- a/SRC/interpreter/OpenSeesElementCommands.cpp
+++ b/SRC/interpreter/OpenSeesElementCommands.cpp
@@ -130,6 +130,7 @@ void* OPS_SSPquadUP();
 void* OPS_SSPbrick();
 void* OPS_SSPbrickUP();
 void* OPS_SurfaceLoad();
+void* OPS_TriSurfaceLoad();
 void* OPS_TPB1D();
 void* OPS_ElasticTubularJoint();
 void* OPS_FourNodeQuad3d();
@@ -758,6 +759,7 @@ namespace {
 	functionMap.insert(std::make_pair("SSPbrickUP", &OPS_SSPbrickUP));
 	functionMap.insert(std::make_pair("SSPBrickUP", &OPS_SSPbrickUP));
 	functionMap.insert(std::make_pair("SurfaceLoad", &OPS_SurfaceLoad));
+	functionMap.insert(std::make_pair("TriSurfaceLoad", &OPS_TriSurfaceLoad));
 	functionMap.insert(std::make_pair("elasticBeamColumn", &OPS_ElasticBeam));
 	functionMap.insert(std::make_pair("elasticBeamColumnWarping", &OPS_ElasticBeamWarping3d));
 	functionMap.insert(std::make_pair("dispBeamColumnWarping", &OPS_DispBeamColumnWarping3d));	


### PR DESCRIPTION
This analysis with one `TriSurfaceLoad` should give reactions that equal pressure * element area.

Am I missing something, @jaabell, or was there an issue when you copied `SurfaceLoad` to `TriSurfaceLoad`?

```python
ops.wipe()
ops.model('basic','-ndm',3,'-ndf',3)

ops.node(1,0,0,0); ops.fix(1,1,1,1)
ops.node(2,1,-1,0); ops.fix(2,1,1,1)
ops.node(3,1,1,0); ops.fix(3,1,1,1)

p = 1

ops.element('TriSurfaceLoad',3,1,2,3,p)

ops.system('UmfPack')
ops.analysis('Static','-noWarnings')

ops.analyze(1)
ops.reactions()

for nd in ops.getNodeTags():
    print(ops.nodeReaction(nd))
```