### PR TITLE
Build workflow for Mac is fixed.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -14,58 +14,58 @@ on:
   workflow_dispatch:
 
 jobs:
-#   build-ubuntu:
-#     name: Ubuntu bundled build
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 30
-#     steps:
-#     - uses: actions/checkout@v2
-#     - uses: actions/setup-python@v4
-#       with:
-#         python-version: "3.11"
+  build-ubuntu:
+    name: Ubuntu bundled build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
 
-#     - name: Install conan
-#       run: python3 -m pip install conan==1.60.0
+    - name: Install conan
+      run: python3 -m pip install conan==1.60.0
 
-#     - name: Detect Conan Defaults
-#       run: |
-#         conan --version
+    - name: Detect Conan Defaults
+      run: |
+        conan --version
 
-#     - name: Build
-#       run: |
-#         mkdir build
-#         cd build
-#         conan install .. --build missing
-#         cmake ..
-#         cmake --build . -j8
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        conan install .. --build missing
+        cmake ..
+        cmake --build . -j8
 
-#         #- name: Verification
-#         #  run: |
-#         #    cd ./EXAMPLES/verification/ && ../../build/OpenSeesTcl runVerificationSuite.tcl
-#     - name: Build OpenSeesPy
-#       run: |
-#         cd ./build
-#         cmake ..
-#         make -j 4
-#         make OpenSeesPy
-#         mkdir fake_folder
-#     - name: Rename OpenSeesPy
-#       run: |
-#         cd ./build
-#         mv lib/OpenSeesPy.so lib/opensees.so
+        #- name: Verification
+        #  run: |
+        #    cd ./EXAMPLES/verification/ && ../../build/OpenSeesTcl runVerificationSuite.tcl
+    - name: Build OpenSeesPy
+      run: |
+        cd ./build
+        cmake ..
+        make -j 4
+        make OpenSeesPy
+        mkdir fake_folder
+    - name: Rename OpenSeesPy
+      run: |
+        cd ./build
+        mv lib/OpenSeesPy.so lib/opensees.so
 
-# # Simple sanity test
-#     - name: Verification OpenSeesPySP
-#       run: |
-#         cd ./build
-#         cd ../EXAMPLES/ExamplePython/
-#         export PYTHONPATH="../../build/lib/"
-#         python3 -c "import sys; print(sys.path)"
-#         python3 example_variable_analysis.py
-# #        # Simple MP sanity test
-# #        - name: Verification OpenSeesPyMP
-# #          run: |
-# #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
+# Simple sanity test
+    - name: Verification OpenSeesPySP
+      run: |
+        cd ./build
+        cd ../EXAMPLES/ExamplePython/
+        export PYTHONPATH="../../build/lib/"
+        python3 -c "import sys; print(sys.path)"
+        python3 example_variable_analysis.py
+#        # Simple MP sanity test
+#        - name: Verification OpenSeesPyMP
+#          run: |
+#            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
   build-mac:
     name: Mac Build
     runs-on: macos-latest

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -86,7 +86,8 @@ jobs:
          brew install open-mpi
          brew install scalapack
          git submodule update
-         ls -all /usr/local/include
+         ls -all /usr/local
+         ls -all /opt/homebrew
          ln -sf /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
       - name: Build
         run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -68,7 +68,7 @@ jobs:
 # #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
   build-mac:
     name: Mac Build
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -82,8 +82,8 @@ jobs:
          brew upgrade
          # brew install gcc
          # brew install gfortran
-         brew link --overwrite gcc
-         ln -s /usr/local/bin/gfortran-13 /usr/local/bin/gfortran
+         # brew link --overwrite gcc
+         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
          ls -all /usr/local/bin
          brew install hdf5
          brew install open-mpi

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
 
   pull_request:
     branches: [master]
@@ -14,58 +14,58 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-ubuntu:
-    name: Ubuntu bundled build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
+#   build-ubuntu:
+#     name: Ubuntu bundled build
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 30
+#     steps:
+#     - uses: actions/checkout@v2
+#     - uses: actions/setup-python@v4
+#       with:
+#         python-version: "3.11"
 
-    - name: Install conan
-      run: python3 -m pip install conan==1.60.0
+#     - name: Install conan
+#       run: python3 -m pip install conan==1.60.0
 
-    - name: Detect Conan Defaults
-      run: |
-        conan --version
+#     - name: Detect Conan Defaults
+#       run: |
+#         conan --version
 
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-        conan install .. --build missing
-        cmake ..
-        cmake --build . -j8
+#     - name: Build
+#       run: |
+#         mkdir build
+#         cd build
+#         conan install .. --build missing
+#         cmake ..
+#         cmake --build . -j8
 
-        #- name: Verification
-        #  run: |
-        #    cd ./EXAMPLES/verification/ && ../../build/OpenSeesTcl runVerificationSuite.tcl
-    - name: Build OpenSeesPy
-      run: |
-        cd ./build
-        cmake ..
-        make -j 4
-        make OpenSeesPy
-        mkdir fake_folder
-    - name: Rename OpenSeesPy
-      run: |
-        cd ./build
-        mv lib/OpenSeesPy.so lib/opensees.so
+#         #- name: Verification
+#         #  run: |
+#         #    cd ./EXAMPLES/verification/ && ../../build/OpenSeesTcl runVerificationSuite.tcl
+#     - name: Build OpenSeesPy
+#       run: |
+#         cd ./build
+#         cmake ..
+#         make -j 4
+#         make OpenSeesPy
+#         mkdir fake_folder
+#     - name: Rename OpenSeesPy
+#       run: |
+#         cd ./build
+#         mv lib/OpenSeesPy.so lib/opensees.so
 
-# Simple sanity test
-    - name: Verification OpenSeesPySP
-      run: |
-        cd ./build
-        cd ../EXAMPLES/ExamplePython/
-        export PYTHONPATH="../../build/lib/"
-        python3 -c "import sys; print(sys.path)"
-        python3 example_variable_analysis.py
-#        # Simple MP sanity test
-#        - name: Verification OpenSeesPyMP
-#          run: |
-#            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
+# # Simple sanity test
+#     - name: Verification OpenSeesPySP
+#       run: |
+#         cd ./build
+#         cd ../EXAMPLES/ExamplePython/
+#         export PYTHONPATH="../../build/lib/"
+#         python3 -c "import sys; print(sys.path)"
+#         python3 example_variable_analysis.py
+# #        # Simple MP sanity test
+# #        - name: Verification OpenSeesPyMP
+# #          run: |
+# #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
   build-mac:
     name: Mac Build
     runs-on: macos-latest
@@ -81,6 +81,7 @@ jobs:
         run: |
          brew install gcc
          brew install gfortran
+         ls /usr/local/bin
          ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
          brew install hdf5
          brew install open-mpi

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -82,6 +82,7 @@ jobs:
          brew upgrade
          # brew install gcc
          # brew install gfortran
+         brew link --overwrite gcc
          ln -s /usr/local/bin/gfortran-13 /usr/local/bin/gfortran
          ls -all /usr/local/bin
          brew install hdf5

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,9 +85,6 @@ jobs:
          brew install hdf5
          brew install open-mpi
          brew install scalapack
-         ls -all /usr/local/bin
-         ls -all /opt/homebrew/bin
-         git submodule init
          git submodule update 
       - name: Build
         run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
 
   pull_request:
     branches: [master]

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,7 +85,8 @@ jobs:
          brew install hdf5
          brew install open-mpi
          brew install scalapack
-         git submodule update 
+         git submodule update
+         sudo ln -s /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
          ln -s /opt/homebrew/bin/gcc-13 /usr/local/bin/gcc
          ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
+         brew install eigen
          brew install hdf5
          brew install open-mpi
          brew install scalapack

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: "3.11"
       - name: Install Library
         run: |
-         ln - s /opt/homebrew/bin/gcc-13 /usr/local/bin/gcc
+         ln -s /opt/homebrew/bin/gcc-13 /usr/local/bin/gcc
          ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
          brew install hdf5
          brew install open-mpi

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Library
+        shell: zsh {0}
         run: |
          where gfortran-13
          where gcc-13

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,7 +85,6 @@ jobs:
          brew install hdf5
          brew install open-mpi
          brew install scalapack
-         git submodule update
          sudo ln -sf /opt/homebrew/include/eigen3/Eigen /opt/homebrew/include/Eigen
       - name: Build
         run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -68,7 +68,7 @@ jobs:
 # #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
   build-mac:
     name: Mac Build
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       # - uses: actions/checkout@v3

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -79,13 +79,14 @@ jobs:
           python-version: "3.11"
       - name: Install Library
         run: |
-         brew install gcc
+         brew update --auto-update
+         # brew install gcc
          brew install gfortran
-         ls /usr/local/bin
-         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-         brew install hdf5
-         brew install open-mpi
-         brew install scalapack
+         ls -all /usr/local/bin
+         # ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+         # brew install hdf5
+         # brew install open-mpi
+         # brew install scalapack
       - name: Build
         run: |
           mkdir build
@@ -94,12 +95,12 @@ jobs:
           cmake --build . --target OpenSees -j8
           cmake --build . --target OpenSeesPy -j8
           mv ./OpenSeesPy.dylib ./opensees.so
-      - name: Verification OpenSeesPySP
-        run: |
-          cd ./EXAMPLES/ExamplePython/
-          export PYTHONPATH="../../build/"
-          python3 -c "import sys; print(sys.path)"
-          python3 example_variable_analysis.py
+      # - name: Verification OpenSeesPySP
+      #   run: |
+      #     cd ./EXAMPLES/ExamplePython/
+      #     export PYTHONPATH="../../build/"
+      #     python3 -c "import sys; print(sys.path)"
+      #     python3 example_variable_analysis.py
 # Not building on Windows until we can figure out how to use Fortran
 # with Github Actions
     #  build-win32:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -86,7 +86,7 @@ jobs:
          brew install open-mpi
          brew install scalapack
          git submodule update
-         sudo ln -s /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
+         sudo ln -sf /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Install Library
         run: |
          brew upgrade
-         brew install gcc
-         brew install gfortran
+         # brew install gcc
+         # brew install gfortran
+         ln -s /usr/local/bin/gfortran-13 /usr/local/bin/gfortran
          ls -all /usr/local/bin
-         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
          brew install hdf5
          brew install open-mpi
          brew install scalapack

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -71,15 +71,15 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+      # - uses: actions/checkout@v3
+      #   with:
+      #     fetch-depth: 0
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: "3.11"
       - name: Install Library
         run: |
-         brew update --auto-update
+         brew upgrade
          # brew install gcc
          brew install gfortran
          ls -all /usr/local/bin

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,6 +85,8 @@ jobs:
          brew install hdf5
          brew install open-mpi
          brew install scalapack
+         ls -all /usr/local/bin
+         ls -all /opt/homebrew/bin
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -86,9 +86,7 @@ jobs:
          brew install open-mpi
          brew install scalapack
          git submodule update
-         ls -all /usr/local
-         ls -all /opt/homebrew
-         ln -sf /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
+         sudo ln -sf /opt/homebrew/include/eigen3/Eigen /opt/homebrew/include/Eigen
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -86,7 +86,8 @@ jobs:
          brew install open-mpi
          brew install scalapack
          git submodule update
-         sudo ln -sf /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
+         ls -all /usr/local/include
+         ln -sf /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -71,22 +71,22 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     steps:
-      # - uses: actions/checkout@v3
-      #   with:
-      #     fetch-depth: 0
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: "3.11"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
       - name: Install Library
         run: |
          brew upgrade
-         # brew install gcc
+         brew install gcc
          brew install gfortran
          ls -all /usr/local/bin
-         # ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-         # brew install hdf5
-         # brew install open-mpi
-         # brew install scalapack
+         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+         brew install hdf5
+         brew install open-mpi
+         brew install scalapack
       - name: Build
         run: |
           mkdir build
@@ -95,30 +95,9 @@ jobs:
           cmake --build . --target OpenSees -j8
           cmake --build . --target OpenSeesPy -j8
           mv ./OpenSeesPy.dylib ./opensees.so
-      # - name: Verification OpenSeesPySP
-      #   run: |
-      #     cd ./EXAMPLES/ExamplePython/
-      #     export PYTHONPATH="../../build/"
-      #     python3 -c "import sys; print(sys.path)"
-      #     python3 example_variable_analysis.py
-# Not building on Windows until we can figure out how to use Fortran
-# with Github Actions
-    #  build-win32:
-    #    name: Build on Windows
-    #    runs-on: [windows-latest]
-    #    steps:
-    #    - name: Checkout sources
-    #      uses: actions/checkout@v2
-    #      with: {ref: cmake-build}
-    #
-    #    - name: Install Conan
-    #      uses: turtlebrowser/get-conan@main
-    #
-    #    - name: Build
-    #      run: |
-    #        mkdir build
-    #        cd build
-    #        cmake ..
-    #        cmake --build . --target OpenSeesTcl -j5
-
-
+      - name: Verification OpenSeesPySP
+        run: |
+          cd ./EXAMPLES/ExamplePython/
+          export PYTHONPATH="../../build/"
+          python3 -c "import sys; print(sys.path)"
+          python3 example_variable_analysis.py

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -87,6 +87,8 @@ jobs:
          brew install scalapack
          ls -all /usr/local/bin
          ls -all /opt/homebrew/bin
+         git submodule init
+         git submodule update 
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -79,15 +79,17 @@ jobs:
           python-version: "3.11"
       - name: Install Library
         run: |
-         brew upgrade
+         where gfortran-13
+         where gcc-13
+         # brew upgrade
          # brew install gcc
          # brew install gfortran
          # brew link --overwrite gcc
-         ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-         ls -all /usr/local/bin
-         brew install hdf5
-         brew install open-mpi
-         brew install scalapack
+         # ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+         # ls -all /usr/local/bin
+         # brew install hdf5
+         # brew install open-mpi
+         # brew install scalapack
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -78,19 +78,12 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Library
-        shell: zsh {0}
         run: |
-         where gfortran-13
-         where gcc-13
-         # brew upgrade
-         # brew install gcc
-         # brew install gfortran
-         # brew link --overwrite gcc
-         # ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-         # ls -all /usr/local/bin
-         # brew install hdf5
-         # brew install open-mpi
-         # brew install scalapack
+         ln - s /opt/homebrew/bin/gcc-13 /usr/local/bin/gcc
+         ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
+         brew install hdf5
+         brew install open-mpi
+         brew install scalapack
       - name: Build
         run: |
           mkdir build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
@@ -71,10 +71,10 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install Library

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -68,7 +68,7 @@ jobs:
 # #            mpiexec -np 2 python ../EXAMPLES/ExamplePython/example_mpi_paralleltruss_explicit.py
   build-mac:
     name: Mac Build
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Build workflow for Mac has been failing through a month. There may be two reasons for failures. 1. Github-hosted runner has been updated and locations of binary files are changed. 2. New material added which requires eigen3.
Then, Eigen3 installation via Homebrew is added and links to binary or include files are updated. Besides, versions of actions/checkout and actions/setup-python are also updated because older have yielded warning "Node.js 16 actions are deprecated."
