### PR TITLE
Trapezoidal beam loads for 3d ForceBeamColumn element

### DIFF
--- a/SRC/domain/load/Beam3dPartialUniformLoad.cpp
+++ b/SRC/domain/load/Beam3dPartialUniformLoad.cpp
@@ -17,7 +17,7 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+                                                                          
 // $Revision$
 // $Date$
 // $Source$
@@ -30,19 +30,19 @@
 #include <Information.h>
 #include <Parameter.h>
 
-Vector Beam3dPartialUniformLoad::data(5);
+Vector Beam3dPartialUniformLoad::data(8);
 
-Beam3dPartialUniformLoad::Beam3dPartialUniformLoad(int tag, double wy, double wz, double wa,
-						   double aL, double bL, int theElementTag)
+Beam3dPartialUniformLoad::Beam3dPartialUniformLoad(int tag, double wya, double wza, double waa,
+						   double aL, double bL, double wyb, double wzb, double wab, int theElementTag)
   :ElementalLoad(tag, LOAD_TAG_Beam3dPartialUniformLoad, theElementTag),
-   wTransy(wy), wTransz(wz), wAxial(wa), aOverL(aL), bOverL(bL), parameterID(0)
+   wTransya(wya), wTransza(wza), wAxiala(waa), aOverL(aL), bOverL(bL), wTransyb(wyb), wTranszb(wzb), wAxialb(wab), parameterID(0)
 {
 
 }
 
 Beam3dPartialUniformLoad::Beam3dPartialUniformLoad()
   :ElementalLoad(LOAD_TAG_Beam3dPartialUniformLoad),
-   wTransy(0.0), wTransz(0.0), wAxial(0.0), aOverL(0.0), bOverL(0.0), parameterID(0)
+   wTransya(0.0), wTransza(0.0), wAxiala(0.0), aOverL(0.0), bOverL(0.0), wTransyb(0.0), wTranszb(0.0), wAxialb(0.0), parameterID(0)
 {
 
 }
@@ -56,11 +56,14 @@ const Vector &
 Beam3dPartialUniformLoad::getData(int &type, double loadFactor)
 {
   type = LOAD_TAG_Beam3dPartialUniformLoad;
-  data(0) = wTransy;
-  data(1) = wTransz;
-  data(2) = wAxial;
+  data(0) = wTransya;
+  data(1) = wTransza;
+  data(2) = wAxiala;
   data(3) = aOverL;
   data(4) = bOverL;
+  data(5) = wTransyb;
+  data(6) = wTranszb;
+  data(7) = wAxialb;
   return data;
 }
 
@@ -70,15 +73,17 @@ Beam3dPartialUniformLoad::sendSelf(int commitTag, Channel &theChannel)
 {
   int dbTag = this->getDbTag();
 
-  static Vector vectData(7);
-  vectData(0) = wTransy;
-  vectData(1) = wTransz;  
-  vectData(2) = wAxial;
+  static Vector vectData(10);
+  vectData(0) = wTransya;
+  vectData(1) = wTransza;  
+  vectData(2) = wAxiala;
   vectData(3) = eleTag;
   vectData(4) = this->getTag();
   vectData(5) = aOverL;
   vectData(6) = bOverL;
-
+  vectData(7) = wTransyb;
+  vectData(8) = wTranszb;
+  vectData(9) = wAxialb;
   int result = theChannel.sendVector(dbTag, commitTag, vectData);
   if (result < 0) {
     opserr << "Beam3dPartialUniformLoad::sendSelf - failed to send data\n";
@@ -93,7 +98,7 @@ Beam3dPartialUniformLoad::recvSelf(int commitTag, Channel &theChannel,  FEM_Obje
 {
   int dbTag = this->getDbTag();
 
-  static Vector vectData(7);
+  static Vector vectData(10);
 
   int result = theChannel.recvVector(dbTag, commitTag, vectData);
   if (result < 0) {
@@ -102,12 +107,15 @@ Beam3dPartialUniformLoad::recvSelf(int commitTag, Channel &theChannel,  FEM_Obje
   }
 
   this->setTag(vectData(4));
-  wTransy = vectData(0);
-  wTransz = vectData(1);  
-  wAxial = vectData(2);
+  wTransya = vectData(0);
+  wTransza = vectData(1);  
+  wAxiala = vectData(2);
   eleTag = vectData(3);
   aOverL = vectData(5);
   bOverL = vectData(6);
+  wTransyb = vectData(7);
+  wTranszb = vectData(8);
+  wAxialb = vectData(9);
 
   return 0;
 }
@@ -116,9 +124,9 @@ void
 Beam3dPartialUniformLoad::Print(OPS_Stream &s, int flag)
 {
   s << "Beam3dPartialUniformLoad - tag " << this->getTag() << endln;
-  s << "  Transverse y: " << wTransy << endln;
-  s << "  Transverse z: " << wTransz << endln;
-  s << "  Axial:      " << wAxial << endln;
+  s << "  Transverse y: at start:" << wTransya << " , at end:" << wTransyb << endln;
+  s << "  Transverse z: at start:" << wTransza << " , at end:" << wTranszb << endln;
+  s << "  Axial:        at start:" << wAxiala << " , at end:" << wAxialb << endln;
   s << "  Region:     " << aOverL << " to " << bOverL << endln;
   s << "  Element acted on: " << eleTag << endln;
 }
@@ -129,13 +137,13 @@ Beam3dPartialUniformLoad::setParameter(const char **argv, int argc, Parameter &p
   if (argc < 1)
     return -1;
   
-  if (strcmp(argv[0],"wTransy") == 0 || strcmp(argv[0],"wy") == 0)
+  if (strcmp(argv[0],"wTransya") == 0 || strcmp(argv[0],"wya") == 0)
     return param.addObject(1, this);
 
-  if (strcmp(argv[0],"wTransz") == 0 || strcmp(argv[0],"wz") == 0)
+  if (strcmp(argv[0],"wTransza") == 0 || strcmp(argv[0],"wza") == 0)
     return param.addObject(5, this);  
 
-  if (strcmp(argv[0],"wAxial") == 0 || strcmp(argv[0],"wx") == 0)
+  if (strcmp(argv[0],"wAxiala") == 0 || strcmp(argv[0],"wxa") == 0)
     return param.addObject(2, this);
 
   if (strcmp(argv[0],"aOverL") == 0 || strcmp(argv[0],"a") == 0)
@@ -143,6 +151,15 @@ Beam3dPartialUniformLoad::setParameter(const char **argv, int argc, Parameter &p
 
   if (strcmp(argv[0],"bOverL") == 0 || strcmp(argv[0],"b") == 0)
     return param.addObject(4, this);
+
+  if (strcmp(argv[0], "wTransyb") == 0 || strcmp(argv[0], "wyb") == 0)
+    return param.addObject(6, this);
+
+  if (strcmp(argv[0], "wTranszb") == 0 || strcmp(argv[0], "wzb") == 0)
+    return param.addObject(7, this);
+
+  if (strcmp(argv[0], "wAxialb") == 0 || strcmp(argv[0], "wxb") == 0)
+    return param.addObject(8, this);
 
   return -1;
 }
@@ -152,19 +169,28 @@ Beam3dPartialUniformLoad::updateParameter(int parameterID, Information &info)
 {
   switch (parameterID) {
   case 1:
-    wTransy = info.theDouble;
+    wTransya = info.theDouble;
     return 0;
   case 5:
-    wTransz = info.theDouble;
+    wTransza = info.theDouble;
     return 0;    
   case 2:
-    wAxial = info.theDouble;
+    wAxiala = info.theDouble;
     return 0;
   case 3:
     aOverL = info.theDouble;
     return 0;
   case 4:
     bOverL = info.theDouble;
+    return 0;
+  case 6:
+    wTransyb = info.theDouble;
+    return 0;
+  case 7:
+    wTranszb = info.theDouble;
+    return 0;
+  case 8:
+    wAxialb = info.theDouble;
     return 0;
   default:
     return -1;
@@ -200,9 +226,17 @@ Beam3dPartialUniformLoad::getSensitivityData(int gradNumber)
   case 4:
     data(4) = 1.0;
     break;
+  case 6:
+    data(5) = 1.0;
+    break;
+  case 7:
+    data(6) = 1.0;
+    break;
+  case 8:
+    data(7) = 1.0;
+    break;
   default:
     break;
   }
-
   return data;
 }

--- a/SRC/domain/load/Beam3dPartialUniformLoad.h
+++ b/SRC/domain/load/Beam3dPartialUniformLoad.h
@@ -17,7 +17,7 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+                                                                          
 // $Revision$
 // $Date$
 // $Source$
@@ -34,7 +34,7 @@
 class Beam3dPartialUniformLoad : public ElementalLoad
 {
  public:
-  Beam3dPartialUniformLoad(int tag, double wTransy, double wTransz, double wAxial, double aL, double bL, int eleTag);
+  Beam3dPartialUniformLoad(int tag, double wTransya, double wTransza, double wAxiala, double aL, double bL, double wTransyb, double wTranszb, double wAxialb, int eleTag);
   Beam3dPartialUniformLoad();    
   ~Beam3dPartialUniformLoad();
 
@@ -53,11 +53,14 @@ class Beam3dPartialUniformLoad : public ElementalLoad
  protected:
   
  private:
-  double wTransy;
-  double wTransz;
-  double wAxial;
+  double wTransya;
+  double wTransza;
+  double wAxiala;
   double aOverL;
   double bOverL;
+  double wTransyb;
+  double wTranszb;
+  double wAxialb;
   static Vector data;
   
   int parameterID;

--- a/SRC/element/forceBeamColumn/ForceBeamColumn3d.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn3d.cpp
@@ -17,7 +17,7 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+                                                                         
 // $Revision: 1.33 $
 // $Date: 2010-09-13 21:26:10 $
 // $Source: /usr/local/cvs/OpenSees/SRC/element/forceBeamColumn/ForceBeamColumn3d.cpp,v $
@@ -787,20 +787,29 @@ ForceBeamColumn3d::computeReactions(double *p0)
       p0[4] -= V;
     }
     else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
-      double wa = data(2)*loadFactor;  // Axial
-      double wy = data(0)*loadFactor;  // Transverse
-      double wz = data(1)*loadFactor;  // Transverse
-      double a = data(3)*L;
-      double b = data(4)*L;
-
-      p0[0] -= wa*(b-a);
-      double Fy = wy*(b-a);
-      double c = a + 0.5*(b-a);
-      p0[1] -= Fy*(1-c/L);
-      p0[2] -= Fy*c/L;
-      double Fz = wz*(b-a);
-      p0[3] -= Fz*(1-c/L);
-      p0[4] -= Fz*c/L;      
+      double wy = data(0) * loadFactor;  // Transverse Y at start
+      double wz = data(1) * loadFactor;  // Transverse Z at start
+      double wa = data(2) * loadFactor;  // Axial at start
+      double a = data(3) * L;
+      double b = data(4) * L;
+      double wyb = data(5) * loadFactor;  // Transverse Y at end
+      double wzb = data(6) * loadFactor;  // Transverse Z at end
+      double wab = data(7) * loadFactor;  // Axial at end
+      p0[0] -= wa * (b - a) + 0.5 * (wab - wa) * (b - a);
+      double c = a + 0.5 * (b - a);
+      double Fy = wy * (b - a); // resultant transverse load Y (uniform part)
+      p0[1] -= Fy * (1 - c / L);
+      p0[2] -= Fy * c / L;
+      double Fz = wz * (b - a); // resultant transverse load Z (uniform part)
+      p0[3] -= Fz * (1 - c / L);
+      p0[4] -= Fz * c / L;
+      c = a + 2.0 / 3.0 * (b - a);
+      Fy = 0.5 * (wyb - wy) * (b - a); // resultant transverse load Y (triang. part)
+      p0[1] -= Fy * (1 - c / L);
+      p0[2] -= Fy * c / L;
+      Fz = 0.5 * (wzb - wz) * (b - a); // resultant transverse load Z (triang. part)
+      p0[3] -= Fz * (1 - c / L);
+      p0[4] -= Fz * c / L;
     }
     else if (type == LOAD_TAG_Beam3dPointLoad) {
       double Py = data(0)*loadFactor;
@@ -1565,23 +1574,31 @@ ForceBeamColumn3d::computeSectionForces(Vector &sp, int isec)
       }
     }
     else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
-      double wa = data(2)*loadFactor;  // Axial
-      double wy = data(0)*loadFactor;  // Transverse
-      double wz = data(1)*loadFactor;  // Transverse
+      double wy = data(0) * loadFactor;  // Transverse Y at start
+      double wz = data(1) * loadFactor;  // Transverse Z at start
+      double wa = data(2) * loadFactor;  // Axial at start
       double a = data(3)*L;
       double b = data(4)*L;
-
-      double Fa = wa*(b-a); // resultant axial load
-      double Fy = wy*(b-a); // resultant transverse load
-      double Fz = wz*(b-a); // resultant transverse load
-      double c = a + 0.5*(b-a);
-      double VyI = Fy*(1-c/L);
-      double VyJ = Fy*c/L;
-      double VzI = Fz*(1-c/L);
-      double VzJ = Fz*c/L;      
-
+      double wyb = data(5) * loadFactor;  // Transverse Y at end
+      double wzb = data(6) * loadFactor;  // Transverse Z at end
+      double wab = data(7) * loadFactor;  // Axial at end
+      double Fa = wa * (b - a) + 0.5 * (wab - wa) * (b - a); // resultant axial load
+      double Fy = wy * (b - a); // resultant transverse load
+      double Fz = wz * (b - a); // resultant transverse load
+      double c = a + 0.5 * (b - a);
+      double VyI = Fy * (1 - c / L);
+      double VyJ = Fy * c / L;
+      double VzI = Fz * (1 - c / L);
+      double VzJ = Fz * c / L;
+      Fy = 0.5 * (wyb - wy) * (b - a); // resultant transverse load
+      Fz = 0.5 * (wzb - wz) * (b - a); // resultant transverse load
+      c = a + 2.0 / 3.0 * (b - a);
+      VyI += Fy * (1 - c / L);
+      VyJ += Fy * c / L;
+      VzI += Fz * (1 - c / L);
+      VzJ += Fz * c / L;
+     
       for (int ii = 0; ii < order; ii++) {
-	
 	if (x <= a) {
 	  switch(code(ii)) {
 	  case SECTION_RESPONSE_P:
@@ -1597,7 +1614,7 @@ ForceBeamColumn3d::computeSectionForces(Vector &sp, int isec)
 	    sp(ii) -= VyI;
 	    break;
 	  case SECTION_RESPONSE_VZ:
-	    sp(ii) += VzI;
+        sp(ii) += VzI;
 	    break;	    
 	  default:
 	    break;
@@ -1622,26 +1639,28 @@ ForceBeamColumn3d::computeSectionForces(Vector &sp, int isec)
 	  }
 	}
 	else {
+      double wyy = wy + (wyb - wy) / (b - a) * (x - a);
+      double wzz = wz + (wzb - wz) / (b - a) * (x - a);
 	  switch(code(ii)) {
 	  case SECTION_RESPONSE_P:
-	    sp(ii) += Fa-wa*(x-a);
+	    sp(ii) += Fa - wa * (x - a) - 0.5 * (wab - wa) / (b - a) * (x - a) * (x - a);
 	    break;
 	  case SECTION_RESPONSE_MZ:
-	    sp(ii) += -VyI*x + 0.5*wy*x*x + wy*a*(0.5*a-x);
+        sp(ii) += -VyI * x + 0.5 * wy * (x - a) * (x - a) + 0.5 * (wyy - wy) * (x - a) * (x - a) / 3.0;
 	    break;
 	  case SECTION_RESPONSE_MY:
-	    sp(ii) += VzI*x - 0.5*wz*x*x - wz*a*(0.5*a-x);
+          sp(ii) += VzI * x - 0.5 * wz * (x - a) * (x - a) - 0.5 * (wzz - wz) * (x - a) * (x - a) / 3.0;
 	    break;	    
 	  case SECTION_RESPONSE_VY:
-	    sp(ii) += -VyI + wy*(x-a);
-	    break;
-	  case SECTION_RESPONSE_VZ:
-	    sp(ii) -= -VzI + wz*(x-a);	    
-	    break;
+        sp(ii) += -VyI + wy * (x - a) + 0.5 * (wyy - wy) * (x - a);
+        break;
+	  case SECTION_RESPONSE_VZ:	   
+        sp(ii) -= -VzI + wz * (x - a) - 0.5 * (wzz - wz) * (x - a);
+        break;
 	  default:
 	    break;
 	  }
-	}
+    }
       }
     }
     else if (type == LOAD_TAG_Beam3dPointLoad) {
@@ -3187,7 +3206,7 @@ ForceBeamColumn3d::getInitialDeformations(Vector &v0)
 	//by SAJalali
 	else if (strcmp(argv[0], "energy") == 0)
 	{
-		theResponse = new ElementResponse(this, 2000, 0.0);
+		theResponse = new ElementResponse(this, 10, 0.0);
 	}
 
     if (theResponse == 0) {
@@ -3638,7 +3657,7 @@ ForceBeamColumn3d::getResponse(int responseID, Information &eleInfo)
     return -1;
   }
   //by SAJalali
-  else if (responseID == 2000) {
+  else if (responseID == 10) {
 	  double xi[maxNumSections];
 	  double L = crdTransf->getInitialLength();
 	  beamIntegr->getSectionWeights(numSections, L, xi);

--- a/SRC/interpreter/OpenSeesPatternCommands.cpp
+++ b/SRC/interpreter/OpenSeesPatternCommands.cpp
@@ -33,7 +33,7 @@ PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT,
 UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 *************************************************************************** */
-
+  
 // Written: Minjie
 
 // Description: command to create pattern
@@ -43,8 +43,8 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <NodalLoad.h>
 #include <Beam2dPartialUniformLoad.h>
 #include <Beam2dUniformLoad.h>
-#include <Beam3dPartialUniformLoad.h>
 #include <Beam3dUniformLoad.h>
+#include <Beam3dPartialUniformLoad.h>
 #include <Beam2dPointLoad.h>
 #include <Beam3dPointLoad.h>
 #include <BrickSelfWeight.h>
@@ -279,7 +279,6 @@ int OPS_ElementalLoad()
     const char* type = OPS_GetString();
     if (strcmp(type,"-beamUniform") == 0 ||
 	strcmp(type,"beamUniform") == 0) {
-
 	if (ndm == 2) {
 	    // wta, waa, aL, bL, wtb, wab
         double data[6] = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0};
@@ -299,7 +298,7 @@ int OPS_ElementalLoad()
 		  data[5] = data[1];
 		}
 		if (data[2] > 0.0 || data[3] < 1.0 || numdata > 4)
-		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0], data[4], data[1], data[5], data[2], data[3], theEleTags(i));
+		    theLoad = new Beam2dPartialUniformLoad(eleLoadTag, data[0],data[4], data[1], data[5], data[2], data[3], theEleTags(i));
 		else
 		    theLoad = new Beam2dUniformLoad(eleLoadTag, data[0], data[1], theEleTags(i));
 
@@ -307,10 +306,8 @@ int OPS_ElementalLoad()
 		    opserr << "WARNING eleLoad - out of memory creating load of type " << type;
 		    return -1;
 		}
-
 		// get the current pattern tag if no tag given in i/p
 		int loadPatternTag = theActiveLoadPattern->getTag();
-
 		// add the load to the domain
 		if (theDomain->addElementalLoad(theLoad, loadPatternTag) == false) {
 		    opserr << "WARNING eleLoad - could not add following load to domain:\n ";
@@ -320,37 +317,37 @@ int OPS_ElementalLoad()
 		}
 		eleLoadTag++;
 	    }
-
 	    return 0;
 	}
-
 	else if (ndm == 3) {
-	    // wy, wz, wx, aL, bL
-	    double data[5] = { 0.0, 0.0, 0.0, 0.0, 1.0 };
-	    int numdata = OPS_GetNumRemainingInputArgs();
-	    if (numdata < 2) {
-		opserr<<"WARNING eleLoad - beamUniform want Wy Wz <Wx>\n";
-		return -1;
-	    }
-	    if (numdata > 5) numdata = 5;
-	    if (OPS_GetDoubleInput(&numdata, data) < 0) {
-		opserr<<"WARNING eleLoad - invalid value for beamUniform\n";
-		return -1;
-	    }
-	    for (int i=0; i<theEleTags.Size(); i++) {
-		if (numdata > 3)
-	  	    theLoad = new Beam3dPartialUniformLoad(eleLoadTag, data[0], data[1], data[2], data[3], data[4], theEleTags(i));
-		else
-		    theLoad = new Beam3dUniformLoad(eleLoadTag, data[0], data[1], data[2], theEleTags(i));
-
-		if (theLoad == 0) {
-		    opserr << "WARNING eleLoad - out of memory creating load of type " << type;
-		    return -1;
+		// wy, wz, wx, aL, bL, wyb, wzb, wxb,
+		double data[8] = { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 };
+		int numdata = OPS_GetNumRemainingInputArgs();
+		if (numdata < 2) {
+			opserr << "WARNING eleLoad - beamUniform want Wy Wz <Wx>\n";
+			return -1;
 		}
-
+		if (numdata > 8) numdata = 8;
+		if (OPS_GetDoubleInput(&numdata, data) < 0) {
+			opserr << "WARNING eleLoad - invalid value for beamUniform\n";
+			return -1;
+		}
+		for (int i = 0; i < theEleTags.Size(); i++) {
+			if (numdata == 4 || numdata == 5) {
+				data[5] = data[0];
+				data[6] = data[1];
+				data[7] = data[2];
+			}
+			if (numdata > 3)
+				theLoad = new Beam3dPartialUniformLoad(eleLoadTag, data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7], theEleTags(i));
+			else
+			    theLoad = new Beam3dUniformLoad(eleLoadTag, data[0], data[1], data[2], theEleTags(i));
+			if (theLoad == 0) {
+				opserr << "WARNING eleLoad - out of memory creating load of type " << type;
+				return -1;
+			}
 		// get the current pattern tag if no tag given in i/p
 		int loadPatternTag = theActiveLoadPattern->getTag();
-
 		// add the load to the domain
 		if (theDomain->addElementalLoad(theLoad, loadPatternTag) == false) {
 		    opserr << "WARNING eleLoad - could not add following load to domain:\n ";
@@ -360,9 +357,7 @@ int OPS_ElementalLoad()
 		}
 		eleLoadTag++;
 	    }
-
 	    return 0;
-
 	}
 	else {
 	    opserr << "WARNING eleLoad beamUniform currently only valid only for ndm=2 or 3\n";

--- a/SRC/modelbuilder/tcl/TclModelBuilder.cpp
+++ b/SRC/modelbuilder/tcl/TclModelBuilder.cpp
@@ -2070,9 +2070,10 @@ TclCommand_addElementalLoad(ClientData clientData, Tcl_Interp *interp, int argc,
       return 0;
     }
     else if (ndm == 3) {
-      double wy, wz;
+      double wy, wz, wyb, wzb;
       double wx = 0.0;
-      if (count >= argc || Tcl_GetDouble(interp, argv[count], &wy) != TCL_OK) {
+	  double wxb = 0.0;
+	  if (count >= argc || Tcl_GetDouble(interp, argv[count], &wy) != TCL_OK) {
 	opserr << "WARNING eleLoad - invalid wy for beamUniform \n";
 	return TCL_ERROR;
       }
@@ -2101,7 +2102,7 @@ TclCommand_addElementalLoad(ClientData clientData, Tcl_Interp *interp, int argc,
 
       for (int i=0; i<theEleTags.Size(); i++) {
 	if (aL > 0.0 || bL < 1.0)
-	  theLoad = new Beam3dPartialUniformLoad(eleLoadTag, wy, wz, wx, aL, bL, theEleTags(i));
+	  theLoad = new Beam3dPartialUniformLoad(eleLoadTag, wy, wz, wx, aL, bL, wyb, wzb, wxb, theEleTags(i));
 	else 
 	  theLoad = new Beam3dUniformLoad(eleLoadTag, wy, wz, wx, theEleTags(i));    	
 


### PR DESCRIPTION
Application of "trapezoidal" member load using additional arguments to the eleload command for 3d ForceBeamColumn:
ops.eleLoad('-ele',eleTag,'-type','beamUniform',wya,wza,wxa,aOverL,bOverL,wyb,wzb,wxb)