### PR TITLE
Bugfix a Python error by adding TriSurfaceLoad to interpreter

### DIFF
--- a/SRC/interpreter/OpenSeesElementCommands.cpp
+++ b/SRC/interpreter/OpenSeesElementCommands.cpp
@@ -130,6 +130,7 @@ void* OPS_SSPquadUP();
 void* OPS_SSPbrick();
 void* OPS_SSPbrickUP();
 void* OPS_SurfaceLoad();
+void* OPS_TriSurfaceLoad();
 void* OPS_TPB1D();
 void* OPS_ElasticTubularJoint();
 void* OPS_FourNodeQuad3d();
@@ -758,6 +759,7 @@ namespace {
 	functionMap.insert(std::make_pair("SSPbrickUP", &OPS_SSPbrickUP));
 	functionMap.insert(std::make_pair("SSPBrickUP", &OPS_SSPbrickUP));
 	functionMap.insert(std::make_pair("SurfaceLoad", &OPS_SurfaceLoad));
+	functionMap.insert(std::make_pair("TriSurfaceLoad", &OPS_TriSurfaceLoad));
 	functionMap.insert(std::make_pair("elasticBeamColumn", &OPS_ElasticBeam));
 	functionMap.insert(std::make_pair("elasticBeamColumnWarping", &OPS_ElasticBeamWarping3d));
 	functionMap.insert(std::make_pair("dispBeamColumnWarping", &OPS_DispBeamColumnWarping3d));	

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -510,6 +510,31 @@ int OPS_ElementalLoad()
 	}
 	return 0;
     }
+
+    else if (strcmp(type,"-triSurfaceLoad") == 0 || strcmp(type,"-TriSurfaceLoad") == 0) {
+
+	for (int i=0; i<theEleTags.Size(); i++) {
+	    theLoad = new SurfaceLoader(eleLoadTag, theEleTags(i));
+
+	    if (theLoad == 0) {
+		opserr << "WARNING eleLoad - out of memory creating load of type " << type;
+		return -1;
+	    }
+
+	    // get the current pattern tag if no tag given in i/p
+	    int loadPatternTag = theActiveLoadPattern->getTag();
+
+	    // add the load to the domain
+	    if (theDomain->addElementalLoad(theLoad, loadPatternTag) == false) {
+		opserr << "WARNING eleLoad - could not add following load to domain:\n ";
+		opserr << theLoad;
+		delete theLoad;
+		return -1;
+	    }
+	    eleLoadTag++;
+	}
+	return 0;
+    }
 // Added: C.McGann, U.Washington
     else if ((strcmp(type,"-selfWeight") == 0) || (strcmp(type,"-SelfWeight") == 0)) {
 	// xf, yf, zf


### PR DESCRIPTION
This PR fixes the following error when using TriSurfaceLoad element in OpenSeesPy:

```
WARNING element type TriSurfaceLoad is unknown
Traceback (most recent call last):
  File "<string>", line 17, in __PYTHON_EL_eval
    ops.element('TriSurfaceLoad', 3, 1, 2, 3, p)
```
