### PR TITLE
Fixing getCopy() in SLModel

### DIFF
--- a/SRC/material/uniaxial/SLModel.cpp
+++ b/SRC/material/uniaxial/SLModel.cpp
@@ -918,7 +918,7 @@ SLModel::revertToStart(void)
 UniaxialMaterial *
 SLModel::getCopy(void)
 {
-	SLModel *theCopy = new SLModel(this->getTag(), Dt, E, sgm_ini, c, gamma, q, beta, sigmaCDivSigmaY, epsiCDivEpsiY, Ed1DivE, Ed2DivE, sigmaDMDivSigmaC, aSigma, aE, lambda1Degrad, cDegrad);
+	SLModel *theCopy = new SLModel(this->getTag(), Dt, E, sgm_ini, c, gamma, q, beta, sigmaC, epsiC, Ed1, Ed2, sigmaDM, aSigma, aE, lambda1Degrad, cDegrad);
 
 	//Fixed Model parameters: need to change according to material properties
 	theCopy -> status = status;


### PR DESCRIPTION
@Diegohere Please review. Also, how in the world was this version of the model - with such a major error in `getCopy()` - verified, validated, and used to generate (presumably) and/or compare with publishable results? I do not understand.