### PR TITLE
New ForceBeamColumn3dThermal element and other minor changes

### DIFF
--- a/SRC/element/forceBeamColumn/CMakeLists.txt
+++ b/SRC/element/forceBeamColumn/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(OPS_Element
         ForceBeamColumn2d.cpp
         ForceBeamColumn3d.cpp
         ForceBeamColumn2dThermal.cpp
+	ForceBeamColumn3dThermal.cpp
         ElasticForceBeamColumn2d.cpp
         ElasticForceBeamColumn3d.cpp
         ElasticForceBeamColumnWarping2d.cpp
@@ -43,6 +44,7 @@ target_sources(OPS_Element
         ForceBeamColumn2d.h
         ForceBeamColumn3d.h
         ForceBeamColumn2dThermal.h
+        ForceBeamColumn3dThermal.h
         ElasticForceBeamColumn2d.h
         ElasticForceBeamColumn3d.h
         ElasticForceBeamColumnWarping2d.h

--- a/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.cpp
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.cpp
@@ -1,0 +1,4757 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+                                                                         
+// $Revision: 1.33 $
+// $Date: 2010-09-13 21:26:10 $
+// $Source: /usr/local/cvs/OpenSees/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.cpp,v $
+
+/*
+ * References
+ *
+
+State Determination Algorithm
+---
+Neuenhofer, A. and F. C. Filippou (1997). "Evaluation of Nonlinear Frame Finite
+Element Models." Journal of Structural Engineering, 123(7):958-966.
+
+Spacone, E., V. Ciampi, and F. C. Filippou (1996). "Mixed Formulation of
+Nonlinear Beam Finite Element." Computers and Structures, 58(1):71-83.
+
+
+Plastic Hinge Integration
+---
+Scott, M. H. and G. L. Fenves (2006). "Plastic Hinge Integration Methods for
+Force-Based Beam-Column Elements." Journal of Structural Engineering,
+132(2):244-252.
+
+
+Analytical Response Sensitivity (DDM)
+---
+Scott, M. H., P. Franchin, G. L. Fenves, and F. C. Filippou (2004).
+"Response Sensitivity for Nonlinear Beam-Column Elements."
+Journal of Structural Engineering, 130(9):1281-1288.
+
+
+Software Design
+---
+Scott, M. H., G. L. Fenves, F. T. McKenna, and F. C. Filippou (2007).
+"Software Patterns for Nonlinear Beam-Column Models."
+Journal of Structural Engineering, Approved for publication, February 2007.
+
+ *
+ */
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <float.h>
+
+#include <Information.h>
+#include <Parameter.h>
+#include <ForceBeamColumn3dThermal.h>
+#include <MatrixUtil.h>
+#include <Domain.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <Renderer.h>
+#include <math.h>
+#include <elementAPI.h>
+#include <string>
+#include <fstream>
+using std::ifstream;
+#include <fstream>
+#include <ElementResponse.h>
+#include <CompositeResponse.h>
+#include <ElementalLoad.h>
+#include <ElementIter.h>
+#include <NodalThermalAction.h>
+#include <ThermalActionWrapper.h>
+
+#define DefaultLoverGJ 1.0e-10
+
+Matrix ForceBeamColumn3dThermal::theMatrix(12,12);
+Vector ForceBeamColumn3dThermal::theVector(12);
+double ForceBeamColumn3dThermal::workArea[200];
+
+Vector ForceBeamColumn3dThermal::vsSubdivide[maxNumSections];
+Matrix ForceBeamColumn3dThermal::fsSubdivide[maxNumSections];
+Vector ForceBeamColumn3dThermal::SsrSubdivide[maxNumSections];
+
+void* OPS_ForceBeamColumn3dThermal()
+{
+    int dampingTag = 0;
+    Damping* theDamping = 0;
+    if (OPS_GetNumRemainingInputArgs() < 5) {
+	opserr<<"insufficient arguments:eleTag,iNode,jNode,transfTag,integrationTag\n";
+	return 0;
+    }
+
+    int ndm = OPS_GetNDM();
+    int ndf = OPS_GetNDF();
+    if(ndm != 3 || ndf != 6) {
+	opserr<<"ndm must be 3 and ndf must be 6\n";
+	return 0;
+    }
+
+    // inputs: 
+    int iData[5];
+    int numData = 5;
+    if(OPS_GetIntInput(&numData,&iData[0]) < 0) {
+	opserr << "WARNING invalid int inputs\n";
+	return 0;
+    }
+
+    // options
+    double mass = 0.0, tol=1e-12, subFac=10.0;
+    int maxIter = 10, numSub = 4;
+    numData = 1;
+    while(OPS_GetNumRemainingInputArgs() > 0) {
+	const char* type = OPS_GetString();
+	if(strcmp(type,"-iter") == 0) {
+	    if(OPS_GetNumRemainingInputArgs() > 1) {
+		if(OPS_GetIntInput(&numData,&maxIter) < 0) {
+		    opserr << "WARNING invalid maxIter\n";
+		    return 0;
+		}
+		if(OPS_GetDoubleInput(&numData,&tol) < 0) {
+		    opserr << "WARNING invalid tol\n";
+		    return 0;
+		}
+	    }
+	} else if(strcmp(type,"-subdivide") == 0) {
+	    if(OPS_GetNumRemainingInputArgs() > 1) {
+		if(OPS_GetIntInput(&numData,&numSub) < 0) {
+		    opserr << "WARNING invalid numSubdivide\n";
+		    return 0;
+		}
+		if(OPS_GetDoubleInput(&numData,&subFac) < 0) {
+		    opserr << "WARNING invalid subdivideFactor\n";
+		    return 0;
+		}
+	    }
+	} else if(strcmp(type,"-mass") == 0) {
+	    if(OPS_GetNumRemainingInputArgs() > 0) {
+		if(OPS_GetDoubleInput(&numData,&mass) < 0) {
+		    opserr << "WARNING invalid mass\n";
+		    return 0;
+		}
+	    }
+	}
+    //Tang.S
+    else if (strcmp(type, "-damp") == 0) {
+
+        if (OPS_GetNumRemainingInputArgs() > 0) {
+            if (OPS_GetIntInput(&numData, &dampingTag) < 0) return 0;
+            theDamping = OPS_getDamping(dampingTag);
+            if (theDamping == 0) {
+                opserr << "damping not found\n";
+                return 0;
+            }
+        }
+    }
+    }
+
+    // check transf
+    CrdTransf* theTransf = OPS_getCrdTransf(iData[3]);
+    if(theTransf == 0) {
+	opserr<<"coord transfomration not found\n";
+	return 0;
+    }
+
+    // check beam integrataion
+    BeamIntegrationRule* theRule = OPS_getBeamIntegrationRule(iData[4]);
+    if(theRule == 0) {
+	opserr<<"beam integration not found\n";
+	return 0;
+    }
+    BeamIntegration* bi = theRule->getBeamIntegration();
+    if(bi == 0) {
+	opserr<<"beam integration is null\n";
+	return 0;
+    }
+
+    // check sections
+    const ID& secTags = theRule->getSectionTags();
+    SectionForceDeformation** sections = new SectionForceDeformation *[secTags.Size()];
+    for(int i=0; i<secTags.Size(); i++) {
+	sections[i] = OPS_getSectionForceDeformation(secTags(i));
+	if(sections[i] == 0) {
+	    opserr<<"section "<<secTags(i)<<"not found\n";
+	    return 0;
+	}
+    }
+
+    Element *theEle =  new ForceBeamColumn3dThermal(iData[0],iData[1],iData[2],secTags.Size(),sections,
+					     *bi,*theTransf,mass,maxIter,tol,numSub,subFac,theDamping);
+    delete [] sections;
+    return theEle;
+}
+
+void *OPS_ForceBeamColumn3dThermal(const ID &info) {
+    // data needed
+    int iData[5];
+    double mass = 0.0, tol = 1e-12, subFac=10.0;
+    int maxIter = 10, numSub = 4;
+    int numData;
+    int dampingTag = 0;
+    Damping* theDamping = 0;
+
+    int ndm = OPS_GetNDM();
+    int ndf = OPS_GetNDF();
+    if (ndm != 3 || ndf != 6) {
+        opserr << "ndm must be 3 and ndf must be 6\n";
+        return 0;
+    }
+
+    // 1. regular elements
+    if (info.Size() == 0) {
+        numData = 3;
+        if (OPS_GetNumRemainingInputArgs() < numData) {
+            opserr << "insufficient "
+                      "arguments:eleTag,iNode,jNode\n";
+            return 0;
+        }
+        if (OPS_GetIntInput(&numData, &iData[0]) < 0) {
+            opserr << "WARNING invalid int inputs\n";
+            return 0;
+        }
+    }
+
+    // 2. regular elements or save data
+    if (info.Size() == 0 || info(0) == 1) {
+        numData = 2;
+        if (OPS_GetNumRemainingInputArgs() < numData) {
+            opserr << "insufficient "
+                      "arguments:transfTag,integrationTag\n";
+            return 0;
+        }
+        if (OPS_GetIntInput(&numData, &iData[3]) < 0) {
+            opserr << "WARNING invalid int inputs\n";
+            return 0;
+        }
+
+        numData = 1;
+        while (OPS_GetNumRemainingInputArgs() > 0) {
+            const char *type = OPS_GetString();
+            if (strcmp(type, "-iter") == 0) {
+                if (OPS_GetNumRemainingInputArgs() > 1) {
+                    if (OPS_GetIntInput(&numData, &maxIter) < 0) {
+                        opserr << "WARNING invalid maxIter\n";
+                        return 0;
+                    }
+                    if (OPS_GetDoubleInput(&numData, &tol) < 0) {
+                        opserr << "WARNING invalid tol\n";
+                        return 0;
+                    }
+                }
+            } else if(strcmp(type,"-subdivide") == 0) {
+	      if(OPS_GetNumRemainingInputArgs() > 1) {
+		if(OPS_GetIntInput(&numData,&numSub) < 0) {
+		  opserr << "WARNING invalid numSubdivide\n";
+		  return 0;
+		}
+		if(OPS_GetDoubleInput(&numData,&subFac) < 0) {
+		  opserr << "WARNING invalid subdivideFactor\n";
+		  return 0;
+		}
+	      }
+	    }
+	    else if (strcmp(type, "-mass") == 0) {
+                if (OPS_GetNumRemainingInputArgs() > 0) {
+                    if (OPS_GetDoubleInput(&numData, &mass) < 0) {
+                        opserr << "WARNING invalid mass\n";
+                        return 0;
+                    }
+                }
+        }
+        //Tang.S
+        else if (strcmp(type, "-damp") == 0) {
+
+                if (OPS_GetNumRemainingInputArgs() > 0) {
+                    if (OPS_GetIntInput(&numData, &dampingTag) < 0) return 0;
+                    theDamping = OPS_getDamping(dampingTag);
+                    if (theDamping == 0) {
+                        opserr << "damping not found\n";
+                        return 0;
+                    }
+                }
+            }
+        }
+    }
+
+    // 3: save data
+    static std::map<int, Vector> meshdata;
+    if (info.Size() > 0 && info(0) == 1) {
+        if (info.Size() < 2) {
+            opserr << "WARNING: need info -- inmesh, meshtag\n";
+            return 0;
+        }
+
+        // save the data for a mesh
+        Vector &mdata = meshdata[info(1)];
+        mdata.resize(7);
+        mdata(0) = iData[3];
+        mdata(1) = iData[4];
+        mdata(2) = mass;
+        mdata(3) = tol;
+        mdata(4) = maxIter;
+	mdata(5) = numSub;
+	mdata(6) = subFac;	
+        return &meshdata;
+    }
+
+    // 4: load data
+    if (info.Size() > 0 && info(0) == 2) {
+        if (info.Size() < 5) {
+            opserr << "WARNING: need info -- inmesh, meshtag, "
+                      "eleTag, nd1, nd2\n";
+            return 0;
+        }
+
+        // get the data for a mesh
+        Vector &mdata = meshdata[info(1)];
+        if (mdata.Size() < 5) return 0;
+
+        iData[0] = info(2);
+        iData[1] = info(3);
+        iData[2] = info(4);
+        iData[3] = mdata(0);
+        iData[4] = mdata(1);
+        mass = mdata(2);
+        tol = mdata(3);
+        maxIter = mdata(4);
+	numSub = mdata(5);
+	subFac = mdata(6);
+    }
+
+    // 5: create element
+    CrdTransf *theTransf = OPS_getCrdTransf(iData[3]);
+    if (theTransf == 0) {
+        opserr << "coord transfomration not found\n";
+        return 0;
+    }
+
+    // check beam integrataion
+    BeamIntegrationRule *theRule =
+        OPS_getBeamIntegrationRule(iData[4]);
+    if (theRule == 0) {
+        opserr << "beam integration not found\n";
+        return 0;
+    }
+    BeamIntegration *bi = theRule->getBeamIntegration();
+    if (bi == 0) {
+        opserr << "beam integration is null\n";
+        return 0;
+    }
+
+    // check sections
+    const ID &secTags = theRule->getSectionTags();
+    SectionForceDeformation **sections =
+        new SectionForceDeformation *[secTags.Size()];
+    for (int i = 0; i < secTags.Size(); i++) {
+        sections[i] = OPS_getSectionForceDeformation(secTags(i));
+        if (sections[i] == 0) {
+            opserr << "section " << secTags(i) << "not found\n";
+            return 0;
+        }
+    }
+
+    Element *theEle = new ForceBeamColumn3dThermal(
+        iData[0], iData[1], iData[2], secTags.Size(), sections, *bi,
+        *theTransf, mass, maxIter, tol, numSub, subFac,theDamping);
+    delete[] sections;
+    return theEle;
+}
+
+// constructor:
+// invoked by a FEM_ObjectBroker, recvSelf() needs to be invoked on this object.
+ForceBeamColumn3dThermal::ForceBeamColumn3dThermal(): 
+  Element(0,ELE_TAG_ForceBeamColumn3dThermal), connectedExternalNodes(2), 
+  beamIntegr(0), numSections(0), sections(0), crdTransf(0),
+  rho(0.0), maxIters(0), tol(0.0),
+  initialFlag(0),
+  kv(NEBD,NEBD), Se(NEBD),
+  kvcommit(NEBD,NEBD), Secommit(NEBD),
+  fs(0), vs(0), Ssr(0), vscommit(0),
+  numEleLoads(0), sizeEleLoads(0), eleLoads(0), eleLoadFactors(0), load(12),
+  Ki(0), isTorsion(false), maxSubdivisions(1), subdivideFactor(1.0), parameterID(0),
+  theDamping(0), counterTemperature(0), Vsth0(0)
+{
+  load.Zero();
+
+  theNodes[0] = 0;  
+  theNodes[1] = 0;
+}
+
+// constructor which takes the unique element tag, sections,
+// and the node ID's of its nodal end points. 
+// allocates the necessary space needed by each object
+ForceBeamColumn3dThermal::ForceBeamColumn3dThermal (int tag, int nodeI, int nodeJ,
+				      int numSec, SectionForceDeformation **sec,
+				      BeamIntegration &bi,
+				      CrdTransf &coordTransf, double massDensPerUnitLength,
+				      int maxNumIters, double tolerance,
+				      int maxNumSub, double subFac,
+				      Damping *damping):
+  Element(tag,ELE_TAG_ForceBeamColumn3dThermal), connectedExternalNodes(2),
+  beamIntegr(0), numSections(0), sections(0), crdTransf(0),
+  rho(massDensPerUnitLength),maxIters(maxNumIters), tol(tolerance), 
+  initialFlag(0),
+  kv(NEBD,NEBD), Se(NEBD), 
+  kvcommit(NEBD,NEBD), Secommit(NEBD),
+  fs(0), vs(0),Ssr(0), vscommit(0),
+  numEleLoads(0), sizeEleLoads(0), eleLoads(0), eleLoadFactors(0), load(12),
+  Ki(0), isTorsion(false), maxSubdivisions(maxNumSub), subdivideFactor(subFac), parameterID(0),
+  theDamping(0), counterTemperature(0), Vsth0(0)
+{
+  if (maxSubdivisions < 1)
+    maxSubdivisions = 1;
+  if (subdivideFactor < 1.0)
+    subdivideFactor = 1.0;
+  
+  load.Zero();
+  
+  theNodes[0] = 0;
+  theNodes[1] = 0;
+
+  connectedExternalNodes(0) = nodeI;
+  connectedExternalNodes(1) = nodeJ;    
+
+  beamIntegr = bi.getCopy();
+  if (beamIntegr == 0) {
+    opserr << "Error: ForceBeamColumn3dThermal::ForceBeamColumn3dThermal: could not create copy of beam integration object" << endln;
+    exit(-1);
+  }
+
+  // get copy of the transformation object   
+  crdTransf = coordTransf.getCopy3d(); 
+  if (crdTransf == 0) {
+    opserr << "Error: ForceBeamColumn3dThermal::ForceBeamColumn3dThermal: could not create copy of coordinate transformation object" << endln;
+    exit(-1);
+  }
+
+  if (damping)
+  {
+    theDamping =(*damping).getCopy();
+    
+    if (!theDamping) {
+      opserr << "Error: ForceBeamColumn3dThermal::ForceBeamColumn3dThermal: could not create copy of damping object\n";
+      exit(-1);
+    }
+  }
+
+  this->setSectionPointers(numSec, sec);
+
+  //add by J.Jiang - edit GR
+
+  residThermal[0] = 0.0;
+  residThermal[1] = 0.0;
+  residThermal[2] = 0.0;
+  residThermal[3] = 0.0;
+  residThermal[4] = 0.0;
+
+
+  counterTemperature = 0;
+  AverageThermalElong = 0;
+  for (int i = 0; i < numSections; i++) {
+      SectionThermalElong[i] = 0;
+  }
+
+  this->setSectionPointers(numSec, sec);
+
+  if (Vsth0 == 0)
+      Vsth0 = new Vector[maxNumSections];
+
+  for (int m = 0; m < numSections; m++) {
+      Vsth0[m] = Vector(4); // places equal to order
+      Vsth0[m].Zero();
+  }
+  // end edit GR
+}
+
+// ~ForceBeamColumn3dThermal():
+// 	destructor
+//      delete must be invoked on any objects created by the object
+ForceBeamColumn3dThermal::~ForceBeamColumn3dThermal()
+{
+  if (sections != 0) {
+    for (int i=0; i < numSections; i++)
+      if (sections[i] != 0)
+	delete sections[i];
+    delete [] sections;
+  }
+  
+  if (sizeEleLoads != 0) {
+      if (eleLoads != 0)
+          delete[] eleLoads;
+
+      if (eleLoadFactors != 0)
+          delete[] eleLoadFactors;
+  }
+
+  if (fs != 0) 
+    delete [] fs;
+  
+  if (vs != 0) 
+    delete [] vs;
+  
+  if (Ssr != 0) 
+    delete [] Ssr;
+  
+  if (vscommit != 0) 
+    delete [] vscommit;
+  
+  if (crdTransf != 0)
+    delete crdTransf;
+
+  if (beamIntegr != 0)
+    delete beamIntegr;
+  
+  if (Ki != 0)
+    delete Ki;
+
+	if (theDamping) delete theDamping;
+
+    if (Vsth0 != 0)
+        delete[] Vsth0;
+}
+
+int
+ForceBeamColumn3dThermal::getNumExternalNodes(void) const
+{
+  return 2;
+}
+
+const ID &
+ForceBeamColumn3dThermal::getExternalNodes(void) 
+{
+  return connectedExternalNodes;
+}
+
+Node **
+ForceBeamColumn3dThermal::getNodePtrs()
+{
+  return theNodes;
+}
+
+int
+ForceBeamColumn3dThermal::getNumDOF(void) 
+{
+  return NEGD;
+}
+
+void
+ForceBeamColumn3dThermal::setDomain(Domain *theDomain)
+{
+  // check Domain is not null - invoked when object removed from a domain
+  if (theDomain == 0) {
+    theNodes[0] = 0;
+    theNodes[1] = 0;
+    
+    opserr << "ForceBeamColumn3dThermal::setDomain:  theDomain = 0 ";
+    exit(0); 
+  }
+
+  // get pointers to the nodes
+  
+  int Nd1 = connectedExternalNodes(0);  
+  int Nd2 = connectedExternalNodes(1);
+  
+  theNodes[0] = theDomain->getNode(Nd1);
+  theNodes[1] = theDomain->getNode(Nd2);  
+  
+  if (theNodes[0] == 0) {
+    opserr << "ForceBeamColumn3dThermal::setDomain: Nd1: ";
+    opserr << Nd1 << "does not exist in model\n";
+    exit(0);
+  }
+  
+  if (theNodes[1] == 0) {
+    opserr << "ForceBeamColumn3dThermal::setDomain: Nd2: ";
+    opserr << Nd2 << "does not exist in model\n";
+    exit(0);
+  }
+  
+  // call the DomainComponent class method 
+  this->DomainComponent::setDomain(theDomain);
+  
+  // ensure connected nodes have correct number of dof's
+  int dofNode1 = theNodes[0]->getNumberDOF();
+  int dofNode2 = theNodes[1]->getNumberDOF();
+  
+  if ((dofNode1 != NND) || (dofNode2 != NND)) {
+    opserr << "ForceBeamColumn3dThermal::setDomain(): Nd2 or Nd1 incorrect dof ";
+    exit(0);
+  }
+   
+  // initialize the transformation
+  if (crdTransf->initialize(theNodes[0], theNodes[1])) {
+    opserr << "ForceBeamColumn3dThermal::setDomain(): Error initializing coordinate transformation";  
+    exit(0);
+  }
+    
+  // initialize the damping
+  if (theDamping && theDamping->setDomain(theDomain, NEBD)) {
+    opserr << "ForceBeamColumn3dThermal::setDomain(): Error initializing damping";  
+    exit(0);
+  }
+    
+  // get element length
+  double L = crdTransf->getInitialLength();
+  if (L == 0.0) {
+    opserr << "ForceBeamColumn3dThermal::setDomain() -- zero length for element with tag: " << this->getTag();  
+    exit(0);
+  }
+
+  if (initialFlag == 0) 
+    this->initializeSectionHistoryVariables();
+}
+
+int
+ForceBeamColumn3dThermal::setDamping(Domain *theDomain, Damping *damping)
+{
+  if (theDomain && damping)
+  {
+    if (theDamping) delete theDamping;
+
+    theDamping =(*damping).getCopy();
+    
+    if (!theDamping) {
+      opserr << "ForceBeamColumn3dThermal::setDamping -- failed to get copy of damping\n";
+      return -1;
+    }
+    if (theDamping->setDomain(theDomain, NEBD)) {
+      opserr << "ForceBeamColumn3dThermal::setDamping -- Error initializing damping\n";
+      return -2;
+    }
+  }
+  
+  return 0;
+}
+
+int
+ForceBeamColumn3dThermal::commitState()
+{
+  int err = 0;
+  int i = 0;
+
+  // call element commitState to do any base class stuff
+  if ((err = this->Element::commitState()) != 0) {
+    opserr << "ForceBeamColumn3dThermal::commitState () - failed in base class";
+  }    
+  
+  do {
+    vscommit[i] = vs[i];
+    err = sections[i++]->commitState();
+    
+  } while (err == 0 && i < numSections);
+  
+  if (err)
+    return err;
+  
+  // commit the transformation between coord. systems
+  if ((err = crdTransf->commitState()) != 0)
+    return err;
+  
+  // commit the element variables state
+  kvcommit = kv;
+  Secommit = Se;
+  
+  //   initialFlag = 0;  fmk - commented out, see what happens to Example3.1.tcl if uncommented
+  //                         - i have not a clue why, ask remo if he ever gets in contact with us again!
+  
+  if (theDamping && (err = theDamping->commitState()))
+    return err;
+
+  return err;
+}
+
+int ForceBeamColumn3dThermal::revertToLastCommit()
+{
+  int err;
+  int i = 0;
+  
+  do {
+    vs[i] = vscommit[i];
+    err = sections[i]->revertToLastCommit();
+    
+    sections[i]->setTrialSectionDeformation(vs[i]);      
+    Ssr[i] = sections[i]->getStressResultant();
+    fs[i]  = sections[i]->getSectionFlexibility();
+    
+    i++;
+  } while (err == 0 && i < numSections);
+  
+  
+  if (err)
+    return err;
+  
+  // revert the transformation to last commit
+  if ((err = crdTransf->revertToLastCommit()) != 0)
+    return err;
+  
+  // revert the element state to last commit
+  Se   = Secommit;
+  kv   = kvcommit;
+  
+  initialFlag = 0;
+  // this->update();
+  
+  if (theDamping && (err = theDamping->revertToLastCommit()))
+    return err;
+
+  return err;
+}
+
+int ForceBeamColumn3dThermal::revertToStart()
+{
+  // revert the sections state to start
+  int err;
+  int i = 0;
+  
+  do {
+    fs[i].Zero();
+    vs[i].Zero();
+    Ssr[i].Zero();
+    err = sections[i++]->revertToStart();
+    
+  } while (err == 0 && i < numSections);
+  
+  if (err)
+    return err;
+  
+  // revert the transformation to start
+  if ((err = crdTransf->revertToStart()) != 0)
+    return err;
+  
+  // revert the element state to start
+  Secommit.Zero();
+  kvcommit.Zero();
+  
+  Se.Zero();
+  kv.Zero();
+  
+  initialFlag = 0;
+  // this->update();
+
+  if (theDamping && (err = theDamping->revertToStart()))
+    return err;
+
+  return err;
+}
+
+
+const Matrix &
+ForceBeamColumn3dThermal::getInitialStiff(void)
+{
+  // check for quick return
+  if (Ki != 0)
+    return *Ki;
+
+  static Matrix f(NEBD,NEBD);   // element flexibility matrix  
+  this->getInitialFlexibility(f);
+  
+  static Matrix I(NEBD,NEBD);   // an identity matrix for matrix inverse  
+  I.Zero();
+  for (int i=0; i<NEBD; i++)
+    I(i,i) = 1.0;
+  
+  // calculate element stiffness matrix
+  // invert3by3Matrix(f, kv);
+  static Matrix kvInit(NEBD, NEBD);
+  if (f.Solve(I, kvInit) < 0)
+    opserr << "ForceBeamColumn3dThermal::getInitialStiff() -- could not invert flexibility for element with tag: " << this->getTag() << endln;
+
+  if(theDamping) kvInit *= theDamping->getStiffnessMultiplier();
+
+    Ki = new Matrix(crdTransf->getInitialGlobalStiffMatrix(kvInit));
+
+    return *Ki;
+  }
+
+  const Matrix &
+  ForceBeamColumn3dThermal::getTangentStiff(void)
+  {
+    crdTransf->update();	// Will remove once we clean up the corotational 3d transformation -- MHS
+    return crdTransf->getGlobalStiffMatrix(kv, Se);
+  }
+
+void
+ForceBeamColumn3dThermal::computeReactions(double *p0)
+{
+  int type;
+  double L = crdTransf->getInitialLength();
+  
+  for (int i = 0; i < numEleLoads; i++) {
+    
+    double loadFactor = eleLoadFactors[i];
+    const Vector &data = eleLoads[i]->getData(type, loadFactor);
+
+    if (type == LOAD_TAG_Beam3dUniformLoad) {
+      double wy = data(0)*loadFactor;  // Transverse
+      double wz = data(1)*loadFactor;  // Transverse
+      double wa = data(2)*loadFactor;  // Axial
+
+      p0[0] -= wa*L;
+      double V = 0.5*wy*L;
+      p0[1] -= V;
+      p0[2] -= V;
+      V = 0.5*wz*L;
+      p0[3] -= V;
+      p0[4] -= V;
+    }
+    else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
+      double wy = data(0) * loadFactor;  // Transverse Y at start
+      double wz = data(1) * loadFactor;  // Transverse Z at start
+      double wa = data(2) * loadFactor;  // Axial at start
+      double a = data(3) * L;
+      double b = data(4) * L;
+      double wyb = data(5) * loadFactor;  // Transverse Y at end
+      double wzb = data(6) * loadFactor;  // Transverse Z at end
+      double wab = data(7) * loadFactor;  // Axial at end
+      p0[0] -= wa * (b - a) + 0.5 * (wab - wa) * (b - a);
+      double c = a + 0.5 * (b - a);
+      double Fy = wy * (b - a); // resultant transverse load Y (uniform part)
+      p0[1] -= Fy * (1 - c / L);
+      p0[2] -= Fy * c / L;
+      double Fz = wz * (b - a); // resultant transverse load Z (uniform part)
+      p0[3] -= Fz * (1 - c / L);
+      p0[4] -= Fz * c / L;
+      c = a + 2.0 / 3.0 * (b - a);
+      Fy = 0.5 * (wyb - wy) * (b - a); // resultant transverse load Y (triang. part)
+      p0[1] -= Fy * (1 - c / L);
+      p0[2] -= Fy * c / L;
+      Fz = 0.5 * (wzb - wz) * (b - a); // resultant transverse load Z (triang. part)
+      p0[3] -= Fz * (1 - c / L);
+      p0[4] -= Fz * c / L;
+    }
+    else if (type == LOAD_TAG_Beam3dPointLoad) {
+      double Py = data(0)*loadFactor;
+      double Pz = data(1)*loadFactor;
+      double N  = data(2)*loadFactor;
+      double aOverL = data(3);
+      
+      if (aOverL < 0.0 || aOverL > 1.0)
+	continue;
+      
+      double V1 = Py*(1.0-aOverL);
+      double V2 = Py*aOverL;
+      p0[0] -= N;
+      p0[1] -= V1;
+      p0[2] -= V2;
+      V1 = Pz*(1.0-aOverL);
+      V2 = Pz*aOverL;
+      p0[3] -= V1;
+      p0[4] -= V2;
+    }
+    //J.Jiang add to consider thermal load
+    else if (type == LOAD_TAG_Beam3dThermalAction) {
+        // GR copied from dispBeamColumn3dThermal
+        // load not inside fire load pattern
+         //static Vector factors(9);
+         //factors.Zero();
+         //factors += loadFactor;
+        // return this->addLoad(theLoad, factors);
+       /// This code block is added by LJ and copied from DispBeamColumn2d(Modified edition) for 'FireLoadPattern'--08-May-2012--//[END]
+        counterTemperature = 1;
+        for (int i = 0; i < 5; i++) {
+            residThermal[i] = 0;
+        }
+        double ThermalN, ThermalMz, ThermalMy;
+        ThermalN = 0.;
+        ThermalMz = 0;
+        ThermalMy = 0;
+
+        double xi[maxNumSections];
+        beamIntegr->getSectionLocations(numSections, L, xi);
+        double wt[maxNumSections];
+        beamIntegr->getSectionWeights(numSections, L, wt);
+
+        // Zero for integration
+        //q.Zero();
+        Vector* dataMixV;
+        if (data.Size() == 18)
+            dataMixV = new Vector(18);
+        else
+            dataMixV = new Vector(25);
+
+        *dataMixV = data;
+
+#ifdef _DEBUG
+        //if(this->getTag()==1){
+      // opserr<<"dataMix in Element"<<this->getTag()<< "___dataMix "<<*dataMixV<<endln;
+          //  }
+#endif
+    // Loop over the integration points
+        for (int i = 0; i < numSections; i++) {
+            // Get section stress resultant
+            const Vector& s = sections[i]->getTemperatureStress(*dataMixV);
+            //opserr<< "Temperature  Stress "<<s<<endln;
+
+            //apply temp along y
+            residThermal[0] = -s(0);
+            residThermal[1] = -s(1);
+            residThermal[2] = s(1);
+            residThermal[3] = -s(2);
+            residThermal[4] = s(2);
+            // opserr<<residThermal[1]<<" "<<residThermal[2]<<"  "<<residThermal[3]<<" "<<residThermal[4]<<endln;
+           //apply temp along z
+             //residThermal[0] = -s(0);
+             //residThermal[1] = -0.;
+             //residThermal[2] = -0.;
+             //residThermal[3] = -s(1);
+             //residThermal[4] = s(1);
+            SectionThermalElong[i] = 0;
+        }
+        AverageThermalElong = 0;
+    }
+    //Added by Liming for implementation of NodalThermalAction
+    else if (type == LOAD_TAG_NodalThermalAction) {
+
+        // load not inside fire load pattern
+      //static Vector factors(9);
+      //factors.Zero();
+      //factors += loadFactor;
+
+        AverageThermalElong = 0.0;
+        for (int i = 0; i < 5; i++) {
+            residThermal[i] = 0;
+        }
+
+        NodalThermalAction* theNodalThermal0 = theNodes[0]->getNodalThermalActionPtr();
+        NodalThermalAction* theNodalThermal1 = theNodes[1]->getNodalThermalActionPtr();
+        int type;
+        const Vector& data0 = theNodalThermal0->getData(type);
+        const Vector& data1 = theNodalThermal1->getData(type);
+        Vector* Loc; Vector* NodalT0; Vector* NodalT1;
+
+        if (data0.Size() == 9) {
+            Loc = new Vector(9);
+            NodalT0 = new Vector(9);
+            NodalT1 = new Vector(9);
+#ifdef _BDEBUG
+            if (this->getTag() == 1) {
+                //opserr<<"NodalT0: "<<data0<<endln<<"NodalT1: "<<data1;
+            }
+#endif
+            for (int i = 0; i < 9; i++) {
+                if (data0(2 * i + 1) - data1(2 * i + 1) > 1e-8 || data0(2 * i + 1) - data1(2 * i + 1) < -1e-8) {
+                    opserr << "Warning:The NodalThermalAction in dispBeamColumn2dThermalNUT " << this->getTag()
+                        << "incompatible loc input for datapoint " << i << endln;
+                }
+                else {
+                    (*Loc)(i) = data0(2 * i + 1);
+                    (*NodalT0)(i) = data0(2 * i);
+                    (*NodalT1)(i) = data1(2 * i);
+                }
+            }
+        }
+        //for 9 data POINTS
+        else {
+            Loc = new Vector(10);
+            NodalT0 = new Vector(15);
+            NodalT1 = new Vector(15);
+
+            for (int i = 0; i < 5; i++) {
+                if (data0(2 * i + 1) - data1(2 * i + 1) > 1e-8 || data0(2 * i + 1) - data1(2 * i + 1) < -1e-8) {
+                    opserr << "Warning:The NodalThermalAction in dispBeamColumn2dThermalNUT " << this->getTag()
+                        << "incompatible loc input for datapoint " << i << endln;
+                }
+                else {
+                    //for loc
+                    (*Loc)(i) = data0(2 * i + 1);
+                    (*Loc)(i + 5) = data0(3 * i + 12);
+                    //for NodalT0
+                    (*NodalT0)(i) = data0(2 * i);
+                    (*NodalT0)(i + 5) = data0(3 * i + 10);
+                    (*NodalT0)(i + 10) = data0(3 * i + 11);
+                    //for NodalT1
+                    (*NodalT1)(i) = data1(2 * i);
+                    (*NodalT1)(i + 5) = data1(3 * i + 10);
+                    (*NodalT1)(i + 10) = data1(3 * i + 11);
+                }
+            }
+
+        }
+        //for 15 data points
+     // opserr<<"data0: "<<data0<<endln<<"NodalT0: "<<NodalT0;
+        double ThermalN, ThermalMz, ThermalMy;
+        ThermalN = 0;
+        ThermalMz = 0;
+        ThermalMy = 0;
+
+        double xi[maxNumSections];
+        beamIntegr->getSectionLocations(numSections, L, xi);
+        double wt[maxNumSections];
+        beamIntegr->getSectionWeights(numSections, L, wt);
+
+        // Loop over the integration points
+        for (int i = 0; i < numSections; i++) {
+            // Get section stress resultant
+            Vector* dataMixV;
+            if (NodalT0->Size() == 9) {
+                for (int m = 0; m < 9; m++) {
+                    (*dataMixV)(2 * m) = (*NodalT0)(m) + xi[i] * ((*NodalT1)(m) - (*NodalT0)(m)); //Linear temperature interpolation
+                    (*dataMixV)(2 * m + 1) = (*Loc)(m);
+                    (*dataMixV)(18 + m) = 1000;
+                }
+            }
+            else if (NodalT0->Size() == 15) {
+                for (int m = 0; m < 5; m++) {
+                    (*dataMixV)(2 * m) = (*NodalT0)(m) + xi[i] * ((*NodalT1)(m) - (*NodalT0)(m)); ////5 temps through y, Linear temperature interpolation
+                    (*dataMixV)(3 * m + 10) = (*NodalT0)(m + 5) + xi[i] * ((*NodalT1)(m + 5) - (*NodalT0)(m + 5));///////5 temps through Z in bottom flange
+                    (*dataMixV)(3 * m + 11) = (*NodalT0)(m + 10) + xi[i] * ((*NodalT1)(m + 10) - (*NodalT0)(m + 10));/////5 temps through Z in top flange
+                    (*dataMixV)(2 * m + 1) = (*Loc)(m);////5 (*Loc)s through y
+                    (*dataMixV)(3 * m + 12) = (*Loc)(m + 5);///////5 (*Loc)s through Z
+                }
+            }
+            const Vector& s = sections[i]->getTemperatureStress(*dataMixV);
+#ifdef _BDEBUG
+            if (this->getTag() == 1) {
+                opserr << "Tag: " << this->getTag() << "Beam3D::dataMixv " << endln << dataMixV << endln;
+            }
+#endif
+            SectionThermalElong[i] = sections[i]->getThermalElong()(0);
+            //opserr<< "Beam3D::Temperature  Stress "<<s<<endln;
+            //apply temp along y
+            residThermal[0] = -s(0);
+            residThermal[1] = -s(1);
+            residThermal[2] = s(1);
+            residThermal[3] = -s(2);
+            residThermal[4] = s(2);
+            // opserr<<residThermal[1]<<" "<<residThermal[2]<<"  "<<residThermal[3]<<" "<<residThermal[4]<<endln;
+            //apply temp along z
+            //residThermal[0] = -s(0);
+            //residThermal[1] = -0.;
+            //residThermal[2] = -0.;
+            //residThermal[3] = -s(1);
+            //residThermal[4] = s(1);
+            double ThermalEloni = SectionThermalElong[i] * wt[i];
+            AverageThermalElong += ThermalEloni;
+        } // for
+     } // if
+
+  } // for each load
+}
+
+void
+ForceBeamColumn3dThermal::computeReactionSensitivity(double *dp0dh, int gradNumber)
+{
+  int type;
+  double L = crdTransf->getInitialLength();
+  
+  double dLdh = crdTransf->getdLdh();
+
+  for (int i = 0; i < numEleLoads; i++) {
+    
+    const Vector &data = eleLoads[i]->getData(type, 1.0);
+
+    if (type == LOAD_TAG_Beam3dUniformLoad) {
+      double wy = data(0)*1.0;  // Transverse
+      double wz = data(1)*1.0;  // Transverse
+      double wa = data(2)*1.0;  // Axial
+
+      const Vector &sens = eleLoads[i]->getSensitivityData(gradNumber);
+      double dwydh = sens(0);
+      double dwzdh = sens(1);
+      double dwadh = sens(2);
+      
+      //p0[0] -= wa*L;
+      dp0dh[0] -= wa*dLdh + dwadh*L;
+
+      //double V = 0.5*wy*L;
+      //p0[1] -= V;
+      //p0[2] -= V;
+      double dVdh = 0.5*(wy*dLdh + dwydh*L);
+      dp0dh[1] -= dVdh;
+      dp0dh[2] -= dVdh;
+      dVdh = 0.5*(wz*L + dwzdh*L);
+      dp0dh[3] -= dVdh;
+      dp0dh[4] -= dVdh;
+    }
+    else if (type == LOAD_TAG_Beam3dPointLoad) {
+      double Py = data(0)*1.0;
+      double Pz = data(1)*1.0;
+      double N  = data(2)*1.0;
+      double aOverL = data(3);
+
+      if (aOverL < 0.0 || aOverL > 1.0)
+	continue;
+      
+      const Vector &sens = eleLoads[i]->getSensitivityData(gradNumber);
+      double dPydh = sens(0);
+      double dPzdh = sens(1);
+      double dNdh  = sens(2);
+      double daLdh = sens(3);
+
+      //double a = aOverL*L;
+      
+      //double V1 = Py*(1.0-aOverL);
+      //double V2 = Py*aOverL;
+      double dV1dh = Py*(0.0-daLdh) + dPydh*(1.0-aOverL);
+      double dV2dh = Py*daLdh + dPydh*aOverL;
+      
+      //p0[0] -= N;
+      //p0[1] -= V1;
+      //p0[2] -= V2;
+      dp0dh[0] -= dNdh;
+      dp0dh[1] -= dV1dh;
+      dp0dh[2] -= dV2dh;
+
+      dV1dh = Pz*(0.0-daLdh) + dPzdh*(1.0-aOverL);
+      dV2dh = Pz*daLdh + dPzdh*aOverL;
+      dp0dh[3] -= dV1dh;
+      dp0dh[4] -= dV2dh;
+    }
+  }
+}
+
+const Vector &
+ForceBeamColumn3dThermal::getResistingForce(void)
+{
+  // Will remove once we clean up the corotational 3d transformation -- MHS
+  crdTransf->update();
+  
+  double p0[5];
+  Vector p0Vec(p0, 5);
+  p0Vec.Zero();
+  
+  if (numEleLoads > 0)
+    this->computeReactions(p0);
+  
+  theVector =  crdTransf->getGlobalResistingForce(Se, p0Vec);
+  
+  if (rho != 0)
+    theVector.addVector(1.0, load, -1.0);
+  
+  return theVector;
+}
+
+const Vector &
+ForceBeamColumn3dThermal::getDampingForce(void)
+{
+  crdTransf->update();
+
+  return crdTransf->getGlobalResistingForce(theDamping->getDampingForce(), Vector(5));
+}
+
+void
+  ForceBeamColumn3dThermal::initializeSectionHistoryVariables (void)
+{
+  for (int i = 0; i < numSections; i++) {
+    int order = sections[i]->getOrder();
+    
+    fs[i] = Matrix(order,order);
+    vs[i] = Vector(order);
+    Ssr[i] = Vector(order);
+    
+      vscommit[i] = Vector(order);
+  }
+}
+
+  /********* NEWTON , SUBDIVIDE AND INITIAL ITERATIONS ********************
+   */
+  int
+  ForceBeamColumn3dThermal::update()
+  {
+    // if have completed a recvSelf() - do a revertToLastCommit
+    // to get Ssr, etc. set correctly
+    if (initialFlag == 2)
+      this->revertToLastCommit();
+
+    // update the transformation
+    crdTransf->update();
+
+    // get basic displacements and increments
+    const Vector &v = crdTransf->getBasicTrialDisp();    
+
+    static Vector dv(NEBD);
+    dv = crdTransf->getBasicIncrDeltaDisp();    
+
+    if (initialFlag != 0 && dv.Norm() <= DBL_EPSILON && numEleLoads == 0)
+      return 0;
+
+    static Vector vin(NEBD);
+    vin = v;
+    vin -= dv;
+    double L = crdTransf->getInitialLength();
+    double oneOverL  = 1.0/L;  
+
+    double xi[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, xi);
+
+    double wt[maxNumSections];
+    beamIntegr->getSectionWeights(numSections, L, wt);
+
+    static Vector vr(NEBD);       // element residual displacements
+    static Matrix f(NEBD,NEBD);   // element flexibility matrix
+
+    static Matrix I(NEBD,NEBD);   // an identity matrix for matrix inverse
+    double dW;                    // section strain energy (work) norm 
+    int i, j;
+
+    I.Zero();
+    for (i=0; i<NEBD; i++)
+      I(i,i) = 1.0;
+
+    int numSubdivide = 1;
+    bool converged = false;
+    static Vector dSe(NEBD);
+    static Vector dvToDo(NEBD);
+    static Vector dvTrial(NEBD);
+    static Vector SeTrial(NEBD);
+    static Matrix kvTrial(NEBD, NEBD);
+
+    dvToDo = dv;
+    dvTrial = dvToDo;
+
+    //static double factor = 10;
+    double factor = subdivideFactor;
+    double dW0 = 0.0;
+
+    //maxSubdivisions = 10;
+
+    // fmk - modification to get compatible ele forces and deformations 
+    //   for a change in deformation dV we try first a newton iteration, if
+    //   that fails we try an initial flexibility iteration on first iteration 
+    //   and then regular newton, if that fails we use the initial flexiblity
+    //   for all iterations.
+    //
+    //   if they both fail we subdivide dV & try to get compatible forces
+    //   and deformations. if they work and we have subdivided we apply
+    //   the remaining dV.
+    int ThermalCounter = 0;
+    while (converged == false && numSubdivide <= maxSubdivisions) {
+
+      // try regular newton (if l==0), or
+      // initial tangent iterations (if l==1), or
+      // initial tangent on first iteration then regular newton (if l==2)
+
+      for (int l=0; l<3; l++) {
+
+	//      if (l == 1) l = 2;
+	SeTrial = Se;
+	kvTrial = kv;
+	for (i=0; i<numSections; i++) {
+	  vsSubdivide[i] = vs[i];
+	  fsSubdivide[i] = fs[i];
+	  SsrSubdivide[i] = Ssr[i];
+	}
+
+	// calculate nodal force increments and update nodal forces      
+	// dSe = kv * dv;
+	dSe.addMatrixVector(0.0, kvTrial, dvTrial, 1.0);
+	SeTrial += dSe;
+
+	if (initialFlag != 2) {
+
+	  int numIters = maxIters;
+	  if (l == 1) 
+	    numIters = 10*maxIters; // allow 10 times more iterations for initial tangent
+
+	  for (j=0; j <numIters; j++) {
+
+	    // initialize f and vr for integration
+	    f.Zero();
+	    vr.Zero();
+
+	for (i=0; i<numSections; i++) {
+	  
+	  int order      = sections[i]->getOrder();
+	  const ID &code = sections[i]->getType();
+	  
+	  static Vector Ss;
+	  static Vector dSs;
+	  static Vector dvs;
+	  static Matrix fb;
+	  
+	  Ss.setData(workArea, order);
+	  dSs.setData(&workArea[order], order);
+	  dvs.setData(&workArea[2*order], order);
+	  fb.setData(&workArea[3*order], order, NEBD);
+	  
+	  double xL  = xi[i];
+	  double xL1 = xL-1.0;
+	  double wtL = wt[i]*L;
+	  
+	  // calculate total section forces
+	  // Ss = b*Se + bp*currDistrLoad;
+	  // Ss.addMatrixVector(0.0, b[i], Se, 1.0);
+	  int ii;
+	  for (ii = 0; ii < order; ii++) {
+	    switch(code(ii)) {
+	    case SECTION_RESPONSE_P:
+	      Ss(ii) = SeTrial(0);
+	      break;
+	    case SECTION_RESPONSE_MZ:
+	      Ss(ii) = xL1*SeTrial(1) + xL*SeTrial(2);
+	      break;
+	    case SECTION_RESPONSE_VY:
+	      Ss(ii) = oneOverL*(SeTrial(1)+SeTrial(2));
+	      break;
+	    case SECTION_RESPONSE_MY:
+	      Ss(ii) = xL1*SeTrial(3) + xL*SeTrial(4);
+	      break;
+	    case SECTION_RESPONSE_VZ:
+	      Ss(ii) = oneOverL*(SeTrial(3)+SeTrial(4));
+	      break;
+	    case SECTION_RESPONSE_T:
+	      Ss(ii) = SeTrial(5);
+	      break;
+	    default:
+	      Ss(ii) = 0.0;
+	      break;
+	    }
+	  }
+	  
+	  // Add the effects of element loads, if present
+          // s = b*q + sp
+          if (numEleLoads > 0)
+            this->computeSectionForces(Ss, i);
+	  
+	  // dSs = Ss - Ssr[i];
+	  dSs = Ss;
+	  dSs.addVector(1.0, SsrSubdivide[i], -1.0);
+	  
+	  // compute section deformation increments
+	  if (l == 0) {
+	    
+	    //  regular newton 
+	    //    vs += fs * dSs;     
+	    
+	    dvs.addMatrixVector(0.0, fsSubdivide[i], dSs, 1.0);
+	    
+	  } else if (l == 2) {
+	    
+	    //  newton with initial tangent if first iteration
+	    //    vs += fs0 * dSs;     
+	    //  otherwise regular newton 
+	    //    vs += fs * dSs;     
+	    
+	    if (j == 0) {
+	      const Matrix &fs0 = sections[i]->getInitialFlexibility();
+	      
+	      dvs.addMatrixVector(0.0, fs0, dSs, 1.0);
+	    } else
+	      dvs.addMatrixVector(0.0, fsSubdivide[i], dSs, 1.0);
+	    
+	  } else {
+	    
+	    //  newton with initial tangent
+	    //    vs += fs0 * dSs;     
+	    
+	    const Matrix &fs0 = sections[i]->getInitialFlexibility();
+	    dvs.addMatrixVector(0.0, fs0, dSs, 1.0);
+	  }
+	  
+      if (ThermalCounter == 0 && counterTemperature == 1) {
+          const Vector& Vsth = sections[i]->getThermalElong();
+          // Vsth0->Zero();
+          //for(int t=0;t<Vsth.Size();t++)
+           //vsSubdivide[i](t) +=(Vsth(t)-Vsth0[i](t));
+
+#ifdef _BDEBUG
+          opserr << "Vsth " << Vsth << "  Vsth0 " << Vsth0[i];
+#endif
+          double xi6 = 6.0 * xi[i];
+          int index;
+          for (index = 0; index < order; index++) {
+              switch (code(index)) {
+              case SECTION_RESPONSE_P:
+                  dvs(index) = Vsth(0) - Vsth0[i](0); break;
+              case SECTION_RESPONSE_MZ:
+                  dvs(index) = oneOverL * ((xi6 - 4.0) * dvTrial(1) + (xi6 - 2.0) * dvTrial(2));
+                  break;
+              case SECTION_RESPONSE_MY:
+                  dvs(index) = oneOverL * ((xi6 - 4.0) * dvTrial(3) + (xi6 - 2.0) * dvTrial(4));
+                  break;
+              case SECTION_RESPONSE_VY:
+                  dvs(index) = oneOverL * (dvTrial(1) + dvTrial(2));
+                  break;
+              case SECTION_RESPONSE_VZ:
+                  dvs(index) = oneOverL * (dvTrial(3) + dvTrial(4));
+                  break;
+              case SECTION_RESPONSE_T:
+                  dvs(index) = dvTrial(5);
+                  break;
+              default:
+                  dvs(index) = 0.0; break;
+              }
+          }
+
+          Vsth0[i] = Vsth;
+      }
+
+	  // set section deformations
+	  if (initialFlag != 0)
+	    vsSubdivide[i] += dvs;
+	  
+	  if ( sections[i]->setTrialSectionDeformation(vsSubdivide[i]) < 0) {
+	    opserr << "ForceBeamColumn3dThermal::update() - section failed in setTrial\n";
+	    return -1;
+	  }
+	  
+	  // get section resisting forces
+	  SsrSubdivide[i] = sections[i]->getStressResultant();
+	  
+	  // get section flexibility matrix
+	  // FRANK 
+	  fsSubdivide[i] = sections[i]->getSectionFlexibility();
+	  
+//#ifdef _DEBUG 
+//      if (ops_TheActiveDomain->getCurrentTime() >= 1.18 && this->getTag() == 575)
+//          opserr << "Flex index " << i  << " - val: " << fsSubdivide[i] << endln;
+//#endif
+
+	  /*
+	    const Matrix &sectionStiff = sections[i]->getSectionTangent();
+	    int n = sectionStiff.noRows();
+	    Matrix I(n,n); I.Zero(); for (int l=0; l<n; l++) I(l,l) = 1.0;
+	    Matrix sectionFlex(n,n);
+	    sectionStiff.SolveSVD(I, sectionFlex, 1.0e-6);
+	    fsSubdivide[i] = sectionFlex;	    
+	  */
+	  
+	  // calculate section residual deformations
+	  // dvs = fs * (Ss - Ssr);
+	  dSs = Ss;
+	  dSs.addVector(1.0, SsrSubdivide[i], -1.0);  // dSs = Ss - Ssr[i];
+	  
+	  dvs.addMatrixVector(0.0, fsSubdivide[i], dSs, 1.0);
+	  
+	  // integrate element flexibility matrix
+	  // f = f + (b^ fs * b) * wtL;
+	  //f.addMatrixTripleProduct(1.0, b[i], fs[i], wtL);
+	  int jj;
+	  const Matrix &fSec = fsSubdivide[i];
+	  fb.Zero();
+	  double tmp;
+	  for (ii = 0; ii < order; ii++) {
+	    switch(code(ii)) {
+	    case SECTION_RESPONSE_P:
+	      for (jj = 0; jj < order; jj++)
+		fb(jj,0) += fSec(jj,ii)*wtL;
+	      break;
+	    case SECTION_RESPONSE_MZ:
+	      for (jj = 0; jj < order; jj++) {
+		tmp = fSec(jj,ii)*wtL;
+		    fb(jj,1) += xL1*tmp;
+		    fb(jj,2) += xL*tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_VY:
+		  for (jj = 0; jj < order; jj++) {
+		    tmp = oneOverL*fSec(jj,ii)*wtL;
+		    fb(jj,1) += tmp;
+		    fb(jj,2) += tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_MY:
+		  for (jj = 0; jj < order; jj++) {
+		    tmp = fSec(jj,ii)*wtL;
+		    fb(jj,3) += xL1*tmp;
+		    fb(jj,4) += xL*tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_VZ:
+		  for (jj = 0; jj < order; jj++) {
+		    tmp = oneOverL*fSec(jj,ii)*wtL;
+		    fb(jj,3) += tmp;
+		    fb(jj,4) += tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_T:
+		  for (jj = 0; jj < order; jj++)
+		    fb(jj,5) += fSec(jj,ii)*wtL;
+		  break;
+		default:
+		  break;
+		}
+	      }
+
+	      for (ii = 0; ii < order; ii++) {
+		switch (code(ii)) {
+		case SECTION_RESPONSE_P:
+		  for (jj = 0; jj < NEBD; jj++)
+		    f(0,jj) += fb(ii,jj);
+		  break;
+		case SECTION_RESPONSE_MZ:
+		  for (jj = 0; jj < NEBD; jj++) {
+		    tmp = fb(ii,jj);
+		    f(1,jj) += xL1*tmp;
+		    f(2,jj) += xL*tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_VY:
+		  for (jj = 0; jj < NEBD; jj++) {
+		    tmp = oneOverL*fb(ii,jj);
+		    f(1,jj) += tmp;
+		    f(2,jj) += tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_MY:
+		  for (jj = 0; jj < NEBD; jj++) {
+		    tmp = fb(ii,jj);
+		    f(3,jj) += xL1*tmp;
+		    f(4,jj) += xL*tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_VZ:
+		  for (jj = 0; jj < NEBD; jj++) {
+		    tmp = oneOverL*fb(ii,jj);
+		    f(3,jj) += tmp;
+		    f(4,jj) += tmp;
+		  }
+		  break;
+		case SECTION_RESPONSE_T:
+		  for (jj = 0; jj < NEBD; jj++)
+		    f(5,jj) += fb(ii,jj);
+		  break;
+		default:
+		  break;
+		}
+	      }
+
+	      // integrate residual deformations
+	      // vr += (b^ (vs + dvs)) * wtL;
+	      //vr.addMatrixTransposeVector(1.0, b[i], vs[i] + dvs, wtL);
+	      dvs.addVector(1.0, vsSubdivide[i], 1.0);
+	      double dei;
+	      for (ii = 0; ii < order; ii++) {
+//#ifdef _DEBUG 
+//              if (isnan(vr(3)))
+//                  opserr << "stop";
+//#endif
+		dei = dvs(ii)*wtL;
+		switch(code(ii)) {
+		case SECTION_RESPONSE_P:
+		  vr(0) += dei;
+		  break;
+		case SECTION_RESPONSE_MZ:
+		  vr(1) += xL1*dei; vr(2) += xL*dei;
+		  break;
+		case SECTION_RESPONSE_VY:
+		  tmp = oneOverL*dei;
+		  vr(1) += tmp; vr(2) += tmp;
+		  break;
+		case SECTION_RESPONSE_MY:
+		  vr(3) += xL1*dei; vr(4) += xL*dei;
+		  break;
+		case SECTION_RESPONSE_VZ:
+		  tmp = oneOverL*dei;
+		  vr(3) += tmp; vr(4) += tmp;
+		  break;
+		case SECTION_RESPONSE_T:
+		  vr(5) += dei;
+		  break;
+		default:
+		  break;
+		}
+	      }
+	    }
+
+	    if (!isTorsion) {
+	      f(5,5) = DefaultLoverGJ;
+	      vr(5) = SeTrial(5)*DefaultLoverGJ;
+	    }
+
+	    // calculate element stiffness matrix
+	    // invert3by3Matrix(f, kv);	  
+	    // FRANK
+	    //	  if (f.SolveSVD(I, kvTrial, 1.0e-12) < 0)
+	    if (f.Solve(I, kvTrial) < 0)
+	      opserr << "ForceBeamColumn3dThermal::update() -- could not invert flexibility for element with tag: " << this->getTag() << " - Time: " << ops_TheActiveDomain->getCurrentTime() << endln;;
+	    
+	    // dv = vin + dvTrial  - vr
+	    dv = vin;
+	    dv += dvTrial;
+	    dv -= vr;
+
+	    // dv.addVector(1.0, vr, -1.0);
+
+	    // dSe = kv * dv;
+	    dSe.addMatrixVector(0.0, kvTrial, dv, 1.0);
+
+	    dW = dv ^ dSe; 
+	    if (dW0 == 0.0) 
+	      dW0 = dW;
+
+	    SeTrial += dSe;
+
+	    // check for convergence of this interval
+        ThermalCounter = 1;
+	    if (fabs(dW) < tol) { 
+
+	      // set the target displacement
+	      dvToDo -= dvTrial;
+	      vin += dvTrial;
+
+	      // check if we have got to where we wanted
+	      if (dvToDo.Norm() <= DBL_EPSILON) {
+		converged = true;
+
+	      } else {  // we convreged but we have more to do
+
+		// reset variables for start of next subdivision
+		dvTrial = dvToDo;
+		numSubdivide = 1;  // NOTE setting subdivide to 1 again maybe too much
+	      }
+
+	      // set kv, vs and Se values
+	      kv = kvTrial;
+	      Se = SeTrial;
+
+	      for (int k=0; k<numSections; k++) {
+		vs[k] = vsSubdivide[k];
+		fs[k] = fsSubdivide[k];
+		Ssr[k] = SsrSubdivide[k];
+	      }
+
+	      // break out of j & l loops
+	      j = numIters+1;
+	      l = 4;
+
+	    } else {   //  if (fabs(dW) < tol) { 
+
+	      // if we have failed to convrege for all of our newton schemes
+	      // - reduce step size by the factor specified
+	      if (j == (numIters-1) && (l == 2)) {
+		dvTrial /= factor;
+		numSubdivide++;
+	      }
+	    }
+
+	  } // for (j=0; j<numIters; j++)
+	} // if (initialFlag != 2)
+      } // for (int l=0; l<2; l++)
+    } // while (converged == false)
+
+  if (theDamping)
+  {
+    kv *= theDamping->getStiffnessMultiplier();
+    theDamping->update(Se);
+  }
+
+    // if fail to converge we return an error flag & print an error message
+
+    if (converged == false) {
+      opserr << "WARNING - ForceBeamColumn3dThermal::update - failed to get compatible ";
+      opserr << "element forces & deformations for element: ";
+      opserr << this->getTag() << "(dW: << " << dW << ", dW0: " << dW0 << ")\n";
+
+      /*
+      opserr << "Section Tangent Condition Numbers: ";
+      for (int i=0; i<numSections; i++) {
+	const Matrix &sectionStiff = sections[i]->getSectionTangent();
+	double conditionNumber = sectionStiff.conditionNumber();
+	opserr << conditionNumber << " ";
+      }
+      opserr << endln;
+      */
+
+      return -1;
+    }
+
+    initialFlag = 1;
+
+    return 0;
+  }
+
+  void ForceBeamColumn3dThermal::getForceInterpolatMatrix(double xi, Matrix &b, const ID &code)
+  {
+    b.Zero();
+
+    double L = crdTransf->getInitialLength();
+    for (int i = 0; i < code.Size(); i++) {
+      switch (code(i)) {
+      case SECTION_RESPONSE_MZ:		// Moment, Mz, interpolation
+	b(i,1) = xi - 1.0;
+	b(i,2) = xi;
+	break;
+      case SECTION_RESPONSE_P:		// Axial, P, interpolation
+	b(i,0) = 1.0;
+	break;
+      case SECTION_RESPONSE_VY:		// Shear, Vy, interpolation
+	b(i,1) = b(i,2) = 1.0/L;
+	break;
+      case SECTION_RESPONSE_MY:              // Moment, My, interpolation
+	b(i,3) = xi - 1.0;
+	b(i,4) = xi;
+	break;
+      case SECTION_RESPONSE_VZ:              // Shear, Vz, interpolation
+	b(i,3) = b(i,4) = 1.0/L;
+	break;
+      case SECTION_RESPONSE_T:               // Torque, T, interpolation
+	b(i,5) = 1.0;
+	break;
+      default:
+	break;
+      }
+    }
+  }
+
+  void ForceBeamColumn3dThermal::getDistrLoadInterpolatMatrix(double xi, Matrix &bp, const ID &code)
+  {
+    bp.Zero();
+
+    double L = crdTransf->getInitialLength();
+    for (int i = 0; i < code.Size(); i++) {
+      switch (code(i)) {
+      case SECTION_RESPONSE_MZ:		// Moment, Mz, interpolation
+	bp(i,1) = xi*(xi-1)*L*L/2;
+	break;
+      case SECTION_RESPONSE_P:		// Axial, P, interpolation
+	bp(i,0) = (1-xi)*L;
+	break;
+      case SECTION_RESPONSE_VY:		// Shear, Vy, interpolation
+	bp(i,1) = (xi-0.5)*L;
+	break;
+      case SECTION_RESPONSE_MY:              // Moment, My, interpolation
+	bp(i,2) = xi*(1-xi)*L*L/2;
+	break;
+      case SECTION_RESPONSE_VZ:              // Shear, Vz, interpolation
+	bp(i,2) = (0.5-xi)*L;
+	break;
+      case SECTION_RESPONSE_T:               // Torsion, T, interpolation
+	break;
+      default:
+	break;
+      }
+    }
+  }
+
+  const Matrix &
+  ForceBeamColumn3dThermal::getMass(void)
+  { 
+    theMatrix.Zero();
+
+    double L = crdTransf->getInitialLength();
+    if (rho != 0.0)
+      theMatrix(0,0) = theMatrix(1,1) = theMatrix(2,2) =
+	theMatrix(6,6) = theMatrix(7,7) = theMatrix(8,8) = 0.5*L*rho;
+
+    return theMatrix;
+  }
+
+  void 
+  ForceBeamColumn3dThermal::zeroLoad(void)
+  {
+    load.Zero();
+    
+    // This is a semi-hack -- MHS
+    numEleLoads = 0;
+    
+    return;
+  }
+
+int
+ForceBeamColumn3dThermal::addLoad(ElementalLoad *theLoad, double loadFactor)
+{
+  if (numEleLoads == sizeEleLoads) {
+
+    //
+    // create larger arrays, copy old, delete old & set as new
+    //
+
+    ElementalLoad ** theNextEleLoads = new ElementalLoad *[sizeEleLoads+1];
+    double *theNextEleLoadFactors = new double[sizeEleLoads+1];
+    for (int i=0; i<numEleLoads; i++) {
+      theNextEleLoads[i] = eleLoads[i];
+      theNextEleLoadFactors[i] = eleLoadFactors[i];
+    }
+    delete [] eleLoads;
+    delete [] eleLoadFactors;
+    eleLoads = theNextEleLoads;
+    eleLoadFactors = theNextEleLoadFactors;  
+
+    // increment array size
+    sizeEleLoads+=1;
+  }
+
+  eleLoadFactors[numEleLoads] = loadFactor;
+  eleLoads[numEleLoads] = theLoad;
+  numEleLoads++;
+
+  return 0;
+}
+
+void
+ForceBeamColumn3dThermal::computeSectionForces(Vector &sp, int isec)
+{
+  int type;
+
+  double L = crdTransf->getInitialLength();
+
+  double xi[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, xi);
+  double x = xi[isec]*L;
+
+  int order = sections[isec]->getOrder();
+  const ID &code = sections[isec]->getType();
+
+  for (int i = 0; i < numEleLoads; i++) {
+
+    double loadFactor = eleLoadFactors[i];
+    const Vector &data = eleLoads[i]->getData(type, loadFactor);
+
+    if (type == LOAD_TAG_Beam3dUniformLoad) {
+      double wy = data(0)*loadFactor;  // Transverse
+      double wz = data(1)*loadFactor;  // Transverse
+      double wa = data(2)*loadFactor;  // Axial
+
+      for (int ii = 0; ii < order; ii++) {
+	
+	switch(code(ii)) {
+	case SECTION_RESPONSE_P:
+	  sp(ii) += wa*(L-x);
+	  break;
+	case SECTION_RESPONSE_MZ:
+	  sp(ii) += wy*0.5*x*(x-L);
+	  break;
+	case SECTION_RESPONSE_VY:
+	  sp(ii) += wy*(x-0.5*L);
+	  break;
+	case SECTION_RESPONSE_MY:
+	  sp(ii) += wz*0.5*x*(L-x);
+	  break;
+	case SECTION_RESPONSE_VZ:
+	  sp(ii) += wz*(0.5*L-x);
+	  break;
+	default:
+	  break;
+	}
+      }
+    }
+    else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
+      double wy = data(0) * loadFactor;  // Transverse Y at start
+      double wz = data(1) * loadFactor;  // Transverse Z at start
+      double wa = data(2) * loadFactor;  // Axial at start
+      double a = data(3)*L;
+      double b = data(4)*L;
+      double wyb = data(5) * loadFactor;  // Transverse Y at end
+      double wzb = data(6) * loadFactor;  // Transverse Z at end
+      double wab = data(7) * loadFactor;  // Axial at end
+      double Fa = wa * (b - a) + 0.5 * (wab - wa) * (b - a); // resultant axial load
+      double Fy = wy * (b - a); // resultant transverse load
+      double Fz = wz * (b - a); // resultant transverse load
+      double c = a + 0.5 * (b - a);
+      double VyI = Fy * (1 - c / L);
+      double VyJ = Fy * c / L;
+      double VzI = Fz * (1 - c / L);
+      double VzJ = Fz * c / L;
+      Fy = 0.5 * (wyb - wy) * (b - a); // resultant transverse load
+      Fz = 0.5 * (wzb - wz) * (b - a); // resultant transverse load
+      c = a + 2.0 / 3.0 * (b - a);
+      VyI += Fy * (1 - c / L);
+      VyJ += Fy * c / L;
+      VzI += Fz * (1 - c / L);
+      VzJ += Fz * c / L;
+     
+      for (int ii = 0; ii < order; ii++) {
+	if (x <= a) {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_P:
+	    sp(ii) += Fa;
+	    break;
+	  case SECTION_RESPONSE_MZ:
+	    sp(ii) -= VyI*x;
+	    break;
+	  case SECTION_RESPONSE_MY:
+	    sp(ii) += VzI*x;
+	    break;	    
+	  case SECTION_RESPONSE_VY:
+	    sp(ii) -= VyI;
+	    break;
+	  case SECTION_RESPONSE_VZ:
+        sp(ii) += VzI;
+	    break;	    
+	  default:
+	    break;
+	  }
+	}
+	else if (x >= b) {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_MZ:
+	    sp(ii) += VyJ*(x-L);
+	    break;
+	  case SECTION_RESPONSE_MY:
+	    sp(ii) -= VzJ*(x-L);
+	    break;	    
+	  case SECTION_RESPONSE_VY:
+	    sp(ii) += VyJ;
+	    break;
+	  case SECTION_RESPONSE_VZ:
+	    sp(ii) -= VzJ;	    
+	    break;
+	  default:
+	    break;
+	  }
+	}
+	else {
+      double wyy = wy + (wyb - wy) / (b - a) * (x - a);
+      double wzz = wz + (wzb - wz) / (b - a) * (x - a);
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_P:
+	    sp(ii) += Fa - wa * (x - a) - 0.5 * (wab - wa) / (b - a) * (x - a) * (x - a);
+	    break;
+	  case SECTION_RESPONSE_MZ:
+        sp(ii) += -VyI * x + 0.5 * wy * (x - a) * (x - a) + 0.5 * (wyy - wy) * (x - a) * (x - a) / 3.0;
+	    break;
+	  case SECTION_RESPONSE_MY:
+          sp(ii) += VzI * x - 0.5 * wz * (x - a) * (x - a) - 0.5 * (wzz - wz) * (x - a) * (x - a) / 3.0;
+	    break;	    
+	  case SECTION_RESPONSE_VY:
+        sp(ii) += -VyI + wy * (x - a) + 0.5 * (wyy - wy) * (x - a);
+        break;
+	  case SECTION_RESPONSE_VZ:	   
+        sp(ii) -= -VzI + wz * (x - a) - 0.5 * (wzz - wz) * (x - a);
+        break;
+	  default:
+	    break;
+	  }
+    }
+      }
+    }
+    else if (type == LOAD_TAG_Beam3dPointLoad) {
+      double Py = data(0)*loadFactor;
+      double Pz = data(1)*loadFactor;
+      double N  = data(2)*loadFactor;
+      double aOverL = data(3);
+      
+      if (aOverL < 0.0 || aOverL > 1.0)
+	continue;
+      
+      double a = aOverL*L;
+      
+      double Vy1 = Py*(1.0-aOverL);
+      double Vy2 = Py*aOverL;
+      
+      double Vz1 = Pz*(1.0-aOverL);
+      double Vz2 = Pz*aOverL;
+
+      for (int ii = 0; ii < order; ii++) {
+	
+	if (x <= a) {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_P:
+	    sp(ii) += N;
+	    break;
+	  case SECTION_RESPONSE_MZ:
+	    sp(ii) -= x*Vy1;
+	    break;
+	  case SECTION_RESPONSE_VY:
+	    sp(ii) -= Vy1;
+	    break;
+	  case SECTION_RESPONSE_MY:
+	    sp(ii) += x*Vz1;
+	    break;
+	  case SECTION_RESPONSE_VZ:
+	    sp(ii) -= Vz1;
+	    break;
+	  default:
+	    break;
+	  }
+	}
+	else {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_MZ:
+	    sp(ii) -= (L-x)*Vy2;
+	    break;
+	  case SECTION_RESPONSE_VY:
+	    sp(ii) += Vy2;
+	    break;
+	  case SECTION_RESPONSE_MY:
+	    sp(ii) += (L-x)*Vz2;
+	    break;
+	  case SECTION_RESPONSE_VZ:
+	    sp(ii) += Vz2;
+	    break;
+	  default:
+	    break;
+	  }
+	}
+      }
+    } 
+    else if (type == LOAD_TAG_Beam3dThermalAction || type == LOAD_TAG_ThermalActionWrapper || type == LOAD_TAG_NodalThermalAction) {
+        // GR - commented in forceBC2d
+        /*sections[isec]->getTemperatureStress
+
+        switch(code(ii)) {
+      case SECTION_RESPONSE_P:
+        sp(ii) += N;
+        break;
+      case SECTION_RESPONSE_MZ:
+        sp(ii) -= x*V1;
+        break;
+      case SECTION_RESPONSE_VY:
+        sp(ii) -= V1;
+        break;
+      default:
+        break;
+      }
+      */
+
+    }
+    else {
+      opserr << "ForceBeamColumn3dThermal::addLoad -- load type unknown for element with tag: " <<
+	this->getTag() << endln;
+    }
+  }
+  
+  // Don't think we need to do this anymore -- MHS
+  //this->update(); // quick fix -- MHS
+}
+
+void
+ForceBeamColumn3dThermal::computeSectionForceSensitivity(Vector &dspdh, int isec,
+						  int gradNumber)
+{
+  int type;
+
+  double L = crdTransf->getInitialLength();
+  double dLdh = crdTransf->getdLdh();
+
+  double xi[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, xi);
+
+  double dxidh[maxNumSections];
+  beamIntegr->getLocationsDeriv(numSections, L, dLdh, dxidh);
+
+  double x = xi[isec]*L;
+  double dxdh = xi[isec]*dLdh + dxidh[isec]*L;
+      
+  int order = sections[isec]->getOrder();
+  const ID &code = sections[isec]->getType();
+
+  for (int i = 0; i < numEleLoads; i++) {
+
+    const Vector &data = eleLoads[i]->getData(type, 1.0);
+    
+    if (type == LOAD_TAG_Beam3dUniformLoad) {
+      double wy = data(0)*1.0;  // Transverse
+      double wz = data(1)*1.0;  // Transverse
+      double wa = data(2)*1.0;  // Axial
+
+      const Vector &sens = eleLoads[i]->getSensitivityData(gradNumber);
+      double dwydh = sens(0);
+      double dwzdh = sens(1);
+      double dwadh = sens(2);
+
+      for (int ii = 0; ii < order; ii++) {
+	
+	switch(code(ii)) {
+	case SECTION_RESPONSE_P:
+	  //sp(ii) += wa*(L-x);
+	  dspdh(ii) += dwadh*(L-x) + wa*(dLdh-dxdh);
+	  break;
+	case SECTION_RESPONSE_MZ:
+	  //sp(ii) += wy*0.5*x*(x-L);
+	  //dspdh(ii) += 0.5*(dwydh*x*(x-L) + wy*dxdh*(x-L) + wy*x*(dxdh-dLdh));
+	  dspdh(ii) += 0.5*(dwydh*x*(x-L) + wy*(dxdh*(2*x-L)-x*dLdh));
+	  break;
+	case SECTION_RESPONSE_VY:
+	  //sp(ii) += wy*(x-0.5*L);
+	  dspdh(ii) += dwydh*(x-0.5*L) + wy*(dxdh-0.5*dLdh);
+	  break;
+    case SECTION_RESPONSE_MY:
+        //sp(ii) += wz*0.5*x*(L-x);
+        //dspdh(ii) += 0.5*(dwzdh*x*(L-x) + wz*dxdh*(L-x) + wz*x*(dLdh-dxdh));
+        dspdh(ii) += 0.5*(dwzdh*x*(L-x) + wz*(dxdh*(L-2*x) + x*dLdh));
+        break;
+    case SECTION_RESPONSE_VZ:
+        //sp(ii) += wz*(x-0.5*L);
+        dspdh(ii) += dwzdh*(0.5*L-x) + wz*(0.5*dLdh-dxdh);
+        break;
+    default:
+	  break;
+	}
+      }
+    }
+    else if (type == LOAD_TAG_Beam3dPointLoad) {
+      double Py = data(0)*1.0;
+      double Pz = data(1)*1.0;
+      double N = data(2)*1.0;
+      double aOverL = data(3);
+      
+      if (aOverL < 0.0 || aOverL > 1.0)
+	continue;
+      
+      const Vector &sens = eleLoads[i]->getSensitivityData(gradNumber);
+      double dPydh = sens(0);
+      double dPzdh = sens(1);
+      double dNdh = sens(2);
+      double daLdh = sens(3);
+
+      double a = aOverL*L;
+
+      double Vy1 = Py*(1.0-aOverL);
+      double Vy2 = Py*aOverL;
+      double dVy1dh = Py*(0.0-daLdh) + dPydh*(1.0-aOverL);
+      double dVy2dh = Py*daLdh + dPydh*aOverL;
+
+      double Vz1 = Pz*(1.0 - aOverL);
+      double Vz2 = Pz*aOverL;
+      double dVz1dh = Pz*(0.0 - daLdh) + dPzdh*(1.0 - aOverL);
+      double dVz2dh = Pz*daLdh + dPzdh*aOverL;
+
+      for (int ii = 0; ii < order; ii++) {
+	
+	if (x <= a) {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_P:
+	    //sp(ii) += N;
+	    dspdh(ii) += dNdh;
+	    break;
+	  case SECTION_RESPONSE_MZ:
+	    //sp(ii) -= x*Vy1;
+	    dspdh(ii) -= (dxdh*Vy1 + x*dVy1dh);
+	    break;
+	  case SECTION_RESPONSE_VY:
+	    //sp(ii) -= Vy1;
+	    dspdh(ii) -= dVy1dh;
+	    break;
+      case SECTION_RESPONSE_MY:
+          //sp(ii) += x*Vz1;
+          dspdh(ii) += (dxdh*Vz1 + x*dVz1dh);
+          break;
+      case SECTION_RESPONSE_VZ:
+          //sp(ii) -= Vz1;
+          dspdh(ii) -= dVz1dh;
+          break;
+      default:
+	    break;
+	  }
+	}
+	else {
+	  switch(code(ii)) {
+	  case SECTION_RESPONSE_MZ:
+	    //sp(ii) -= (L-x)*Vy2;
+	    dspdh(ii) -= (dLdh-dxdh)*Vy2 + (L-x)*dVy2dh;
+	    break;
+	  case SECTION_RESPONSE_VY:
+	    //sp(ii) += Vy2;
+	    dspdh(ii) += dVy2dh;
+	    break;
+      case SECTION_RESPONSE_MY:
+          //sp(ii) += (L-x)*Vz2;
+          dspdh(ii) += (dLdh-dxdh)*Vz2 + (L-x)*dVz2dh;
+          break;
+      case SECTION_RESPONSE_VZ:
+          //sp(ii) += Vz2;
+          dspdh(ii) += dVz2dh;
+          break;
+      default:
+	    break;
+	  }
+	}
+      }
+    }
+    else {
+      opserr << "ForceBeamColumn3dThermal::computeSectionForceSensitivity -- load type unknown for element with tag: " <<
+	this->getTag() << endln;
+    }
+  }
+}
+
+  int 
+  ForceBeamColumn3dThermal::addInertiaLoadToUnbalance(const Vector &accel)
+  {
+    // Check for a quick return
+    if (rho == 0.0)
+      return 0;
+
+    // get R * accel from the nodes
+    const Vector &Raccel1 = theNodes[0]->getRV(accel);
+    const Vector &Raccel2 = theNodes[1]->getRV(accel);    
+
+    double L = crdTransf->getInitialLength();
+    double m = 0.5*rho*L;
+
+    load(0) -= m*Raccel1(0);
+    load(1) -= m*Raccel1(1);
+    load(2) -= m*Raccel1(2);
+    load(6) -= m*Raccel2(0);
+    load(7) -= m*Raccel2(1);
+    load(8) -= m*Raccel2(2);
+
+    return 0;
+  }
+
+  const Vector &
+  ForceBeamColumn3dThermal::getResistingForceIncInertia()
+  {	
+    // Compute the current resisting force
+    theVector = this->getResistingForce();
+
+    if (theDamping) theVector += this->getDampingForce();
+
+    if (rho != 0.0) {
+      const Vector &accel1 = theNodes[0]->getTrialAccel();
+      const Vector &accel2 = theNodes[1]->getTrialAccel();
+
+      double L = crdTransf->getInitialLength();
+      double m = 0.5*rho*L;
+
+      theVector(0) += m*accel1(0);
+      theVector(1) += m*accel1(1);
+      theVector(2) += m*accel1(2);
+      theVector(6) += m*accel2(0);
+      theVector(7) += m*accel2(1);
+      theVector(8) += m*accel2(2);
+
+      // add the damping forces if rayleigh damping
+      if (alphaM != 0.0 || betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	theVector += this->getRayleighDampingForces();
+
+    } else {
+
+      // add the damping forces if rayleigh damping
+      if (betaK != 0.0 || betaK0 != 0.0 || betaKc != 0.0)
+	theVector += this->getRayleighDampingForces();
+    }
+
+    return theVector;
+  }
+
+  int
+  ForceBeamColumn3dThermal::sendSelf(int commitTag, Channel &theChannel)
+  {  
+    // place the integer data into an ID
+    int dbTag = this->getDbTag();
+    int i, j , k;
+    int loc = 0;
+
+    static ID idData(15);  
+    idData(0) = this->getTag();
+    idData(1) = connectedExternalNodes(0);
+    idData(2) = connectedExternalNodes(1);
+    idData(3) = numSections;
+    idData(4) = maxIters;
+    idData(5) = initialFlag;
+    idData(6) = (isTorsion) ? 1 : 0;
+    idData(13) = maxSubdivisions;
+    
+    idData(7) = crdTransf->getClassTag();
+    int crdTransfDbTag  = crdTransf->getDbTag();
+    if (crdTransfDbTag  == 0) {
+      crdTransfDbTag = theChannel.getDbTag();
+      if (crdTransfDbTag  != 0) 
+	crdTransf->setDbTag(crdTransfDbTag);
+    }
+    idData(8) = crdTransfDbTag;
+
+
+    idData(9) = beamIntegr->getClassTag();
+    int beamIntegrDbTag  = beamIntegr->getDbTag();
+    if (beamIntegrDbTag  == 0) {
+      beamIntegrDbTag = theChannel.getDbTag();
+      if (beamIntegrDbTag  != 0) 
+	beamIntegr->setDbTag(beamIntegrDbTag);
+    }
+    idData(10) = beamIntegrDbTag;
+
+    idData(11) = 0;
+    idData(12) = 0;
+    if (theDamping) {
+      idData(11) = theDamping->getClassTag();
+      int dbTag = theDamping->getDbTag();
+      if (dbTag == 0) {
+        dbTag = theChannel.getDbTag();
+        if (dbTag != 0)
+	        theDamping->setDbTag(dbTag);
+	    }
+      idData(12) = dbTag;
+    }
+
+    if (theChannel.sendID(dbTag, commitTag, idData) < 0) {
+      opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to send ID data\n";
+      return -1;
+    }    
+
+    // send the coordinate transformation
+
+    if (crdTransf->sendSelf(commitTag, theChannel) < 0) {
+      opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to send crdTranf\n";
+      return -1;
+    }      
+
+    if (beamIntegr->sendSelf(commitTag, theChannel) < 0) {
+      opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to send beamIntegr\n";
+      return -1;
+    }      
+
+    //
+    // send an ID for the sections containing each sections dbTag and classTag
+    // if section ha no dbTag get one and assign it
+    //
+
+    ID idSections(2*numSections);
+    loc = 0;
+    for (i = 0; i<numSections; i++) {
+      int sectClassTag = sections[i]->getClassTag();
+      int sectDbTag = sections[i]->getDbTag();
+      if (sectDbTag == 0) {
+	sectDbTag = theChannel.getDbTag();
+	sections[i]->setDbTag(sectDbTag);
+      }
+
+      idSections(loc) = sectClassTag;
+      idSections(loc+1) = sectDbTag;
+      loc += 2;
+    }
+
+    if (theChannel.sendID(dbTag, commitTag, idSections) < 0)  {
+      opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to send ID data\n";
+      return -1;
+    }    
+ 
+    //
+    // send the sections
+    //
+
+    for (j = 0; j<numSections; j++) {
+      if (sections[j]->sendSelf(commitTag, theChannel) < 0) {
+	opserr << "ForceBeamColumn3dThermal::sendSelf() - section " <<
+	  j << "failed to send itself\n";
+	return -1;
+      }
+    }
+
+    // into a vector place distrLoadCommit, rho, UeCommit, Secommit and kvcommit
+    int secDefSize = 0;
+    for (i = 0; i < numSections; i++) {
+       int size = sections[i]->getOrder();
+       secDefSize   += size;
+    }
+
+    Vector dData(1+1+1+NEBD+NEBD*NEBD+secDefSize + 4); 
+    loc = 0;
+
+    // place double variables into Vector
+    dData(loc++) = rho;
+    dData(loc++) = tol;
+    dData(loc++) = subdivideFactor;
+  
+    // put  distrLoadCommit into the Vector
+    //  for (i=0; i<NL; i++) 
+    //dData(loc++) = distrLoadcommit(i);
+
+    // place kvcommit into vector
+    for (i=0; i<NEBD; i++) 
+      dData(loc++) = Secommit(i);
+
+    // place kvcommit into vector
+    for (i=0; i<NEBD; i++) 
+       for (j=0; j<NEBD; j++)
+	  dData(loc++) = kvcommit(i,j);
+
+    // place vscommit into vector
+    for (k=0; k<numSections; k++)
+       for (i=0; i<sections[k]->getOrder(); i++)
+	  dData(loc++) = (vscommit[k])(i);
+
+    // send damping coefficients
+    dData(loc++) = alphaM;
+    dData(loc++) = betaK;
+    dData(loc++) = betaK0;
+    dData(loc++) = betaKc;
+    
+    if (theChannel.sendVector(dbTag, commitTag, dData) < 0) {
+       opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to send Vector data\n";
+
+       return -1;
+    }    
+
+    // Ask the Damping to send itself
+    if (theDamping && theDamping->sendSelf(commitTag, theChannel) < 0) {
+        opserr << "ForceBeamColumn3dThermal::sendSelf -- could not send Damping\n";
+        return -1;
+    }
+
+    return 0;
+  }    
+
+  int
+  ForceBeamColumn3dThermal::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
+  {
+    //
+    // receive the integer data containing tag, numSections and coord transformation info
+    //
+    int dbTag = this->getDbTag();
+    int i,j,k;
+
+    static ID idData(15); // one bigger than needed 
+
+    if (theChannel.recvID(dbTag, commitTag, idData) < 0)  {
+      opserr << "ForceBeamColumn3dThermal::recvSelf() - failed to recv ID data\n";
+
+      return -1;
+    }    
+ 
+    this->setTag(idData(0));
+    connectedExternalNodes(0) = idData(1);
+    connectedExternalNodes(1) = idData(2);
+    maxIters = idData(4);
+    initialFlag = idData(5);
+    isTorsion = (idData(6) == 1) ? true : false;
+    maxSubdivisions = idData(13);
+    
+    int crdTransfClassTag = idData(7);
+    int crdTransfDbTag = idData(8);
+
+    int beamIntegrClassTag = idData(9);
+    int beamIntegrDbTag = idData(10);
+
+    // create a new crdTransf object if one needed
+    if (crdTransf == 0 || crdTransf->getClassTag() != crdTransfClassTag) {
+	if (crdTransf != 0)
+	    delete crdTransf;
+
+	crdTransf = theBroker.getNewCrdTransf(crdTransfClassTag);
+
+	if (crdTransf == 0) {
+	    opserr << "ForceBeamColumn3dThermal::recvSelf() - failed to obtain a CrdTrans object with classTag" <<
+	      crdTransfClassTag << endln;
+	    return -2;	  
+	}
+    }
+
+    crdTransf->setDbTag(crdTransfDbTag);
+    // invoke recvSelf on the crdTransf obkject
+    if (crdTransf->recvSelf(commitTag, theChannel, theBroker) < 0)  
+    {
+       opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to recv crdTranf\n";
+       return -3;
+    }      
+
+    // create a new beamIntegr object if one needed
+    if (beamIntegr == 0 || beamIntegr->getClassTag() != beamIntegrClassTag) {
+	if (beamIntegr != 0)
+	    delete beamIntegr;
+
+	beamIntegr = theBroker.getNewBeamIntegration(beamIntegrClassTag);
+
+	if (beamIntegr == 0) {opserr << "ForceBeamColumn3dThermal::recvSelf() - failed to obtain the beam integration object with classTag" <<
+	    beamIntegrClassTag << endln;
+	  exit(-1);
+	}
+    }
+
+    beamIntegr->setDbTag(beamIntegrDbTag);
+
+    // invoke recvSelf on the beamIntegr object
+    if (beamIntegr->recvSelf(commitTag, theChannel, theBroker) < 0)  
+    {
+       opserr << "ForceBeamColumn3dThermal::sendSelf() - failed to recv beam integration\n";
+
+       return -3;
+    }      
+
+    //
+    // recv an ID for the sections containing each sections dbTag and classTag
+    //
+
+    ID idSections(2*idData(3));
+    int loc = 0;
+
+    if (theChannel.recvID(dbTag, commitTag, idSections) < 0)  {
+      opserr << "ForceBeamColumn3dThermal::recvSelf() - failed to recv ID data\n";
+      return -1;
+    }    
+
+    //
+    // now receive the sections
+    //
+    if (numSections != idData(3)) {
+
+      //
+      // we do not have correct number of sections, must delete the old and create
+      // new ones before can recvSelf on the sections
+      //
+
+      // delete the old
+      if (numSections != 0) {
+	for (int i=0; i<numSections; i++)
+	  delete sections[i];
+	delete [] sections;
+      }
+
+      // create a section and recvSelf on it
+      numSections = idData(3);
+
+      // Delete the old
+      if (vscommit != 0)
+	delete [] vscommit;
+
+      // Allocate the right number
+      vscommit = new Vector[numSections];
+      if (vscommit == 0) {
+	opserr << "ForceBeamColumn3dThermal::recvSelf -- failed to allocate vscommit array\n";
+	return -1;
+      }
+
+      // Delete the old
+      if (fs != 0)
+	delete [] fs;
+
+      // Allocate the right number
+      fs = new Matrix[numSections];  
+      if (fs == 0) {
+	opserr << "ForceBeamColumn3dThermal::recvSelf -- failed to allocate fs array\n";
+	return -1;
+      }
+
+      // Delete the old
+      if (vs != 0)
+	delete [] vs;
+
+      // Allocate the right number
+      vs = new Vector[numSections];  
+      if (vs == 0) {
+	opserr << "ForceBeamColumn3dThermal::recvSelf -- failed to allocate vs array\n";
+	return -1;
+      }
+
+      // Delete the old
+      if (Ssr != 0)
+	delete [] Ssr;
+
+      // Allocate the right number
+      Ssr = new Vector[numSections];  
+      if (Ssr == 0) {
+	opserr << "ForceBeamColumn3dThermal::recvSelf -- failed to allocate Ssr array\n";
+
+	return -1;
+      }
+
+      // create a new array to hold pointers
+      sections = new SectionForceDeformation *[idData(3)];
+      if (sections == 0) {
+	opserr << "ForceBeamColumn3dThermal::recvSelf() - out of memory creating sections array of size" <<
+	  idData(3) << endln;
+	exit(-1);
+      }    
+
+      loc = 0;
+
+      for (i=0; i<numSections; i++) {
+	int sectClassTag = idSections(loc);
+	int sectDbTag = idSections(loc+1);
+	loc += 2;
+	sections[i] = theBroker.getNewSection(sectClassTag);
+	if (sections[i] == 0) {
+	  opserr << "ForceBeamColumn3dThermal::recvSelf() - Broker could not create Section of class type" <<
+	    sectClassTag << endln;
+	  exit(-1);
+	}
+	
+	sections[i]->setDbTag(sectDbTag);
+	if (sections[i]->recvSelf(commitTag, theChannel, theBroker) < 0) {
+	  opserr << "ForceBeamColumn3dThermal::recvSelf() - section " << 
+	    i << " failed to recv itself\n";
+	  return -1;
+	} 
+      }
+
+      this->initializeSectionHistoryVariables();
+
+    } else {
+
+      // 
+      // for each existing section, check it is of correct type
+      // (if not delete old & create a new one) then recvSelf on it
+      //
+
+      loc = 0;
+      for (i=0; i<numSections; i++) {
+	int sectClassTag = idSections(loc);
+	int sectDbTag = idSections(loc+1);
+	loc += 2;
+
+	// check of correct type
+	if (sections[i]->getClassTag() !=  sectClassTag) {
+	  // delete the old section[i] and create a new one
+	  delete sections[i];
+	  sections[i] = theBroker.getNewSection(sectClassTag);
+	  if (sections[i] == 0) {
+	    opserr << "ForceBeamColumn3dThermal::recvSelf() - Broker could not create Section of class type " 
+		   << sectClassTag << endln;;
+	    exit(-1);
+	  }
+	}
+
+	// recvvSelf on it
+	sections[i]->setDbTag(sectDbTag);
+	if (sections[i]->recvSelf(commitTag, theChannel, theBroker) < 0) {
+	  opserr << "ForceBeamColumn3dThermal::recvSelf() - section " <<
+	    i << " failed to recv itself\n";
+	  return -1;
+	}     
+      }
+    }
+
+    // into a vector place distrLoadCommit, rho, UeCommit, Secommit and kvcommit
+    int secDefSize = 0;
+    for (int ii = 0; ii < numSections; ii++) {
+       int size = sections[ii]->getOrder();
+       secDefSize   += size;
+    }
+
+    Vector dData(1+1+1+NEBD+NEBD*NEBD+secDefSize+4);   
+
+    if (theChannel.recvVector(dbTag, commitTag, dData) < 0)  {
+      opserr << "ForceBeamColumn3dThermal::recvSelf() - failed to send Vector data\n";
+      return -1;
+    }    
+
+    loc = 0;
+
+    // place double variables into Vector
+    rho = dData(loc++);
+    tol = dData(loc++);
+    subdivideFactor = dData(loc++);
+  
+    // put  distrLoadCommit into the Vector
+    //for (i=0; i<NL; i++) 
+    // distrLoad(i) = dData(loc++);
+
+    // place kvcommit into vector
+    for (i=0; i<NEBD; i++) 
+      Secommit(i) = dData(loc++);
+
+    // place kvcommit into vector
+    for (i=0; i<NEBD; i++) 
+       for (j=0; j<NEBD; j++)
+	  kvcommit(i,j) = dData(loc++);
+
+    kv   = kvcommit;
+    Se   = Secommit;
+
+    for (k = 0; k < numSections; k++) {
+      int order = sections[k]->getOrder();
+
+      // place vscommit into vector
+      vscommit[k] = Vector(order);
+      for (i = 0; i < order; i++)
+	(vscommit[k])(i) = dData(loc++);
+    }
+
+    // set damping coefficients
+    alphaM = dData(loc++);
+    betaK = dData(loc++);
+    betaK0 = dData(loc++);
+    betaKc = dData(loc++);
+    
+    initialFlag = 2;  
+
+    // Check if the Damping is null; if so, get a new one
+    int dmpTag = (int)idData(11);
+    if (dmpTag) {
+      if (theDamping == 0) {
+        theDamping = theBroker.getNewDamping(dmpTag);
+        if (theDamping == 0) {
+          opserr << "ForceBeamColumn3dThermal::recvSelf -- could not get a Damping\n";
+          exit(-1);
+        }
+      }
+    
+      // Check that the Damping is of the right type; if not, delete
+      // the current one and get a new one of the right type
+      if (theDamping->getClassTag() != dmpTag) {
+        delete theDamping;
+        theDamping = theBroker.getNewDamping(dmpTag);
+        if (theDamping == 0) {
+          opserr << "ForceBeamColumn3dThermal::recvSelf -- could not get a Damping\n";
+          exit(-1);
+        }
+      }
+    
+      // Now, receive the Damping
+      theDamping->setDbTag((int)idData(12));
+      if (theDamping->recvSelf(commitTag, theChannel, theBroker) < 0) {
+        opserr << "ForceBeamColumn3dThermal::recvSelf -- could not receive Damping\n";
+        return -1;
+      }
+    }
+    else {
+      if (theDamping) {
+        delete theDamping;
+        theDamping = 0;
+      }
+    }
+    
+    return 0;
+  }
+
+  int
+  ForceBeamColumn3dThermal::getInitialFlexibility(Matrix &fe)
+  {
+    fe.Zero();
+
+    double L = crdTransf->getInitialLength();
+    double oneOverL  = 1.0/L;  
+
+    double xi[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, xi);
+
+    double wt[maxNumSections];
+    beamIntegr->getSectionWeights(numSections, L, wt);
+
+    for (int i = 0; i < numSections; i++) {
+
+      int order      = sections[i]->getOrder();
+      const ID &code = sections[i]->getType();
+
+      Matrix fb(workArea, order, NEBD);
+
+      double xL  = xi[i];
+      double xL1 = xL-1.0;
+      double wtL = wt[i]*L;
+
+      const Matrix &fSec = sections[i]->getInitialFlexibility();
+      fb.Zero();
+      double tmp;
+      int ii, jj;
+      for (ii = 0; ii < order; ii++) {
+	switch(code(ii)) {
+	case SECTION_RESPONSE_P:
+	  for (jj = 0; jj < order; jj++)
+	    fb(jj,0) += fSec(jj,ii)*wtL;
+	  break;
+	case SECTION_RESPONSE_MZ:
+	  for (jj = 0; jj < order; jj++) {
+	    tmp = fSec(jj,ii)*wtL;
+	    fb(jj,1) += xL1*tmp;
+	    fb(jj,2) += xL*tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_VY:
+	  for (jj = 0; jj < order; jj++) {
+	    tmp = oneOverL*fSec(jj,ii)*wtL;
+	    fb(jj,1) += tmp;
+	    fb(jj,2) += tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_MY:
+	  for (jj = 0; jj < order; jj++) {
+	    tmp = fSec(jj,ii)*wtL;
+	    fb(jj,3) += xL1*tmp;
+	    fb(jj,4) += xL*tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_VZ:
+	  for (jj = 0; jj < order; jj++) {
+	    tmp = oneOverL*fSec(jj,ii)*wtL;
+	    fb(jj,3) += tmp;
+	    fb(jj,4) += tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_T:
+	  for (jj = 0; jj < order; jj++)
+	    fb(jj,5) += fSec(jj,ii)*wtL;
+	  break;
+	default:
+	  break;
+	}
+      }
+      for (ii = 0; ii < order; ii++) {
+	switch (code(ii)) {
+	case SECTION_RESPONSE_P:
+	  for (jj = 0; jj < NEBD; jj++)
+	    fe(0,jj) += fb(ii,jj);
+	  break;
+	case SECTION_RESPONSE_MZ:
+	  for (jj = 0; jj < NEBD; jj++) {
+	    tmp = fb(ii,jj);
+	    fe(1,jj) += xL1*tmp;
+	    fe(2,jj) += xL*tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_VY:
+	  for (jj = 0; jj < NEBD; jj++) {
+	    tmp = oneOverL*fb(ii,jj);
+	    fe(1,jj) += tmp;
+	    fe(2,jj) += tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_MY:
+	  for (jj = 0; jj < NEBD; jj++) {
+	    tmp = fb(ii,jj);
+	    fe(3,jj) += xL1*tmp;
+	    fe(4,jj) += xL*tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_VZ:
+	  for (jj = 0; jj < NEBD; jj++) {
+	    tmp = oneOverL*fb(ii,jj);
+	    fe(3,jj) += tmp;
+	    fe(4,jj) += tmp;
+	  }
+	  break;
+	case SECTION_RESPONSE_T:
+	  for (jj = 0; jj < NEBD; jj++)
+	    fe(5,jj) += fb(ii,jj);
+	  break;
+	default:
+	  break;
+	}
+      }
+    }
+
+    if (!isTorsion)
+      fe(5,5) = DefaultLoverGJ;
+
+    return 0;
+  }
+
+int
+ForceBeamColumn3dThermal::getInitialDeformations(Vector &v0)
+{
+  v0.Zero();
+  if (numEleLoads < 1)
+      return 0;
+
+  double L = crdTransf->getInitialLength();
+  double oneOverL = 1.0 / L;
+
+  double xi[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, xi);
+
+  double wt[maxNumSections];
+  beamIntegr->getSectionWeights(numSections, L, wt);
+
+  for (int i = 0; i < numSections; i++) {
+
+      int order = sections[i]->getOrder();
+      const ID &code = sections[i]->getType();
+
+      double xL = xi[i];
+      double xL1 = xL - 1.0;
+      double wtL = wt[i] * L;
+
+      static Vector sp;
+      sp.setData(workArea, order);
+      sp.Zero();
+
+      this->computeSectionForces(sp, i);
+
+      const Matrix &fse = sections[i]->getInitialFlexibility();
+
+      static Vector e;
+      e.setData(&workArea[order], order);
+
+      e.addMatrixVector(0.0, fse, sp, 1.0);
+
+      double dei, tmp;
+      for (int ii = 0; ii < order; ii++) {
+          dei = e(ii)*wtL;
+          switch (code(ii)) {
+          case SECTION_RESPONSE_P:
+              v0(0) += dei;
+              break;
+          case SECTION_RESPONSE_MZ:
+              v0(1) += xL1*dei; v0(2) += xL*dei;
+              break;
+          case SECTION_RESPONSE_VY:
+              tmp = oneOverL*dei;
+              v0(1) += tmp; v0(2) += tmp;
+              break;
+          case SECTION_RESPONSE_MY:
+              v0(3) += xL1*dei; v0(4) += xL*dei;
+              break;
+          case SECTION_RESPONSE_VZ:
+              tmp = oneOverL*dei;
+              v0(3) += tmp; v0(4) += tmp;
+              break;
+          default:
+              break;
+          }
+      }
+  }
+
+  return 0;
+}
+
+  void
+  ForceBeamColumn3dThermal::compSectionDisplacements(Vector sectionCoords[],
+					      Vector sectionDispls[]) const
+  {
+     // get basic displacements and increments
+     static Vector ub(NEBD);
+     ub = crdTransf->getBasicTrialDisp();    
+
+     double L = crdTransf->getInitialLength();
+
+     // get integration point positions and weights
+     static double pts[maxNumSections];
+     beamIntegr->getSectionLocations(numSections, L, pts);
+
+     // setup Vandermode and CBDI influence matrices
+     int i;
+     double xi;
+
+     // get CBDI influence matrix
+     Matrix ls(numSections, numSections);
+     getCBDIinfluenceMatrix(numSections, pts, L, ls);
+
+     // get section curvatures
+     Vector kappa_y(numSections);  // curvature
+     Vector kappa_z(numSections);  // curvature
+     static Vector vs;                // section deformations 
+
+     for (i=0; i<numSections; i++) {
+	 // THIS IS VERY INEFFICIENT ... CAN CHANGE IF RUNS TOO SLOW
+	 int sectionKey1 = 0;
+	 int sectionKey2 = 0;
+	 const ID &code = sections[i]->getType();
+	 int j;
+	 for (j = 0; j < code.Size(); j++)
+	 {
+	     if (code(j) == SECTION_RESPONSE_MZ)
+		 sectionKey1 = j;
+	     if (code(j) == SECTION_RESPONSE_MY)
+		 sectionKey2 = j;
+	 }
+	 if (sectionKey1 == 0) {
+	   opserr << "FATAL ForceBeamColumn3dThermal::compSectionResponse - section does not provide Mz response\n";
+	   exit(-1);
+	 }
+	 if (sectionKey2 == 0) {
+	   opserr << "FATAL ForceBeamColumn3dThermal::compSectionResponse - section does not provide My response\n";
+	   exit(-1);
+	 }
+
+	 // get section deformations
+	 vs = sections[i]->getSectionDeformation();
+
+	 kappa_z(i) = vs(sectionKey1);
+	 kappa_y(i) = vs(sectionKey2); 
+     }
+
+     //cout << "kappa_y: " << kappa_y;   
+     //cout << "kappa_z: " << kappa_z;   
+
+     Vector v(numSections), w(numSections);
+     static Vector xl(NDM), uxb(NDM);
+     static Vector xg(NDM), uxg(NDM); 
+     // double theta;                             // angle of twist of the sections
+
+     // v = ls * kappa_z;  
+     v.addMatrixVector (0.0, ls, kappa_z, 1.0);  
+     // w = ls * kappa_y *  (-1);  
+     w.addMatrixVector (0.0, ls, kappa_y, -1.0);
+
+     for (i=0; i<numSections; i++)
+     {
+	xi = pts[i];
+
+	xl(0) = xi * L;
+	xl(1) = 0;
+	xl(2) = 0;
+
+	// get section global coordinates
+	sectionCoords[i] = crdTransf->getPointGlobalCoordFromLocal(xl);
+
+	// compute section displacements
+	//theta  = xi * ub(5); // consider linear variation for angle of twist. CHANGE LATER!!!!!!!!!!
+	uxb(0) = xi * ub(0); // consider linear variation for axial displacement. CHANGE LATER!!!!!!!!!!
+	uxb(1) = v(i);
+	uxb(2) = w(i);
+
+	// get section displacements in global system 
+	sectionDispls[i] = crdTransf->getPointGlobalDisplFromBasic(xi, uxb);
+     }	       
+    return;	       
+  }
+
+  void
+  ForceBeamColumn3dThermal::Print(OPS_Stream &s, int flag)
+  {
+    // flags with negative values are used by GSA
+    if (flag == -1) { 
+      int eleTag = this->getTag();
+      s << "EL_BEAM\t" << eleTag << "\t";
+      s << sections[0]->getTag() << "\t" << sections[numSections-1]->getTag(); 
+      s  << "\t" << connectedExternalNodes(0) << "\t" << connectedExternalNodes(1);
+      s << "\t0\t0.0000000\n";
+    }  
+
+    // flags with negative values are used by GSA  
+    else if (flag < -1) {
+      int eleTag = this->getTag();
+      int counter = (flag +1) * -1;
+      double P  = Secommit(0);
+      double MZ1 = Secommit(1);
+      double MZ2 = Secommit(2);
+      double MY1 = Secommit(3);
+      double MY2 = Secommit(4);
+      double L = crdTransf->getInitialLength();
+      double VY = (MZ1+MZ2)/L;
+      theVector(1) =  VY;
+      theVector(4) = -VY;
+      double VZ = (MY1+MY2)/L;
+      double T  = Secommit(5);
+
+      double p0[5]; p0[0] = p0[1] = p0[2] = p0[3] = p0[4] = 0.0;
+      if (numEleLoads > 0)
+          this->computeReactions(p0);
+
+      s << "FORCE\t" << eleTag << "\t" << counter << "\t0";
+      s << "\t" << -P+p0[0] << "\t"  <<  VY+p0[1] << "\t"  << -VZ+p0[3]  << endln;
+      s << "FORCE\t" << eleTag << "\t" << counter << "\t1";
+      s << "\t"  << P  << ' '  << -VY+p0[2] << ' ' << VZ+p0[4] << endln;
+      s << "MOMENT\t" << eleTag << "\t" << counter << "\t0";
+      s << "\t" << -T << "\t"  << MY1 << "\t" << MZ1 << endln;
+      s << "MOMENT\t" << eleTag << "\t" << counter << "\t1";
+      s << "\t" << T << ' ' << MY2 << ' '  <<  MZ2 << endln;
+    }
+
+    // flag set to 2 used to print everything .. used for viewing data for UCSD renderer  
+    else if (flag == 2) {
+       static Vector xAxis(3);
+       static Vector yAxis(3);
+       static Vector zAxis(3);
+
+
+       crdTransf->getLocalAxes(xAxis, yAxis, zAxis);
+
+       s << "#ForceBeamColumn3dThermal\n";
+       s << "#LocalAxis " << xAxis(0) << " " << xAxis(1) << " " << xAxis(2);
+       s << " " << yAxis(0) << " " << yAxis(1) << " " << yAxis(2) << " ";
+       s << zAxis(0) << " " << zAxis(1) << " " << zAxis(2) << endln;
+
+       const Vector &node1Crd = theNodes[0]->getCrds();
+       const Vector &node2Crd = theNodes[1]->getCrds();	
+       const Vector &node1Disp = theNodes[0]->getDisp();
+       const Vector &node2Disp = theNodes[1]->getDisp();    
+
+       s << "#NODE " << node1Crd(0) << " " << node1Crd(1) << " " << node1Crd(2)
+	 << " " << node1Disp(0) << " " << node1Disp(1) << " " << node1Disp(2)
+	 << " " << node1Disp(3) << " " << node1Disp(4) << " " << node1Disp(5) << endln;
+
+       s << "#NODE " << node2Crd(0) << " " << node2Crd(1) << " " << node2Crd(2)
+	 << " " << node2Disp(0) << " " << node2Disp(1) << " " << node2Disp(2)
+	 << " " << node2Disp(3) << " " << node2Disp(4) << " " << node2Disp(5) << endln;
+
+       double P  = Secommit(0);
+       double MZ1 = Secommit(1);
+       double MZ2 = Secommit(2);
+       double MY1 = Secommit(3);
+       double MY2 = Secommit(4);
+       double L = crdTransf->getInitialLength();
+       double VY = (MZ1+MZ2)/L;
+       theVector(1) =  VY;
+       theVector(4) = -VY;
+       double VZ = (MY1+MY2)/L;
+       double T  = Secommit(5);
+
+       double p0[5]; p0[0] = p0[1] = p0[2] = p0[3] = p0[4] = 0.0;
+       if (numEleLoads > 0)
+           this->computeReactions(p0);
+
+       s << "#END_FORCES " << -P+p0[0] << ' '  <<  VY+p0[1] << ' '  << -VZ+p0[3] << ' ' 
+	 << -T << ' '  << MY1 << ' ' << MZ1 << endln;
+       s << "#END_FORCES "  << P  << ' '  << -VY+p0[2] << ' ' << VZ+p0[4] << ' '  
+	 << T << ' ' << MY2 << ' '  <<  MZ2 << endln;
+
+       // plastic hinge rotation
+       static Vector vp(6);
+       static Matrix fe(6,6);
+       this->getInitialFlexibility(fe);
+       vp = crdTransf->getBasicTrialDisp();
+       vp.addMatrixVector(1.0, fe, Se, -1.0);
+       s << "#PLASTIC_HINGE_ROTATION " << vp[1] << " " << vp[2] << " " << vp[3] << " " << vp[4] 
+	 << " " << 0.1*L << " " << 0.1*L << endln;
+
+       // allocate array of vectors to store section coordinates and displacements
+       static int maxNumSections = 0;
+       static Vector *coords = 0;
+       static Vector *displs = 0;
+       if (maxNumSections < numSections) {
+	 if (coords != 0) 
+	   delete [] coords;
+	 if (displs != 0)
+	   delete [] displs;
+
+	 coords = new Vector [numSections];
+	 displs = new Vector [numSections];
+
+	 if (!coords) {
+	   opserr << "ForceBeamColumn3dThermal::Print() -- failed to allocate coords array";   
+	   exit(-1);
+	 }
+
+	 int i;
+	 for (i = 0; i < numSections; i++)
+	   coords[i] = Vector(NDM);
+
+	 if (!displs) {
+	   opserr << "ForceBeamColumn3dThermal::Print() -- failed to allocate coords array";   
+	   exit(-1);
+	 }
+
+	 for (i = 0; i < numSections; i++)
+	   displs[i] = Vector(NDM);
+
+	 maxNumSections = numSections;
+       }
+
+       // compute section location & displacements
+       this->compSectionDisplacements(coords, displs);
+
+       // spit out the section location & invoke print on the scetion
+       for (int i=0; i<numSections; i++) {
+	 s << "#SECTION " << (coords[i])(0) << " " << (coords[i])(1) << " " << (coords[i])(2);       
+	 s << " " << (displs[i])(0) << " " << (displs[i])(1) << " " << (displs[i])(2) << endln;
+	 sections[i]->Print(s, flag); 
+       }
+     }
+
+    if (flag == OPS_PRINT_CURRENTSTATE) {
+       s << "\nElement: " << this->getTag() << " Type: ForceBeamColumn3dThermal ";
+       s << "\tConnected Nodes: " << connectedExternalNodes ;
+       s << "\tNumber of Sections: " << numSections;
+       s << "\tMass density: " << rho << endln;
+       beamIntegr->Print(s, flag);
+       double P  = Secommit(0);
+       double MZ1 = Secommit(1);
+       double MZ2 = Secommit(2);
+       double MY1 = Secommit(3);
+       double MY2 = Secommit(4);
+       double L = crdTransf->getInitialLength();
+       double VY = (MZ1+MZ2)/L;
+       theVector(1) =  VY;
+       theVector(4) = -VY;
+       double VZ = (MY1+MY2)/L;
+       double T  = Secommit(5);
+
+       double p0[5]; p0[0] = p0[1] = p0[2] = p0[3] = p0[4] = 0.0;
+       if (numEleLoads > 0)
+           this->computeReactions(p0);
+
+       s << "\tEnd 1 Forces (P MZ VY MY VZ T): "
+	 << -P+p0[0] << " " << MZ1 << " " <<  VY+p0[1] << " " 
+	 << MY1 << " " << -VZ+p0[3] << " " << T << endln;
+       s << "\tEnd 2 Forces (P MZ VY MY VZ T): "
+	 << P        << " " << MZ2 << " " << -VY+p0[2] << " " 
+	 << MY2 << " " <<  VZ+p0[4] << " " << -T << endln;
+
+       for (int i = 0; i < numSections; i++) {
+	 //opserr << "Section Type: " << theSections[i]->getClassTag() << endln;
+	 sections[i]->Print(s,flag);
+       }
+    }
+
+	 if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		 s << "\t\t\t{";
+		 s << "\"name\": " << this->getTag() << ", ";
+		 s << "\"type\": \"ForceBeamColumn3dThermal\", ";
+		 s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
+		 s << "\"sections\": [";
+		 for (int i = 0; i < numSections - 1; i++)
+			 s << "\"" << sections[i]->getTag() << "\", ";
+		 s << "\"" << sections[numSections - 1]->getTag() << "\"], ";
+		 s << "\"integration\": ";
+		 beamIntegr->Print(s, flag);
+		 s << ", \"massperlength\": " << rho << ", ";
+		 s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\"}";
+	 }
+  }
+
+  OPS_Stream &operator<<(OPS_Stream &s, ForceBeamColumn3dThermal &E)
+  {
+    E.Print(s);
+    return s;
+  }
+
+  int
+  ForceBeamColumn3dThermal::displaySelf(Renderer &theViewer, int displayMode, float fact, const char** displayModes, int numModes)
+  {
+    static Vector v1(3);
+    static Vector v2(3);
+
+    theNodes[0]->getDisplayCrds(v1, fact, displayMode);
+    theNodes[1]->getDisplayCrds(v2, fact, displayMode);
+
+    return theViewer.drawLine(v1, v2, 1.0, 1.0, this->getTag());
+  }
+
+  Response*
+  ForceBeamColumn3dThermal::setResponse(const char **argv, int argc, OPS_Stream &output)
+  {
+    Response *theResponse = 0;
+    
+    output.tag("ElementOutput");
+    output.attr("eleType","ForceBeamColumn3dThermal");
+    output.attr("eleTag",this->getTag());
+    output.attr("node1",connectedExternalNodes[0]);
+    output.attr("node2",connectedExternalNodes[1]);
+
+    //
+    // we compare argv[0] for known response types 
+    //
+
+    // global force - 
+    if (strcmp(argv[0],"forces") == 0 || strcmp(argv[0],"force") == 0
+	|| strcmp(argv[0],"globalForce") == 0 || strcmp(argv[0],"globalForces") == 0) {
+
+      output.tag("ResponseType","Px_1");
+      output.tag("ResponseType","Py_1");
+      output.tag("ResponseType","Pz_1");
+      output.tag("ResponseType","Mx_1");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","Px_2");
+      output.tag("ResponseType","Py_2");
+      output.tag("ResponseType","Pz_2");
+      output.tag("ResponseType","Mx_2");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","Mz_2");
+
+
+      theResponse = new ElementResponse(this, 1, theVector);
+
+    // local force -
+    }  else if (strcmp(argv[0],"localForce") == 0 || strcmp(argv[0],"localForces") == 0) {
+
+      output.tag("ResponseType","N_1");
+      output.tag("ResponseType","Vy_1");
+      output.tag("ResponseType","Vz_1");
+      output.tag("ResponseType","T_1");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","N_2");
+      output.tag("ResponseType","Vy_2");
+      output.tag("ResponseType","Vz_2");
+      output.tag("ResponseType","T_2");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","Mz_2");
+      
+      theResponse = new ElementResponse(this, 2, theVector);
+
+    // basic force -
+    } else if (strcmp(argv[0],"basicForce") == 0 || strcmp(argv[0],"basicForces") == 0) {
+      
+      output.tag("ResponseType","N");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","Mz_2");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","T");            
+      
+      theResponse =  new ElementResponse(this, 7, Vector(6));
+
+    // basic stiffness -
+    } else if (strcmp(argv[0],"basicStiffness") == 0) {
+
+      output.tag("ResponseType","N");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","Mz_2");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","T");                  
+      
+      theResponse =  new ElementResponse(this, 19, Matrix(6,6));
+      
+    //global damping force -
+    } else if (theDamping && (strcmp(argv[0],"globalDampingForce") == 0 || strcmp(argv[0],"globalDampingForces") == 0)) {
+
+      output.tag("ResponseType","Px_1");
+      output.tag("ResponseType","Py_1");
+      output.tag("ResponseType","Pz_1");
+      output.tag("ResponseType","Mx_1");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","Px_2");
+      output.tag("ResponseType","Py_2");
+      output.tag("ResponseType","Pz_2");
+      output.tag("ResponseType","Mx_2");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","Mz_2");
+
+
+      theResponse = new ElementResponse(this, 21, theVector);
+
+    // local damping force -
+    } else if (theDamping && (strcmp(argv[0],"localDampingForce") == 0 || strcmp(argv[0],"localDampingForces") == 0)) {
+
+      output.tag("ResponseType","N_1");
+      output.tag("ResponseType","Vy_1");
+      output.tag("ResponseType","Vz_1");
+      output.tag("ResponseType","T_1");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","N_2");
+      output.tag("ResponseType","Vy_2");
+      output.tag("ResponseType","Vz_2");
+      output.tag("ResponseType","T_2");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","Mz_2");
+      
+      theResponse = new ElementResponse(this, 22, theVector);
+
+    } else if (theDamping && (strcmp(argv[0],"basicDampingForce") == 0 || strcmp(argv[0],"basicDampingForces") == 0)) {
+
+      output.tag("ResponseType","N");
+      output.tag("ResponseType","Mz_1");
+      output.tag("ResponseType","Mz_2");
+      output.tag("ResponseType","My_1");
+      output.tag("ResponseType","My_2");
+      output.tag("ResponseType","T");
+    
+      theResponse = new ElementResponse(this, 23, Vector(6));
+      
+    // chord rotation -
+    }  else if (strcmp(argv[0],"chordRotation") == 0 || strcmp(argv[0],"chordDeformation") == 0 
+		|| strcmp(argv[0],"basicDeformation") == 0) {
+      
+      output.tag("ResponseType","eps");
+      output.tag("ResponseType","thetaZ_1");
+      output.tag("ResponseType","thetaZ_2");
+      output.tag("ResponseType","thetaY_1");
+      output.tag("ResponseType","thetaY_2");
+      output.tag("ResponseType","thetaX");
+      
+      theResponse = new ElementResponse(this, 3, Vector(6));
+      
+      // plastic rotation -
+    } else if (strcmp(argv[0],"plasticRotation") == 0 || strcmp(argv[0],"plasticDeformation") == 0) {
+      
+      output.tag("ResponseType","epsP");
+      output.tag("ResponseType","thetaZP_1");
+      output.tag("ResponseType","thetaZP_2");
+      output.tag("ResponseType","thetaYP_1");
+      output.tag("ResponseType","thetaYP_2");
+      output.tag("ResponseType","thetaXP");
+      
+      theResponse = new ElementResponse(this, 4, Vector(6));
+      
+      // point of inflection
+    } else if (strcmp(argv[0],"inflectionPoint") == 0) {
+      theResponse = new ElementResponse(this, 5, Vector(2));
+      
+      // tangent drift
+    } else if (strcmp(argv[0],"tangentDrift") == 0) {
+      theResponse = new ElementResponse(this, 6, Vector(4));
+      
+    } else if (strcmp(argv[0],"getRemCriteria1") == 0) {
+      theResponse = new ElementResponse(this, 77, Vector(2));
+
+    } else if (strcmp(argv[0],"getRemCriteria2") == 0) {
+      theResponse = new ElementResponse(this, 8, Vector(2), ID(6));
+
+    } else if (strcmp(argv[0],"RayleighForces") == 0 || 
+	       strcmp(argv[0],"rayleighForces") == 0) {
+
+      theResponse = new ElementResponse(this, 12, theVector);
+
+    } else if (strcmp(argv[0],"sections") ==0) { 
+      CompositeResponse *theCResponse = new CompositeResponse();
+      int numResponse = 0;
+      double xi[maxNumSections];
+      double L = crdTransf->getInitialLength();
+      beamIntegr->getSectionLocations(numSections, L, xi);
+      
+      for (int i=0; i<numSections; i++) {
+	
+	output.tag("GaussPointOutput");
+	output.attr("number",i+1);
+	output.attr("eta",xi[i]*L);
+	
+	Response *theSectionResponse = sections[i]->setResponse(&argv[1], argc-1, output);
+	
+	if (theSectionResponse != 0) {
+	  numResponse = theCResponse->addResponse(theSectionResponse);
+	}
+      }
+      
+      if (numResponse == 0) // no valid responses found
+	delete theCResponse;
+	  else
+	    theResponse = theCResponse;
+    }
+
+    else if (strcmp(argv[0],"integrationPoints") == 0)
+      theResponse = new ElementResponse(this, 10, Vector(numSections));
+
+    else if (strcmp(argv[0],"integrationWeights") == 0)
+      theResponse = new ElementResponse(this, 11, Vector(numSections));
+
+    else if (strcmp(argv[0],"sectionTags") == 0)
+      theResponse = new ElementResponse(this, 110, ID(numSections));  
+    
+    else if (strcmp(argv[0],"sectionDisplacements") == 0) {
+      if (argc > 1 && strcmp(argv[1],"local") == 0)
+	theResponse = new ElementResponse(this, 1111, Matrix(numSections,3));
+      else
+	theResponse = new ElementResponse(this, 111, Matrix(numSections,3));
+    }
+    
+    else if (strcmp(argv[0],"cbdiDisplacements") == 0)
+      theResponse = new ElementResponse(this, 112, Matrix(1,3));
+
+    // section response -
+    else if (strcmp(argv[0],"sectionX") == 0) {
+      if (argc > 2) {
+	float sectionLoc = atof(argv[1]);
+	
+	double xi[maxNumSections];
+	double L = crdTransf->getInitialLength();
+	beamIntegr->getSectionLocations(numSections, L, xi);
+	
+	sectionLoc /= L;
+	
+	float minDistance = fabs(xi[0]-sectionLoc);
+	int sectionNum = 0;
+	for (int i = 1; i < numSections; i++) {
+	  if (fabs(xi[i]-sectionLoc) < minDistance) {
+	    minDistance = fabs(xi[i]-sectionLoc);
+	    sectionNum = i;
+	  }
+	}
+	
+	output.tag("GaussPointOutput");
+	output.attr("number",sectionNum+1);
+	output.attr("eta",xi[sectionNum]*L);
+	
+	theResponse = sections[sectionNum]->setResponse(&argv[2], argc-2, output);
+      }
+    }
+
+    else if (strcmp(argv[0],"section") == 0) { 
+
+      if (argc > 1) {
+
+	int sectionNum = atoi(argv[1]);
+	
+	if (sectionNum > 0 && sectionNum <= numSections && argc > 2) {
+	  double xi[maxNumSections];
+	  double L = crdTransf->getInitialLength();
+	  beamIntegr->getSectionLocations(numSections, L, xi);
+	  
+	  output.tag("GaussPointOutput");
+	  output.attr("number",sectionNum);
+	  output.attr("eta",2.0*xi[sectionNum-1]-1.0);
+
+	  if (strcmp(argv[2],"dsdh") != 0) {
+	    theResponse = sections[sectionNum-1]->setResponse(&argv[2], argc-2, output);
+	  } else {
+	    int order = sections[sectionNum-1]->getOrder();
+	    theResponse = new ElementResponse(this, 76, Vector(order));
+	    Information &info = theResponse->getInformation();
+	    info.theInt = sectionNum;
+	  }
+	  
+	  output.endTag();
+	  
+	} else if (sectionNum == 0) { // argv[1] was not an int, we want all sections, 
+
+	  CompositeResponse *theCResponse = new CompositeResponse();
+	  int numResponse = 0;
+	  double xi[maxNumSections];
+	  double L = crdTransf->getInitialLength();
+	  beamIntegr->getSectionLocations(numSections, L, xi);
+	  
+	  for (int i=0; i<numSections; i++) {
+	    
+	    output.tag("GaussPointOutput");
+	    output.attr("number",i+1);
+	    output.attr("eta",xi[i]*L);
+	    
+	    Response *theSectionResponse = sections[i]->setResponse(&argv[1], argc-1, output);
+	    
+	    if (theSectionResponse != 0) {
+	      numResponse = theCResponse->addResponse(theSectionResponse);
+	    }
+	  }
+	  
+	  if (numResponse == 0) // no valid responses found
+	    delete theCResponse;
+	  else
+	    theResponse = theCResponse;
+	}
+      }
+    }
+	//by SAJalali
+	else if (strcmp(argv[0], "energy") == 0)
+	{
+		theResponse = new ElementResponse(this, 10, 0.0);
+	}
+
+    if (theResponse == 0) {
+      theResponse = crdTransf->setResponse(argv, argc, output);
+    }
+    
+    output.endTag();
+
+    return theResponse;
+}
+
+int 
+ForceBeamColumn3dThermal::getResponse(int responseID, Information &eleInfo)
+{
+  static Vector vp(6);
+  static Matrix fe(6,6);
+
+  if (responseID == 1)
+    return eleInfo.setVector(this->getResistingForce());
+  
+  else if (responseID == 2) {
+    double p0[5]; p0[0] = p0[1] = p0[2] = p0[3] = p0[4] = 0.0;
+    if (numEleLoads > 0)
+      this->computeReactions(p0);
+    // Axial
+    double N = Se(0);
+    theVector(6) =  N;
+    theVector(0) = -N+p0[0];
+    
+    // Torsion
+    double T = Se(5);
+    theVector(9) =  T;
+    theVector(3) = -T;
+    
+    // Moments about z and shears along y
+    double M1 = Se(1);
+    double M2 = Se(2);
+    theVector(5)  = M1;
+    theVector(11) = M2;
+    double L = crdTransf->getInitialLength();
+    double V = (M1+M2)/L;
+    theVector(1) =  V+p0[1];
+    theVector(7) = -V+p0[2];
+    
+    // Moments about y and shears along z
+    M1 = Se(3);
+    M2 = Se(4);
+    theVector(4)  = M1;
+    theVector(10) = M2;
+    V = (M1+M2)/L;
+    theVector(2) = -V+p0[3];
+    theVector(8) =  V+p0[4];
+      
+    return eleInfo.setVector(theVector);
+
+  }
+      
+  else if (responseID == 21)
+    return eleInfo.setVector(this->getDampingForce());
+
+  else if (responseID == 22) {
+    Vector Sd(NEBD);
+    Sd = theDamping->getDampingForce();
+    // Axial
+    double N = Sd(0);
+    theVector(6) =  N;
+    theVector(0) = -N;
+    
+    // Torsion
+    double T = Sd(5);
+    theVector(9) =  T;
+    theVector(3) = -T;
+    
+    // Moments about z and shears along y
+    double M1 = Sd(1);
+    double M2 = Sd(2);
+    theVector(5)  = M1;
+    theVector(11) = M2;
+    double L = crdTransf->getInitialLength();
+    double V = (M1+M2)/L;
+    theVector(1) =  V;
+    theVector(7) = -V;
+    
+    // Moments about y and shears along z
+    M1 = Sd(3);
+    M2 = Sd(4);
+    theVector(4)  = M1;
+    theVector(10) = M2;
+    V = (M1+M2)/L;
+    theVector(2) = -V;
+    theVector(8) =  V;
+      
+    return eleInfo.setVector(theVector);
+  }
+
+  else if (responseID == 23)
+    return eleInfo.setVector(theDamping->getDampingForce());
+      
+  // Chord rotation
+  else if (responseID == 3) {
+    vp = crdTransf->getBasicTrialDisp();
+    return eleInfo.setVector(vp);
+  }
+
+  else if (responseID == 7)
+    return eleInfo.setVector(Se);
+
+  else if (responseID == 19)
+    return eleInfo.setMatrix(kv);
+  
+  // Plastic rotation
+  else if (responseID == 4) {
+    this->getInitialFlexibility(fe);
+    vp = crdTransf->getBasicTrialDisp();
+    vp.addMatrixVector(1.0, fe, Se, -1.0);
+    Vector v0(6);
+    this->getInitialDeformations(v0);
+    vp.addVector(1.0, v0, -1.0);
+    return eleInfo.setVector(vp);
+  }
+
+  else if (responseID == 10) {
+    double L = crdTransf->getInitialLength();
+    double pts[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, pts);
+    Vector locs(numSections);
+    for (int i = 0; i < numSections; i++)
+      locs(i) = pts[i]*L;
+    return eleInfo.setVector(locs);
+  }
+
+  else if (responseID == 11) {
+    double L = crdTransf->getInitialLength();
+    double wts[maxNumSections];
+    beamIntegr->getSectionWeights(numSections, L, wts);
+    Vector weights(numSections);
+    for (int i = 0; i < numSections; i++)
+      weights(i) = wts[i]*L;
+    return eleInfo.setVector(weights);
+  }
+
+  else if (responseID == 110) {
+    ID tags(numSections);
+    for (int i = 0; i < numSections; i++)
+      tags(i) = sections[i]->getTag();
+    return eleInfo.setID(tags);
+  }
+  
+  else if (responseID == 111 || responseID == 1111) {
+    double L = crdTransf->getInitialLength();
+    double pts[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, pts);
+    // CBDI influence matrix
+    Matrix ls(numSections, numSections);
+    getCBDIinfluenceMatrix(numSections, pts, L, ls);
+    // Curvature vector
+    Vector kappaz(numSections); // about section z
+    Vector kappay(numSections); // about section y
+    for (int i = 0; i < numSections; i++) {
+      const ID &code = sections[i]->getType();
+      const Vector &e = sections[i]->getSectionDeformation();
+      int order = sections[i]->getOrder();
+      for (int j = 0; j < order; j++) {
+	if (code(j) == SECTION_RESPONSE_MZ)
+	  kappaz(i) += e(j);
+	if (code(j) == SECTION_RESPONSE_MY)
+	  kappay(i) += e(j);
+      }
+    }
+    // Displacement vector
+    Vector dispsy(numSections); // along local y
+    Vector dispsz(numSections); // along local z    
+    dispsy.addMatrixVector(0.0, ls, kappaz,  1.0);
+    dispsz.addMatrixVector(0.0, ls, kappay, -1.0);    
+    beamIntegr->getSectionLocations(numSections, L, pts);
+    static Vector uxb(3);
+    static Vector uxg(3);
+    Matrix disps(numSections,3);
+    vp = crdTransf->getBasicTrialDisp();
+    for (int i = 0; i < numSections; i++) {
+      uxb(0) = pts[i]*vp(0); // linear shape function
+      uxb(1) = dispsy(i);
+      uxb(2) = dispsz(i);
+      if (responseID == 111)
+	uxg = crdTransf->getPointGlobalDisplFromBasic(pts[i],uxb);
+      else
+	uxg = crdTransf->getPointLocalDisplFromBasic(pts[i],uxb);
+      disps(i,0) = uxg(0);
+      disps(i,1) = uxg(1);
+      disps(i,2) = uxg(2);            
+    }
+    return eleInfo.setMatrix(disps);
+  }
+
+  else if (responseID == 112) {
+    double L = crdTransf->getInitialLength();
+    double ipts[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, ipts);
+    // CBDI influence matrix
+    double pts[1];
+    pts[0] = eleInfo.theDouble;
+    Matrix ls(1, numSections);
+    getCBDIinfluenceMatrix(1, pts, numSections, ipts, L, ls);
+    // Curvature vector
+    Vector kappaz(numSections); // about section z
+    Vector kappay(numSections); // about section y    
+    for (int i = 0; i < numSections; i++) {
+      const ID &code = sections[i]->getType();
+      const Vector &e = sections[i]->getSectionDeformation();
+      int order = sections[i]->getOrder();
+      for (int j = 0; j < order; j++) {
+	if (code(j) == SECTION_RESPONSE_MZ)
+	  kappaz(i) += e(j);
+	if (code(j) == SECTION_RESPONSE_MY)
+	  kappay(i) += e(j);
+      }
+    }
+    // Displacement vector
+    Vector dispsy(1); // along local y
+    Vector dispsz(1); // along local z    
+    dispsy.addMatrixVector(0.0, ls, kappaz,  1.0);
+    dispsz.addMatrixVector(0.0, ls, kappay, -1.0);
+    static Vector uxb(3);
+    static Vector uxg(3);
+    Matrix disps(1,3);
+    vp = crdTransf->getBasicTrialDisp();
+    uxb(0) = pts[0]*vp(0); // linear shape function
+    uxb(1) = dispsy(0);
+    uxb(2) = dispsz(0);      
+    uxg = crdTransf->getPointGlobalDisplFromBasic(pts[0],uxb);
+    disps(0,0) = uxg(0);
+    disps(0,1) = uxg(1);
+    disps(0,2) = uxg(2);            
+
+    return eleInfo.setMatrix(disps);
+  }
+
+  else if (responseID == 12)
+    return eleInfo.setVector(this->getRayleighDampingForces());
+
+  // Point of inflection
+  else if (responseID == 5) {
+    static Vector LI(2);
+    LI(0) = 0.0;
+    LI(1) = 0.0;
+
+    double L = crdTransf->getInitialLength();
+
+    if (fabs(Se(1)+Se(2)) > DBL_EPSILON)
+      LI(0) = Se(1)/(Se(1)+Se(2))*L;
+
+    if (fabs(Se(3)+Se(4)) > DBL_EPSILON)
+      LI(1) = Se(3)/(Se(3)+Se(4))*L;
+
+    return eleInfo.setVector(LI);
+  }
+
+  // Tangent drift
+  else if (responseID == 6) {
+    double d2z = 0.0;
+    double d2y = 0.0;
+    double d3z = 0.0;
+    double d3y = 0.0;
+
+    double L = crdTransf->getInitialLength();
+
+    double wts[maxNumSections];
+    beamIntegr->getSectionWeights(numSections, L, wts);
+
+    double pts[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, pts);
+
+    // Location of inflection point from node I
+    double LIz = 0.0;
+    if (fabs(Se(1)+Se(2)) > DBL_EPSILON)
+      LIz = Se(1)/(Se(1)+Se(2))*L;
+
+    double LIy = 0.0;
+    if (fabs(Se(3)+Se(4)) > DBL_EPSILON)
+      LIy = Se(3)/(Se(3)+Se(4))*L;
+
+    int i;
+    for (i = 0; i < numSections; i++) {
+      double x = pts[i]*L;
+      const ID &type = sections[i]->getType();
+      int order = sections[i]->getOrder();
+      double kappa = 0.0;
+      if (x < LIz) {
+	for (int j = 0; j < order; j++)
+	  if (type(j) == SECTION_RESPONSE_MZ)
+	    kappa += vs[i](j);
+	double b = -LIz+x;
+	d2z += (wts[i]*L)*kappa*b;
+      }
+      kappa = 0.0;
+      if (x < LIy) {
+	for (int j = 0; j < order; j++)
+	  if (type(j) == SECTION_RESPONSE_MY)
+	    kappa += vs[i](j);
+	double b = -LIy+x;
+	d2y += (wts[i]*L)*kappa*b;
+      }
+    }
+
+    for (i = numSections-1; i >= 0; i--) {
+      double x = pts[i]*L;
+      const ID &type = sections[i]->getType();
+      int order = sections[i]->getOrder();
+      double kappa = 0.0;
+      if (x > LIz) {
+	for (int j = 0; j < order; j++)
+	  if (type(j) == SECTION_RESPONSE_MZ)
+	    kappa += vs[i](j);
+	double b = x-LIz;
+	d3z += (wts[i]*L)*kappa*b;
+      }
+      kappa = 0.0;
+      if (x > LIy) {
+	for (int j = 0; j < order; j++)
+	  if (type(j) == SECTION_RESPONSE_MY)
+	    kappa += vs[i](j);
+	double b = x-LIy;
+	d3y += (wts[i]*L)*kappa*b;
+      }
+    }
+
+    static Vector d(4);
+    d(0) = d2z;
+    d(1) = d3z;
+    d(2) = d2y;
+    d(3) = d3y;
+
+    return eleInfo.setVector(d);
+
+  } else if (responseID == 77) { // Why is this here?
+    return -1;
+  } else if (responseID == 8) {
+
+    ID *eleInfoID = eleInfo.theID;
+
+    int compID = (*eleInfoID)(0);
+    int critID = (*eleInfoID)(1);
+    int nTagbotn11 = (*eleInfoID)(2);
+    int nTagmidn11 = (*eleInfoID)(3);
+    int nTagtopn11 = (*eleInfoID)(4);
+    int globgrav11 = (*eleInfoID)(5);
+
+    const char* filenamewall = eleInfo.theString;
+
+    // int returns
+    double value = 0.0;
+    double checkvalue1 = 0.0;
+
+    if (critID == 7) {
+      Domain *theDomain = this->getDomain();
+
+      double oofwallresp;
+      // determine the in plane horizontal deformation axis
+      // and the out of plane horizontal deformation axis
+      Node *theNode1a = theDomain->getNode(nTagbotn11);
+      Node *theNode3a = theDomain->getNode(nTagtopn11); 
+      const Vector &crdIa1 = theNode1a->getCrds();
+      const Vector &crdJa1 = theNode3a->getCrds();
+      int indwdir1;
+      int indwdir2;
+      if (globgrav11==1) {
+	indwdir1=1;
+	indwdir2=2;
+      }
+      else if (globgrav11==2) {
+	indwdir1=0;
+	indwdir2=2;		  
+      }
+      else if (globgrav11==3) {
+	indwdir1=0;
+	indwdir2=1;		  
+      }
+
+      double dir1a1=crdJa1(indwdir1)-crdIa1(indwdir1);
+      double dir2a1=crdJa1(indwdir2)-crdIa1(indwdir2);
+      double dirsumdum=sqrt(dir1a1*dir1a1+dir2a1*dir2a1);
+      double dir1inp=dir1a1/dirsumdum;		
+      double dir2inp=dir2a1/dirsumdum;
+      
+      double dir1oop=-dir2inp;
+      double dir2oop=dir1inp;
+      
+      Node *theNode1 = theDomain->getNode(nTagbotn11);
+      const Vector &theResponsewall = theNode1->getTrialDisp();
+      double valbotinfn=theResponsewall(indwdir1)*dir1inp+theResponsewall(indwdir2)*dir2inp;
+      double valbotoutfn=theResponsewall(indwdir1)*dir1oop+theResponsewall(indwdir2)*dir2oop;
+      
+      Node *theNode2 = theDomain->getNode(nTagmidn11);
+      const Vector &theResponsewall2 = theNode2->getTrialDisp();
+      double valmidinfn=theResponsewall2(indwdir1)*dir1inp+theResponsewall2(indwdir2)*dir2inp;
+      double valmidoutfn=theResponsewall2(indwdir1)*dir1oop+theResponsewall2(indwdir2)*dir2oop;
+      
+      Node *theNode3 = theDomain->getNode(nTagtopn11);
+      const Vector &theResponsewall3 = theNode3->getTrialDisp();
+      double valtopinfn=theResponsewall3(indwdir1)*dir1inp+theResponsewall3(indwdir2)*dir2inp;
+      double valtopoutfn=theResponsewall3(indwdir1)*dir1oop+theResponsewall3(indwdir2)*dir2oop;
+      
+      value = sqrt(pow((valtopinfn-valbotinfn),2.0));
+      double valoutchck=valmidoutfn-(valtopoutfn+valbotoutfn)/2.0;
+      oofwallresp = sqrt(pow(valoutchck,2.0));
+      //        
+      double outplanevaldat; // variable for input value
+      double inplanevaldat; // variable for input value
+      double outplanevaldat1; // variable for input value
+      double inplanevaldat1; // variable for input value
+      ifstream indata;
+
+      if (filenamewall!=NULL) {
+	//		
+	indata.open(filenamewall); // opens the file
+	if(!indata) { // file couldn't be opened
+		opserr << "ForceBeamColumn3dThermal::getResponse()"
+			<< " file for infill wall (" << filenamewall << " could not be opened" << endln;
+	  return -1;
+	}
+	checkvalue1=0.0;
+	int counterdum=0;
+	while ( !indata.eof() ) { // keep reading until end-of-file
+	  counterdum=counterdum+1;
+	  indata >> outplanevaldat >> inplanevaldat ; // sets EOF flag if no value found
+	  if (counterdum!=1)  {
+	    if (oofwallresp >= outplanevaldat1 && oofwallresp <= outplanevaldat)  {
+	      checkvalue1= inplanevaldat1+(oofwallresp-outplanevaldat1)/(outplanevaldat-outplanevaldat1)*(inplanevaldat-inplanevaldat1);
+	      break; 
+	    }
+	  }
+	  indata >> outplanevaldat1 >> inplanevaldat1;
+	  if (oofwallresp >= outplanevaldat && oofwallresp <= outplanevaldat1)  {
+	    checkvalue1= inplanevaldat+(oofwallresp-outplanevaldat)/(outplanevaldat1-outplanevaldat)*(inplanevaldat1-inplanevaldat);
+	    break;
+	  }
+	}
+	indata.close();
+      }
+
+      static Vector result8(2);
+      result8(0) = value;
+      result8(1) = checkvalue1;      
+      
+      return eleInfo.setVector(result8);
+    }
+
+    return -1;
+  }
+  //by SAJalali
+  else if (responseID == 10) {
+	  double xi[maxNumSections];
+	  double L = crdTransf->getInitialLength();
+	  beamIntegr->getSectionWeights(numSections, L, xi);
+	  double energy = 0;
+	  for (int i = 0; i < numSections; i++) {
+		  energy += sections[i]->getEnergy()*xi[i] * L;
+	  }
+	  return eleInfo.setDouble(energy);
+  }
+
+  else
+    return -1;
+}
+
+int 
+ForceBeamColumn3dThermal::getResponseSensitivity(int responseID, int gradNumber,
+					  Information &eleInfo)
+{
+  // Basic deformation sensitivity
+  if (responseID == 3) {  
+    const Vector &dvdh = crdTransf->getBasicDisplSensitivity(gradNumber);
+    return eleInfo.setVector(dvdh);
+  }
+
+  // Basic force sensitivity
+  else if (responseID == 7) {
+    static Vector dqdh(6);
+
+    const Vector &dvdh = crdTransf->getBasicDisplSensitivity(gradNumber);
+
+    dqdh.addMatrixVector(0.0, kv, dvdh, 1.0);
+
+    dqdh.addVector(1.0, this->computedqdh(gradNumber), 1.0);
+    //opserr << "FBC2d: " << gradNumber;
+
+    return eleInfo.setVector(dqdh);
+  }
+
+  // dsdh
+  else if (responseID == 76) {
+
+    int sectionNum = eleInfo.theInt;
+    int order = sections[sectionNum-1]->getOrder();
+
+    Vector dsdh(order);
+    dsdh.Zero();
+
+    if (numEleLoads > 0) {
+      this->computeSectionForceSensitivity(dsdh, sectionNum-1, gradNumber);
+    }
+    //opserr << "FBC3d::getRespSens dspdh: " << dsdh;
+    static Vector dqdh(6);
+
+    const Vector &dvdh = crdTransf->getBasicDisplSensitivity(gradNumber);
+
+    dqdh.addMatrixVector(0.0, kv, dvdh, 1.0);
+
+    dqdh.addVector(1.0, this->computedqdh(gradNumber), 1.0);
+
+    //opserr << "FBC3d::getRespSens dqdh: " << dqdh;
+ 
+    double L = crdTransf->getInitialLength();
+    double oneOverL  = 1.0/L;  
+    double pts[maxNumSections];
+    beamIntegr->getSectionLocations(numSections, L, pts);
+    
+    const ID &code = sections[sectionNum-1]->getType();
+      
+    double xL  = pts[sectionNum-1];
+    double xL1 = xL-1.0;
+    
+    for (int ii = 0; ii < order; ii++) {
+      switch(code(ii)) {
+      case SECTION_RESPONSE_P:
+	dsdh(ii) += dqdh(0);
+	break;
+      case SECTION_RESPONSE_MZ:
+	dsdh(ii) +=  xL1*dqdh(1) + xL*dqdh(2);
+	break;
+      case SECTION_RESPONSE_VY:
+	dsdh(ii) += oneOverL*(dqdh(1)+dqdh(2));
+	break;
+      case SECTION_RESPONSE_MY:
+	dsdh(ii) +=  xL1*dqdh(3) + xL*dqdh(4);
+	break;
+      case SECTION_RESPONSE_VZ:
+	dsdh(ii) += oneOverL*(dqdh(3)+dqdh(4));
+	break;
+      case SECTION_RESPONSE_T:
+	dsdh(ii) += dqdh(5);
+	break;
+      default:
+	dsdh(ii) += 0.0;
+	break;
+      }
+    }
+    
+    double dLdh = crdTransf->getdLdh();
+    double d1oLdh = crdTransf->getd1overLdh();
+    
+    double dptsdh[maxNumSections];
+    beamIntegr->getLocationsDeriv(numSections, L, dLdh, dptsdh);
+    double dxLdh = dptsdh[sectionNum-1];// - xL/L*dLdh;
+
+    for (int j = 0; j < order; j++) {
+      switch (code(j)) {
+      case SECTION_RESPONSE_MZ:
+	dsdh(j) += dxLdh*(Se(1)+Se(2));
+	//dsdh(j) -= dLdh*xL/L*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_VY:
+	dsdh(j) += d1oLdh*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_MY:
+	dsdh(j) += dxLdh*(Se(3)+Se(4));
+	break;
+      case SECTION_RESPONSE_VZ:
+	dsdh(j) += d1oLdh*(Se(3)+Se(4));
+	break;
+      default:
+	break;
+      }
+    }
+
+    /*
+    opserr << "FBC3d::getRespSens dsdh=b*dqdh+dspdh: " << dsdh;
+
+    dsdh.Zero();
+    if (numEleLoads > 0) {
+      this->computeSectionForceSensitivity(dsdh, sectionNum-1, gradNumber);
+    }
+    const Matrix &ks = sections[sectionNum-1]->getSectionTangent();
+    const Vector &dedh  = sections[sectionNum-1]->getSectionDeformationSensitivity(gradNumber);
+    dsdh.addMatrixVector(1.0, ks, dedh, 1.0);
+    dsdh.addVector(1.0, sections[sectionNum-1]->getStressResultantSensitivity(gradNumber, true), 1.0);
+
+    opserr << "FBC3d::getRespSens dsdh=b*dqdh+dspdh: " << dsdh;
+    */
+
+    return eleInfo.setVector(dsdh);
+  }
+
+  // Plastic deformation sensitivity
+  else if (responseID == 4) {
+    static Vector dvpdh(6);
+
+    const Vector &dvdh = crdTransf->getBasicDisplSensitivity(gradNumber);
+
+    dvpdh = dvdh;
+    //opserr << dvpdh;
+
+    static Matrix fe(6,6);
+    this->getInitialFlexibility(fe);
+
+    const Vector &dqdh = this->computedqdh(gradNumber);
+
+    dvpdh.addMatrixVector(1.0, fe, dqdh, -1.0);
+    //opserr << dvpdh;
+
+    static Matrix fek(6,6);
+    fek.addMatrixProduct(0.0, fe, kv, 1.0);
+
+    dvpdh.addMatrixVector(1.0, fek, dvdh, -1.0);
+    //opserr << dvpdh;
+
+    const Matrix &dfedh = this->computedfedh(gradNumber);
+
+    dvpdh.addMatrixVector(1.0, dfedh, Se, -1.0);
+    //opserr << dvpdh << endln;
+    //opserr << dfedh << endln;
+
+    //opserr << dqdh + kv*dvdh << endln;
+
+    return eleInfo.setVector(dvpdh);
+  }
+
+  else
+    return -1;
+}
+
+int
+ForceBeamColumn3dThermal::setParameter(const char **argv, int argc, Parameter &param)
+{
+  if (argc < 1)
+    return -1;
+
+  int result = -1;
+
+  // If the parameter belongs to the element itself
+  if (strcmp(argv[0],"rho") == 0) {
+    param.setValue(rho);
+    return param.addObject(1, this);
+  }
+
+  // section response -
+  if (strstr(argv[0],"sectionX") != 0) {
+    if (argc > 2) {
+      float sectionLoc = atof(argv[1]);
+
+      double xi[maxNumSections];
+      double L = crdTransf->getInitialLength();
+      beamIntegr->getSectionLocations(numSections, L, xi);
+      
+      sectionLoc /= L;
+
+      float minDistance = fabs(xi[0]-sectionLoc);
+      int sectionNum = 0;
+      for (int i = 1; i < numSections; i++) {
+	if (fabs(xi[i]-sectionLoc) < minDistance) {
+	  minDistance = fabs(xi[i]-sectionLoc);
+	  sectionNum = i;
+	}
+      }
+
+      return sections[sectionNum]->setParameter(&argv[2], argc-2, param);
+    }
+  }
+
+  // If the parameter belongs to a particular section or lower
+  if (strstr(argv[0],"section") != 0) {
+    
+    if (argc < 3)
+      return -1;
+    
+    // Get section number
+    int sectionNum = atoi(argv[1]);
+   
+    if (sectionNum > 0 && sectionNum <= numSections)
+      return sections[sectionNum-1]->setParameter(&argv[2], argc-2, param);
+
+    else
+      return -1;
+  }
+  
+  // If the parameter belongs to all sections or lower
+  if (strstr(argv[0],"allSections") != 0) {
+    
+    if (argc < 2)
+      return -1;
+    
+    int ok;
+    for (int i = 0; i < numSections; i++) {
+      ok = sections[i]->setParameter(&argv[1], argc-1, param);
+      if (ok != -1)
+	result = ok;
+    }
+
+    return result;
+  }
+
+  if (strstr(argv[0],"integration") != 0) {
+    
+    if (argc < 2)
+      return -1;
+
+    return beamIntegr->setParameter(&argv[1], argc-1, param);
+  }
+
+  // Default, send to everything
+  int ok;
+
+  for (int i = 0; i < numSections; i++) {
+    ok = sections[i]->setParameter(argv, argc, param);
+    if (ok != -1)
+      result = ok;
+  }
+
+  ok = beamIntegr->setParameter(argv, argc, param);
+  if (ok != -1)
+    result = ok;
+
+  return result;
+}
+
+int
+ForceBeamColumn3dThermal::updateParameter (int parameterID, Information &info)
+{
+  if (parameterID == 1) {    
+    this->rho = info.theDouble;
+    return 0;
+  }
+  else
+    return -1;
+}
+
+int
+ForceBeamColumn3dThermal::activateParameter(int passedParameterID)
+{
+  parameterID = passedParameterID;
+
+  return 0;  
+}
+
+const Matrix&
+ForceBeamColumn3dThermal::getKiSensitivity(int gradNumber)
+{
+  theMatrix.Zero();
+  return theMatrix;
+}
+
+const Matrix&
+ForceBeamColumn3dThermal::getMassSensitivity(int gradNumber)
+{
+    theMatrix.Zero();
+
+    double L = crdTransf->getInitialLength();
+    if (rho != 0.0 && parameterID == 1)
+      theMatrix(0,0) = theMatrix(1,1) = theMatrix(2,2) =
+	theMatrix(6,6) = theMatrix(7,7) = theMatrix(8,8) = 0.5*L;
+
+    return theMatrix;
+}
+
+const Vector&
+ForceBeamColumn3dThermal::getResistingForceSensitivity(int gradNumber)
+{
+  static Vector dqdh(6);
+  dqdh = this->computedqdh(gradNumber);
+
+  // Transform forces
+  double dp0dh[6]; 
+  dp0dh[0] = 0.0; dp0dh[1] = 0.0; dp0dh[2] = 0.0;
+  dp0dh[3] = 0.0; dp0dh[4] = 0.0; dp0dh[5] = 0.0;
+  this->computeReactionSensitivity(dp0dh, gradNumber);
+  Vector dp0dhVec(dp0dh, 6);
+
+  static Vector P(12);
+  P.Zero();
+
+  if (crdTransf->isShapeSensitivity()) {
+  // dAdh^T q
+    P = crdTransf->getGlobalResistingForceShapeSensitivity(Se, dp0dhVec, gradNumber);
+    // k dAdh u
+    const Vector &dAdh_u = crdTransf->getBasicTrialDispShapeSensitivity();
+    dqdh.addMatrixVector(1.0, kv, dAdh_u, 1.0);
+  }
+
+  // A^T (dqdh + k dAdh u)
+  P += crdTransf->getGlobalResistingForce(dqdh, dp0dhVec);
+
+  return P;
+}
+
+int
+ForceBeamColumn3dThermal::commitSensitivity(int gradNumber, int numGrads)
+{
+  int err = 0;
+
+  double L = crdTransf->getInitialLength();
+  double oneOverL = 1.0/L;
+  
+  double pts[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, pts);
+  
+  double wts[maxNumSections];
+  beamIntegr->getSectionWeights(numSections, L, wts);
+
+  double dLdh = crdTransf->getdLdh();
+
+  double dptsdh[maxNumSections];
+  beamIntegr->getLocationsDeriv(numSections, L, dLdh, dptsdh);
+
+  double d1oLdh = crdTransf->getd1overLdh();
+
+  static Vector dqdh(6);
+  dqdh = this->computedqdh(gradNumber);
+
+  // dvdh = A dudh + dAdh u
+  const Vector &dvdh = crdTransf->getBasicDisplSensitivity(gradNumber);
+  dqdh.addMatrixVector(1.0, kv, dvdh, 1.0);  // A dudh
+
+  if (crdTransf->isShapeSensitivity()) {
+    //const Vector &dAdh_u = crdTransf->getBasicTrialDispShapeSensitivity(gradNumber);
+    //dqdh.addMatrixVector(1.0, kv, dAdh_u, 1.0);  // dAdh u
+  }
+
+  // Loop over integration points
+  for (int i = 0; i < numSections; i++) {
+
+    int order = sections[i]->getOrder();
+    const ID &code = sections[i]->getType();
+    
+    double xL  = pts[i];
+    double xL1 = xL-1.0;
+
+    double dxLdh  = dptsdh[i];    
+
+    Vector ds(workArea, order);
+    ds.Zero();
+
+    // Add sensitivity wrt element loads
+    if (numEleLoads > 0) {
+      this->computeSectionForceSensitivity(ds, i, gradNumber);
+    }
+
+    int j;
+    for (j = 0; j < order; j++) {
+      switch(code(j)) {
+      case SECTION_RESPONSE_P:
+	ds(j) += dqdh(0);
+	break;
+      case SECTION_RESPONSE_MZ:
+	ds(j) += xL1*dqdh(1) + xL*dqdh(2);
+	break;
+      case SECTION_RESPONSE_VY:
+	ds(j) += oneOverL*(dqdh(1)+dqdh(2));
+	break;
+      case SECTION_RESPONSE_MY:
+	ds(j) += xL1*dqdh(3) + xL*dqdh(4);
+	break;
+      case SECTION_RESPONSE_VZ:
+	ds(j) += oneOverL*(dqdh(3)+dqdh(4));
+	break;
+      case SECTION_RESPONSE_T:
+	ds(j) += dqdh(5);
+	break;
+      default:
+	ds(j) += 0.0;
+	break;
+      }
+    }
+
+    const Vector &dsdh = sections[i]->getStressResultantSensitivity(gradNumber,true);
+    ds -= dsdh;
+
+    for (j = 0; j < order; j++) {
+      switch (code(j)) {
+      case SECTION_RESPONSE_MZ:
+	ds(j) += dxLdh*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_VY:
+	ds(j) += d1oLdh*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_MY:
+	ds(j) += dxLdh*(Se(3)+Se(4));
+	break;
+      case SECTION_RESPONSE_VZ:
+	ds(j) += d1oLdh*(Se(3)+Se(4));
+	break;
+      default:
+	break;
+      }
+    }
+
+    Vector de(&workArea[order], order);
+    const Matrix &fs = sections[i]->getSectionFlexibility();
+    de.addMatrixVector(0.0, fs, ds, 1.0);
+
+    err += sections[i]->commitSensitivity(de, gradNumber, numGrads);
+  }
+
+  return err;
+}
+
+const Vector &
+ForceBeamColumn3dThermal::computedqdh(int gradNumber)
+{
+  //opserr << "FBC3d::computedqdh " << gradNumber << endln;
+
+  double L = crdTransf->getInitialLength();
+  double oneOverL = 1.0/L;
+  
+  double pts[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, pts);
+  
+  double wts[maxNumSections];
+  beamIntegr->getSectionWeights(numSections, L, wts);
+
+  double dLdh = crdTransf->getdLdh();
+
+  double dptsdh[maxNumSections];
+  beamIntegr->getLocationsDeriv(numSections, L, dLdh, dptsdh);
+
+  double dwtsdh[maxNumSections];
+  beamIntegr->getWeightsDeriv(numSections, L, dLdh, dwtsdh);
+
+  double d1oLdh = crdTransf->getd1overLdh();
+
+  static Vector dvdh(6);
+  dvdh.Zero();
+
+  // Loop over the integration points
+  for (int i = 0; i < numSections; i++) {
+
+    int order = sections[i]->getOrder();
+    const ID &code = sections[i]->getType();
+    
+    double xL  = pts[i];
+    double xL1 = xL-1.0;
+    double wtL = wts[i]*L;
+    
+    double dxLdh  = dptsdh[i];// - xL/L*dLdh;
+    double dwtLdh = wts[i]*dLdh + dwtsdh[i]*L;
+
+    //opserr << dptsdh[i] << ' ' << dwtsdh[i] << endln;
+
+    // Get section stress resultant gradient
+    Vector dsdh(&workArea[order], order);
+    dsdh = sections[i]->getStressResultantSensitivity(gradNumber,true);
+    //opserr << "FBC2d::dqdh -- " << gradNumber << ' ' << dsdh;
+    
+    Vector dspdh(&workArea[2*order], order);
+    dspdh.Zero();
+    // Add sensitivity wrt element loads
+    if (numEleLoads > 0) {
+      this->computeSectionForceSensitivity(dspdh, i, gradNumber);
+      //opserr << "FBC2d::dspdh -- " << i << ' ' << dsdh;
+    }
+    dsdh.addVector(1.0, dspdh, -1.0);
+
+    int j;
+    for (j = 0; j < order; j++) {
+      switch (code(j)) {
+      case SECTION_RESPONSE_MZ:
+	dsdh(j) -= dxLdh*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_VY:
+	dsdh(j) -= d1oLdh*(Se(1)+Se(2));
+	break;
+      case SECTION_RESPONSE_MY:
+	dsdh(j) -= dxLdh*(Se(3)+Se(4));
+	break;
+      case SECTION_RESPONSE_VZ:
+	dsdh(j) -= d1oLdh*(Se(3)+Se(4));
+	break;
+      default:
+	break;
+      }
+    }
+
+    Vector dedh(workArea, order);
+    const Matrix &fs = sections[i]->getSectionFlexibility();
+    dedh.addMatrixVector(0.0, fs, dsdh, 1.0);
+
+    for (j = 0; j < order; j++) {
+      double dei = dedh(j)*wtL;
+      switch(code(j)) {
+      case SECTION_RESPONSE_P:
+	dvdh(0) += dei; 
+	break;
+      case SECTION_RESPONSE_MZ:
+	dvdh(1) += xL1*dei; 
+	dvdh(2) += xL*dei;
+	break;
+      case SECTION_RESPONSE_VY:
+	dei = oneOverL*dei;
+	dvdh(1) += dei;
+	dvdh(2) += dei;
+	break;
+      case SECTION_RESPONSE_MY:
+	dvdh(3) += xL1*dei; 
+	dvdh(4) += xL*dei;
+	break;
+      case SECTION_RESPONSE_VZ:
+	dei = oneOverL*dei;
+	dvdh(3) += dei;
+	dvdh(4) += dei;
+	break;
+      case SECTION_RESPONSE_T:
+	dvdh(5) += dei; 
+	break;
+      default:
+	break;
+      }
+    }
+
+    const Vector &e = vs[i];
+    for (j = 0; j < order; j++) {
+      switch(code(j)) {
+      case SECTION_RESPONSE_P:
+	dvdh(0) -= e(j)*dwtLdh;
+	break;
+      case SECTION_RESPONSE_MZ:
+	dvdh(1) -= xL1*e(j)*dwtLdh;
+	dvdh(2) -= xL*e(j)*dwtLdh;
+	
+	dvdh(1) -= dxLdh*e(j)*wtL;
+	dvdh(2) -= dxLdh*e(j)*wtL;
+	break;
+      case SECTION_RESPONSE_VY:
+	dvdh(1) -= oneOverL*e(j)*dwtLdh;
+	dvdh(2) -= oneOverL*e(j)*dwtLdh;
+
+	dvdh(1) -= d1oLdh*e(j)*wtL;
+	dvdh(2) -= d1oLdh*e(j)*wtL;
+	break;
+      case SECTION_RESPONSE_MY:
+	dvdh(3) -= xL1*e(j)*dwtLdh;
+	dvdh(4) -= xL*e(j)*dwtLdh;
+	
+	dvdh(3) -= dxLdh*e(j)*wtL;
+	dvdh(4) -= dxLdh*e(j)*wtL;
+	break;
+      case SECTION_RESPONSE_VZ:
+	dvdh(3) -= oneOverL*e(j)*dwtLdh;
+	dvdh(4) -= oneOverL*e(j)*dwtLdh;
+
+	dvdh(3) -= d1oLdh*e(j)*wtL;
+	dvdh(4) -= d1oLdh*e(j)*wtL;
+	break;
+      case SECTION_RESPONSE_T:
+	dvdh(5) -= e(j)*dwtLdh;
+	break;
+      default:
+	break;
+      }
+    }
+  }
+
+  static Matrix dfedh(6,6);
+  dfedh.Zero();
+
+  //opserr << "dfedh: " << dfedh << endln;
+
+  static Vector dqdh(6);
+  dqdh.addMatrixVector(0.0, kv, dvdh, 1.0);
+  
+  //opserr << "dqdh: " << dqdh << endln;
+
+  return dqdh;
+}
+
+const Matrix&
+ForceBeamColumn3dThermal::computedfedh(int gradNumber)
+{
+  static Matrix dfedh(6,6);
+
+  dfedh.Zero();
+
+  double L = crdTransf->getInitialLength();
+  double oneOverL  = 1.0/L;  
+
+  double dLdh = crdTransf->getdLdh();
+  double d1oLdh = crdTransf->getd1overLdh();
+
+  double xi[maxNumSections];
+  beamIntegr->getSectionLocations(numSections, L, xi);
+  
+  double wt[maxNumSections];
+  beamIntegr->getSectionWeights(numSections, L, wt);
+
+  double dptsdh[maxNumSections];
+  beamIntegr->getLocationsDeriv(numSections, L, dLdh, dptsdh);
+
+  double dwtsdh[maxNumSections];
+  beamIntegr->getWeightsDeriv(numSections, L, dLdh, dwtsdh);
+
+  for (int i = 0; i < numSections; i++) {
+
+    int order      = sections[i]->getOrder();
+    const ID &code = sections[i]->getType();
+    
+    Matrix fb(workArea, order, NEBD);
+    Matrix fb2(&workArea[order*NEBD], order, NEBD);
+
+    double xL  = xi[i];
+    double xL1 = xL-1.0;
+    double wtL = wt[i]*L;
+
+    double dxLdh  = dptsdh[i];
+    double dwtLdh = wt[i]*dLdh + dwtsdh[i]*L;
+
+    const Matrix &fs = sections[i]->getInitialFlexibility();
+    const Matrix &dfsdh = sections[i]->getInitialFlexibilitySensitivity(gradNumber);
+    fb.Zero();
+    fb2.Zero();
+
+    double tmp;
+    int ii, jj;
+    for (ii = 0; ii < order; ii++) {
+      switch(code(ii)) {
+      case SECTION_RESPONSE_P:
+	for (jj = 0; jj < order; jj++) {
+	  fb(jj,0) += dfsdh(jj,ii)*wtL; // 1
+
+	  //fb(jj,0) += fs(jj,ii)*dwtLdh; // 3
+
+	  //fb2(jj,0) += fs(jj,ii)*wtL; // 4
+	}
+	break;
+      case SECTION_RESPONSE_MZ:
+	for (jj = 0; jj < order; jj++) {
+	  tmp = dfsdh(jj,ii)*wtL; // 1
+	  fb(jj,1) += xL1*tmp;
+	  fb(jj,2) += xL*tmp;
+
+	  tmp = fs(jj,ii)*wtL; // 2
+	  //fb(jj,1) += dxLdh*tmp;
+	  //fb(jj,2) += dxLdh*tmp;
+
+	  tmp = fs(jj,ii)*dwtLdh; // 3
+	  //fb(jj,1) += xL1*tmp;
+	  //fb(jj,2) += xL*tmp;
+
+	  tmp = fs(jj,ii)*wtL; // 4
+	  //fb2(jj,1) += xL1*tmp;
+	  //fb2(jj,2) += xL*tmp;
+	}
+	break;
+      case SECTION_RESPONSE_VY:
+	for (jj = 0; jj < order; jj++) {
+	  tmp = oneOverL*dfsdh(jj,ii)*wtL;
+	  fb(jj,1) += tmp;
+	  fb(jj,2) += tmp;
+
+	  // Need to complete for dLdh != 0
+	}
+	break;
+      default:
+	break;
+      }
+    }
+    for (ii = 0; ii < order; ii++) {
+      switch (code(ii)) {
+      case SECTION_RESPONSE_P:
+	for (jj = 0; jj < NEBD; jj++)
+	  dfedh(0,jj) += fb(ii,jj);
+	break;
+      case SECTION_RESPONSE_MZ:
+	for (jj = 0; jj < NEBD; jj++) {
+	  tmp = fb(ii,jj); // 1,2,3
+	  dfedh(1,jj) += xL1*tmp;
+	  dfedh(2,jj) += xL*tmp;
+
+	  tmp = fb2(ii,jj); // 4
+	  //dfedh(1,jj) += dxLdh*tmp;
+	  //dfedh(2,jj) += dxLdh*tmp;
+	}
+	break;
+      case SECTION_RESPONSE_VY:
+	for (jj = 0; jj < NEBD; jj++) {
+	  tmp = oneOverL*fb(ii,jj);
+	  dfedh(1,jj) += tmp;
+	  dfedh(2,jj) += tmp;
+
+	  // Need to complete for dLdh != 0
+	}
+	break;
+      default:
+	break;
+      }
+    }
+  }
+  
+  return dfedh;
+}
+
+void
+ForceBeamColumn3dThermal::setSectionPointers(int numSec, SectionForceDeformation **secPtrs)
+{
+  if (numSec > maxNumSections) {
+    opserr << "Error: ForceBeamColumn3dThermal::setSectionPointers -- max number of sections exceeded";
+  }
+  
+  numSections = numSec;
+  
+  if (secPtrs == 0) {
+    opserr << "Error: ForceBeamColumn3dThermal::setSectionPointers -- invalid section pointer";
+  }	  
+  
+  sections = new SectionForceDeformation *[numSections];
+  if (sections == 0) {
+    opserr << "Error: ForceBeamColumn3dThermal::setSectionPointers -- could not allocate section pointers";
+  }  
+  
+  for (int i = 0; i < numSections; i++) {
+    
+    if (secPtrs[i] == 0) {
+      opserr << "Error: ForceBeamColumn3dThermal::setSectionPointers -- null section pointer " << i << endln;
+    }
+    
+    sections[i] = secPtrs[i]->getCopy();
+    
+    if (sections[i] == 0) {
+      opserr << "Error: ForceBeamColumn3dThermal::setSectionPointers -- could not create copy of section " << i << endln;
+    }
+
+    int order = sections[i]->getOrder();
+    const ID &code = sections[i]->getType();
+    for (int j = 0; j < order; j++) {
+      if (code(j) == SECTION_RESPONSE_T)
+	isTorsion = true;
+    }
+  }
+  
+  if (!isTorsion)
+    opserr << "ForceBeamColumn3dThermal::ForceBeamColumn3dThermal -- no torsion detected in sections, " <<
+      "continuing with element torsional stiffness GJ/L = " << 1.0/DefaultLoverGJ;
+
+  // allocate section flexibility matrices and section deformation vectors
+  fs  = new Matrix [numSections];
+  if (fs == 0) {
+    opserr << "ForceBeamColumn3dThermal::setSectionPointers -- failed to allocate fs array";
+  }
+  
+  vs = new Vector [numSections];
+  if (vs == 0) {
+    opserr << "ForceBeamColumn3dThermal::setSectionPointers -- failed to allocate vs array";
+  }
+  
+  Ssr  = new Vector [numSections];
+  if (Ssr == 0) {
+    opserr << "ForceBeamColumn3dThermal::setSectionPointers -- failed to allocate Ssr array";
+  }
+  
+  vscommit = new Vector [numSections];
+  if (vscommit == 0) {
+    opserr << "ForceBeamColumn3dThermal::setSectionPointers -- failed to allocate vscommit array";   
+  }
+  
+}

--- a/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.h
+++ b/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.h
@@ -1,0 +1,237 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// $Revision: 1.12 $
+// $Date: 2010-09-13 21:26:10 $
+// $Source: /usr/local/cvs/OpenSees/SRC/element/forceBeamColumn/ForceBeamColumn3dThermal.h,v $
+
+/*
+ * References
+ *
+
+State Determination Algorithm
+---
+Neuenhofer, A. and F. C. Filippou (1997). "Evaluation of Nonlinear Frame Finite
+Element Models." Journal of Structural Engineering, 123(7):958-966.
+
+Spacone, E., V. Ciampi, and F. C. Filippou (1996). "Mixed Formulation of
+Nonlinear Beam Finite Element." Computers and Structures, 58(1):71-83.
+
+
+Plastic Hinge Integration
+---
+Scott, M. H. and G. L. Fenves (2006). "Plastic Hinge Integration Methods for
+Force-Based Beam-Column Elements." Journal of Structural Engineering,
+132(2):244-252.
+
+
+Analytical Response Sensitivity (DDM)
+---
+Scott, M. H., P. Franchin, G. L. Fenves, and F. C. Filippou (2004).
+"Response Sensitivity for Nonlinear Beam-Column Elements."
+Journal of Structural Engineering, 130(9):1281-1288.
+
+
+Software Design
+---
+Scott, M. H., G. L. Fenves, F. T. McKenna, and F. C. Filippou (2007).
+"Software Patterns for Nonlinear Beam-Column Models."
+Journal of Structural Engineering, Approved for publication, February 2007.
+
+ *
+ */
+
+#ifndef ForceBeamColumn3dThermal_h
+#define ForceBeamColumn3dThermal_h
+
+#include <Element.h>
+#include <Node.h>
+#include <Matrix.h>
+#include <Vector.h>
+#include <Channel.h>
+#include <BeamIntegration.h>
+#include <SectionForceDeformation.h>
+#include <CrdTransf.h>
+#include <Damping.h>
+
+class Response;
+class ElementalLoad;
+
+class ForceBeamColumn3dThermal: public Element
+{
+ public:
+  ForceBeamColumn3dThermal();
+  ForceBeamColumn3dThermal(int tag, int nodeI, int nodeJ, 
+		    int numSections, SectionForceDeformation **sec,
+		    BeamIntegration &beamIntegr,
+		    CrdTransf &coordTransf, double rho = 0.0, 
+		    int maxNumIters = 10, double tolerance = 1.0e-12,
+		    int maxNumSubdivide = 4, double subdivideFactor = 10.0,		    
+		    Damping *theDamping = 0);
+  
+  ~ForceBeamColumn3dThermal();
+
+  const char *getClassType(void) const {return "ForceBeamColumn3dThermal";};
+  
+  int getNumExternalNodes(void) const;
+  const ID &getExternalNodes(void);
+  Node **getNodePtrs(void);
+  
+  int getNumDOF(void);
+  
+  void setDomain(Domain *theDomain);
+  int setDamping(Domain *theDomain, Damping *theDamping);
+  int commitState(void);
+  int revertToLastCommit(void);        
+  int revertToStart(void);
+  int update(void);    
+  
+  const Matrix &getTangentStiff(void);
+  const Matrix &getInitialStiff(void);
+  const Matrix &getMass(void);    
+  
+  void zeroLoad(void);	
+  int addLoad(ElementalLoad *theLoad, double loadFactor);
+  int addInertiaLoadToUnbalance(const Vector &accel);
+  
+  const Vector &getResistingForce(void);
+  const Vector &getDampingForce(void);
+  const Vector &getResistingForceIncInertia(void);            
+  
+  int sendSelf(int cTag, Channel &theChannel);
+  int recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
+  int displaySelf(Renderer &theViewer, int displayMode, float fact, const char** displayModes = 0, int numModes = 0);
+  
+  friend OPS_Stream &operator<<(OPS_Stream &s, ForceBeamColumn3dThermal &E);        
+  void Print(OPS_Stream &s, int flag =0);    
+  
+  Response *setResponse(const char **argv, int argc, OPS_Stream &s);
+  int getResponse(int responseID, Information &eleInformation);
+  
+ // AddingSensitivity:BEGIN //////////////////////////////////////////
+  int setParameter(const char **argv, int argc, Parameter &param);
+  int updateParameter(int parameterID, Information &info);
+  int activateParameter(int parameterID);
+  const Vector &getResistingForceSensitivity(int gradNumber);
+  const Matrix &getKiSensitivity(int gradNumber);
+  const Matrix &getMassSensitivity(int gradNumber);
+  int commitSensitivity(int gradNumber, int numGrads);
+  int getResponseSensitivity(int responseID, int gradNumber,
+			     Information &eleInformation);
+  // AddingSensitivity:END ///////////////////////////////////////////
+
+ protected:
+  void setSectionPointers(int numSections, SectionForceDeformation **secPtrs);
+  int getInitialFlexibility(Matrix &fe);
+  int getInitialDeformations(Vector &v0);
+  
+ private:
+  void getForceInterpolatMatrix(double xi, Matrix &b, const ID &code);
+  void getDistrLoadInterpolatMatrix(double xi, Matrix &bp, const ID &code);
+  void compSectionDisplacements(Vector sectionCoords[], Vector sectionDispls[]) const;
+  void initializeSectionHistoryVariables (void);
+  
+  // Reactions of basic system due to element loads
+  void computeReactions(double *p0);
+
+  // Section forces due to element loads
+  void computeSectionForces(Vector &sp, int isec);
+
+  // internal data
+  ID     connectedExternalNodes; // tags of the end nodes
+
+  BeamIntegration* beamIntegr;
+  int numSections;
+  SectionForceDeformation** sections;          // array of pointers to sections
+  CrdTransf* crdTransf;        // pointer to coordinate transformation object 
+
+  // (performs the transformation between the global and basic system)
+  double rho;                    // mass density per unit length
+  int    maxIters;               // maximum number of local iterations
+  double tol;	                   // tolerance for relative energy norm for local iterations
+  
+  int    initialFlag;            // indicates if the element has been initialized
+  
+  Node *theNodes[2];   // pointers to the nodes
+  
+  Matrix kv;                     // stiffness matrix in the basic system 
+  Vector Se;                     // element resisting forces in the basic system
+  
+  Matrix kvcommit;               // committed stiffness matrix in the basic system
+  Vector Secommit;               // committed element end forces in the basic system
+  
+  Matrix *fs;                    // array of section flexibility matrices
+  Vector *vs;                    // array of section deformation vectors
+  Vector *Ssr;                   // array of section resisting force vectors
+  
+  Vector *vscommit;              // array of committed section deformation vectors
+  
+  enum {maxNumEleLoads = 100};
+  enum {NDM = 3};         // dimension of the problem (3d)
+  enum {NND = 6};         // number of nodal dof's
+  enum {NEGD = 12};        // number of element global dof's
+  enum {NEBD = 6};         // number of element dof's in the basic system
+
+  int numEleLoads; // Number of element load objects
+  int sizeEleLoads;
+  ElementalLoad **eleLoads;
+  double *eleLoadFactors;
+  Vector load;
+
+  Matrix *Ki;
+
+  bool isTorsion;
+
+  Damping *theDamping;
+  
+  static Matrix theMatrix;
+  static Vector theVector;
+  static double workArea[];
+  
+  enum {maxNumSections = 10};
+  
+  // following are added for subdivision of displacement increment
+  int    maxSubdivisions;       // maximum number of subdivisons of dv for local iterations
+  double subdivideFactor;
+  
+  static Vector vsSubdivide[];
+  static Vector SsrSubdivide[];
+  static Matrix fsSubdivide[];
+  //static int maxNumSections;
+
+  // AddingSensitivity:BEGIN //////////////////////////////////////////
+  int parameterID;
+  const Vector &computedqdh(int gradNumber);
+  const Matrix &computedfedh(int gradNumber);
+  void computeReactionSensitivity(double *dp0dh, int gradNumber);
+  void computeSectionForceSensitivity(Vector &dspdh, int isec, int gradNumber);
+  // AddingSensitivity:END ///////////////////////////////////////////
+
+	//double *dataMix; //J.Jiang
+  int counterTemperature;//J.Jiang
+  double residThermal[5];//J.Jiang
+  double residThermalP[5]; //Liming
+
+  double SectionThermalElong[20];
+  double AverageThermalElong;
+  Vector* Vsth0;
+};
+
+#endif

--- a/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
+++ b/SRC/element/forceBeamColumn/TclForceBeamColumnCommand.cpp
@@ -46,6 +46,7 @@
 #include <DispBeamColumn2dThermal.h>
 #include <DispBeamColumn3dThermal.h> //L.Jiang [SIF]
 #include <ForceBeamColumn2dThermal.h> //L.Jiang [SIF]
+#include <ForceBeamColumn3dThermal.h> //GR
 
 #include <CrdTransf.h>
 
@@ -515,6 +516,8 @@ TclModelBuilder_addForceBeamColumn(ClientData clientData, Tcl_Interp *interp,
 	theElement = new TimoshenkoBeamColumn3d(eleTag, iNode, jNode, nIP, sections, *beamIntegr, *theTransf3d, mass);      
       else if (strcmp(argv[1], "dispBeamColumnThermal") == 0)
 	theElement = new DispBeamColumn3dThermal(eleTag, iNode, jNode, nIP, sections, *beamIntegr, *theTransf3d, mass);//added by L.Jiang[SIF]
+      else if (strcmp(argv[1], "forceBeamColumnThermal") == 0)
+    theElement = new ForceBeamColumn3dThermal(eleTag, iNode, jNode, nIP, sections, *beamIntegr, *theTransf3d, mass, numIter, tol, numSub, subFac, theDamping);//added by GR
       else if (strcmp(argv[1],"dispBeamColumnWithSensitivity") == 0)
 	theElement = new DispBeamColumn3dWithSensitivity(eleTag, iNode, jNode, nIP, sections, *beamIntegr, *theTransf3d, mass);
       else

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -44,10 +44,11 @@
 #include <MaterialResponse.h>
 #include <UniaxialMaterial.h>
 #include <ElasticMaterial.h>
+#include <SectionIntegration.h>
 #include <math.h>
 #include <elementAPI.h>
 
-ID FiberSection3dThermal::code(3);
+ID FiberSection3dThermal::code(4);
 
 void* OPS_FiberSection3dThermal()
 {
@@ -104,19 +105,20 @@ void* OPS_FiberSection3dThermal()
     }
     
     int num = 30;
-    SectionForceDeformation *section = new FiberSection3dThermal(tag, num, computeCentroid);
+    SectionForceDeformation *section = new FiberSection3dThermal(tag, num, *torsion, computeCentroid);
     if (deleteTorsion)
       delete torsion;
     return section;
 }
 
 // constructors:
-FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers, bool compCentroid):
+FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers,
+						UniaxialMaterial &torsion,  bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection3dThermal),
   numFibers(num), sizeFibers(num), theMaterials(0), matData(0),
   QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
-  e(3), eCommit(3), s(0), ks(0), sT(3), Fiber_T(0), Fiber_TMax(0),
-  parameterID(0), SHVs(0)
+  sectionIntegr(0), e(4), eCommit(4), s(0), ks(0), theTorsion(0), sT(3), Fiber_T(0), Fiber_TMax(0),
+  parameterID(0), SHVs(0), AverageThermalElong(4)
 {
   if (numFibers > 0) {
     theMaterials = new UniaxialMaterial *[numFibers];
@@ -175,6 +177,10 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers, b
     }
   }
 
+  theTorsion = torsion.getCopy();
+  if (theTorsion == 0)
+    opserr << "FiberSection3d::FiberSection3d -- failed to get copy of torsion material\n";
+
   s = new Vector(sData, 3);
   ks = new Matrix(kData, 3, 3);
 
@@ -182,12 +188,13 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers, b
   sData[1] = 0.0;
   sData[2] = 0.0;
 
-  for (int i=0; i<9; i++)
+  for (int i=0; i<16; i++)
     kData[i] = 0.0;
 
   code(0) = SECTION_RESPONSE_P;
   code(1) = SECTION_RESPONSE_MZ;
   code(2) = SECTION_RESPONSE_MY;
+  code(3) = SECTION_RESPONSE_T;
 
  // AddingSensitivity:BEGIN ////////////////////////////////////
   parameterID = 0;
@@ -195,13 +202,13 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, Fiber **fibers, b
   // AddingSensitivity:END //////////////////////////////////////
 }
 
-FiberSection3dThermal::FiberSection3dThermal(int tag, int num, bool compCentroid):
+FiberSection3dThermal::FiberSection3dThermal(int tag, int num, UniaxialMaterial &torsion, bool compCentroid):
   SectionForceDeformation(tag, SEC_TAG_FiberSection3dThermal),
   numFibers(0), sizeFibers(num), theMaterials(0), matData(0),
   QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(compCentroid),
-  e(3), eCommit(3), s(0), ks(0),
+  sectionIntegr(0), e(4), eCommit(4), s(0), ks(0), theTorsion(0),
   sT(3), Fiber_T(0), Fiber_TMax(0),
-  parameterID(0), SHVs(0)
+  parameterID(0), SHVs(0), AverageThermalElong(4)
 {
   if(sizeFibers > 0) {
     theMaterials = new UniaxialMaterial *[sizeFibers];
@@ -239,20 +246,25 @@ FiberSection3dThermal::FiberSection3dThermal(int tag, int num, bool compCentroid
       Fiber_TMax[i] = 0.0;
     }
   }
+
+    theTorsion = torsion.getCopy();
+    if (theTorsion == 0) 
+      opserr << "FiberSection3d::FiberSection3d -- failed to get copy of torsion material\n";
   
-  s = new Vector(sData, 3);
-  ks = new Matrix(kData, 3, 3);
+  s = new Vector(sData, 4);
+  ks = new Matrix(kData, 4, 4);
 
   sData[0] = 0.0;
   sData[1] = 0.0;
   sData[2] = 0.0;
 
-  for (int i=0; i<9; i++)
+  for (int i=0; i<16; i++)
     kData[i] = 0.0;
 
   code(0) = SECTION_RESPONSE_P;
   code(1) = SECTION_RESPONSE_MZ;
   code(2) = SECTION_RESPONSE_MY;
+  code(3) = SECTION_RESPONSE_T;
 
  // AddingSensitivity:BEGIN ////////////////////////////////////
   parameterID = 0;
@@ -265,23 +277,24 @@ FiberSection3dThermal::FiberSection3dThermal():
   SectionForceDeformation(0, SEC_TAG_FiberSection3dThermal),
   numFibers(0), sizeFibers(0), theMaterials(0), matData(0),
   QzBar(0.0), QyBar(0.0), ABar(0.0), yBar(0.0), zBar(0.0), computeCentroid(true),
-  e(3), eCommit(3), s(0), ks(0),
+  sectionIntegr(0), e(4), eCommit(4), s(0), ks(0), theTorsion(0),
   sT(3), Fiber_T(0), Fiber_TMax(0),
-  parameterID(0), SHVs(0)
+  parameterID(0), SHVs(0), AverageThermalElong(4)
 {
-  s = new Vector(sData, 3);
-  ks = new Matrix(kData, 3, 3);
+  s = new Vector(sData, 4);
+  ks = new Matrix(kData, 4, 4);
 
   sData[0] = 0.0;
   sData[1] = 0.0;
   sData[2] = 0.0;
 
-  for (int i=0; i<9; i++)
+  for (int i=0; i<16; i++)
     kData[i] = 0.0;
 
   code(0) = SECTION_RESPONSE_P;
   code(1) = SECTION_RESPONSE_MZ;
   code(2) = SECTION_RESPONSE_MY;
+  code(3) = SECTION_RESPONSE_T;
 
  // AddingSensitivity:BEGIN ////////////////////////////////////
   parameterID = 0;
@@ -399,7 +412,13 @@ FiberSection3dThermal::~FiberSection3dThermal()
   if (Fiber_T != 0)
     delete [] Fiber_T;
   if (Fiber_TMax != 0)
-    delete [] Fiber_TMax;  
+    delete [] Fiber_TMax;
+
+  if (sectionIntegr != 0)
+    delete sectionIntegr;
+
+  if (theTorsion != 0)
+    delete theTorsion;  
 }
 
 int
@@ -408,18 +427,19 @@ FiberSection3dThermal::setTrialSectionDeformation (const Vector &deforms)
   int res = 0;
   e = deforms;
 
-  kData[0] = 0.0; kData[1] = 0.0; kData[2] = 0.0; kData[3] = 0.0;
-  kData[4] = 0.0; kData[5] = 0.0; kData[6] = 0.0; kData[7] = 0.0;
-  kData[8] = 0.0;
-  sData[0] = 0.0; sData[1] = 0.0;  sData[2] = 0.0;
+  for (int i = 0; i < 4; i++)
+      sData[i] = 0.0;
+  for (int i = 0; i < 16; i++)
+      kData[i] = 0.0;
 
   int loc = 0;
 
   double d0 = deforms(0);
   double d1 = deforms(1);
   double d2 = deforms(2);
+  double d3 = deforms(3);
 
-
+  double tangent, stress;
   for (int i = 0; i < numFibers; i++) {
     UniaxialMaterial *theMat = theMaterials[i];
     double y = matData[loc++] - yBar;
@@ -471,10 +491,10 @@ FiberSection3dThermal::setTrialSectionDeformation (const Vector &deforms)
     kData[1] += vas1;
     kData[2] += vas2;
 
-    kData[4] += vas1 * y;
-    kData[5] += vas1as2;
+    kData[5] += vas1 * y;
+    kData[6] += vas1as2;
 
-    kData[8] += vas2 * z;
+    kData[10] += vas2 * z;
 
     double fs0 = stress * A;
 
@@ -483,9 +503,15 @@ FiberSection3dThermal::setTrialSectionDeformation (const Vector &deforms)
     sData[2] += fs0 * z;
   }
 
-  kData[3] = kData[1];
-  kData[6] = kData[2];
-  kData[7] = kData[5];
+  kData[4] = kData[1];
+  kData[8] = kData[2];
+  kData[9] = kData[6];
+
+  if (theTorsion != 0) {
+    res += theTorsion->setTrial(d3, stress, tangent);
+    sData[3] = stress;
+    kData[15] = tangent;
+  }
 
   return res;
 }
@@ -493,14 +519,10 @@ FiberSection3dThermal::setTrialSectionDeformation (const Vector &deforms)
 const Matrix&
 FiberSection3dThermal::getInitialTangent(void)
 {
-  static double kInitialData[9];
-  static Matrix kInitial(kInitialData, 3, 3);
-
-  kInitialData[0] = 0.0; kInitialData[1] = 0.0;
-  kInitialData[2] = 0.0; kInitialData[3] = 0.0;
-  kInitialData[4] = 0.0; kInitialData[5] = 0.0;
-  kInitialData[6] = 0.0; kInitialData[7] = 0.0;
-  kInitialData[8] = 0.0;
+  static double kInitialData[16];
+  static Matrix kInitial(kInitialData, 4, 4);
+  
+  kInitial.Zero();
 
   int loc = 0;
 
@@ -521,15 +543,18 @@ FiberSection3dThermal::getInitialTangent(void)
     kInitialData[1] += vas1;
     kInitialData[2] += vas2;
 
-    kInitialData[4] += vas1 * y;
-    kInitialData[5] += vas1as2;
+    kInitialData[5] += vas1 * y;
+    kInitialData[6] += vas1as2;
 
-    kInitialData[8] += vas2 * z;
+    kInitialData[10] += vas2 * z;
   }
 
-  kInitialData[3] = kInitialData[1];
-  kInitialData[6] = kInitialData[2];
-  kInitialData[7] = kInitialData[5];
+  kInitialData[4] = kInitialData[1];
+  kInitialData[8] = kInitialData[2];
+  kInitialData[9] = kInitialData[6];
+
+  if (theTorsion != 0)
+    kInitialData[15] = theTorsion->getInitialTangent();
 
   return kInitial;
 }
@@ -558,7 +583,7 @@ const Vector&
 FiberSection3dThermal::getTemperatureStress(const Vector& dataMixed)
 {
   sT.Zero();
-
+  AverageThermalElong.Zero();
   //JJadd, 12/2010, updata yBar = Ai*Ei*yi/(Ai*E*)  start
   double ThermalTangent[1000];
   double ThermalElong[1000];
@@ -616,21 +641,43 @@ FiberSection3dThermal::getTemperatureStress(const Vector& dataMixed)
  // calculate section resisting force due to thermal load
 
   double FiberForce;
+  double SectionArea = 0;
+  double ThermalForce = 0;
+  double ThermalMomentY = 0; double ThermalMomentZ = 0;
+  double SectionMomofAreaY = 0; double SectionMomofAreaZ = 0;
+
   for (int i = 0; i < numFibers; i++) {
 	  FiberForce = ThermalTangent[i]*matData[3*i+2]*ThermalElong[i];
 	  sT(0) += FiberForce;
 	  sT(1) += FiberForce*(matData[3*i] - yBar);
 	  sT(2) += FiberForce*(matData[3*i+1] - zBar);
+      // added GR
+      SectionArea += matData[3 * i+2];
+      SectionMomofAreaY += (matData[3 * i + 2] * (matData[3 * i] - yBar) * (matData[3 * i] - yBar));
+      SectionMomofAreaZ += (matData[3 * i + 2] * (matData[3 * i+1] - zBar) * (matData[3 * i+1] - zBar));
+      ThermalForce += ThermalElong[i] * matData[3 * i + 2];
+      ThermalMomentY += ThermalElong[i] * matData[3 * i + 2] * (matData[3 * i] - yBar);
+      ThermalMomentZ += ThermalElong[i] * matData[3 * i + 2] * (matData[3 * i+1] - zBar);
   }
   //double ThermalMoment;
   //ThermalMoment = abs(sTData[1]);
  // sTData[1] = ThermalMoment;
+  AverageThermalElong(0) = ThermalForce / SectionArea;
+  AverageThermalElong(1) = ThermalMomentY / SectionMomofAreaY;
+  AverageThermalElong(2) = ThermalMomentZ / SectionMomofAreaZ;
+  AverageThermalElong(3) = 0.0; // no contribution in torsion
 
   return sT;
 }
 //JJadd--12.2010---to get section force due to thermal load----end-----
 
-
+//UoE group///Calculating Thermal stresses at each /////////////////////////////////////////////////////end
+const Vector&
+FiberSection3dThermal::getThermalElong(void)
+{
+    return AverageThermalElong;
+}
+//Retuning ThermalElongation
 
 SectionForceDeformation*
 FiberSection3dThermal::getCopy(void)
@@ -639,7 +686,7 @@ FiberSection3dThermal::getCopy(void)
   theCopy->setTag(this->getTag());
 
   theCopy->numFibers = numFibers;
-
+  theCopy->sizeFibers = numFibers;
   if (numFibers > 0) {
     theCopy->theMaterials = new UniaxialMaterial *[numFibers];
 
@@ -687,14 +734,25 @@ FiberSection3dThermal::getCopy(void)
   theCopy->zBar = zBar;
   theCopy->computeCentroid = computeCentroid;
   
-  for (int i=0; i<9; i++)
+  for (int i=0; i<16; i++)
     theCopy->kData[i] = kData[i];
 
   theCopy->sData[0] = sData[0];
   theCopy->sData[1] = sData[1];
   theCopy->sData[2] = sData[2];
+  theCopy->sData[3] = sData[3];
   theCopy->sT = sT;
   
+  if (theTorsion != 0)
+    theCopy->theTorsion = theTorsion->getCopy();
+  else
+    theCopy->theTorsion = 0;
+
+  if (sectionIntegr != 0)
+    theCopy->sectionIntegr = sectionIntegr->getCopy();
+  else
+    theCopy->sectionIntegr = 0;
+
   return theCopy;
 }
 
@@ -707,7 +765,7 @@ FiberSection3dThermal::getType ()
 int
 FiberSection3dThermal::getOrder () const
 {
-  return 3;
+  return 4;
 }
 
 int
@@ -718,6 +776,9 @@ FiberSection3dThermal::commitState(void)
   for (int i = 0; i < numFibers; i++)
     err += theMaterials[i]->commitState();
 
+  if (theTorsion != 0)
+    err += theTorsion->commitState();
+  
   eCommit = e;
 
   return err;
@@ -735,7 +796,8 @@ FiberSection3dThermal::revertToLastCommit(void)
   kData[0] = 0.0; kData[1] = 0.0; kData[2] = 0.0; kData[3] = 0.0;
   kData[4] = 0.0; kData[5] = 0.0; kData[6] = 0.0; kData[7] = 0.0;
   kData[8] = 0.0;
-  sData[0] = 0.0; sData[1] = 0.0;  sData[2] = 0.0;
+  kData[15] = 0.0;
+  sData[0] = 0.0; sData[1] = 0.0;  sData[2] = 0.0; sData[3] = 0.0;
 
   int loc = 0;
 
@@ -760,10 +822,10 @@ FiberSection3dThermal::revertToLastCommit(void)
     kData[1] += vas1;
     kData[2] += vas2;
 
-    kData[4] += vas1 * y;
-    kData[5] += vas1as2;
+    kData[5] += vas1 * y;
+    kData[6] += vas1as2;
 
-    kData[8] += vas2 * z;
+    kData[10] += vas2 * z;
 
     double fs0 = stress * A;
     sData[0] += fs0;
@@ -771,9 +833,15 @@ FiberSection3dThermal::revertToLastCommit(void)
     sData[2] += fs0 * z;
   }
 
-  kData[3] = kData[1];
-  kData[6] = kData[2];
-  kData[7] = kData[5];
+  kData[4] = kData[1];
+  kData[8] = kData[2];
+  kData[9] = kData[6];
+
+  if (theTorsion != 0) {
+    err += theTorsion->revertToLastCommit();
+    kData[15] = theTorsion->getTangent();
+  } else
+    kData[15] = 0.0;
 
   return err;
 }
@@ -787,8 +855,8 @@ FiberSection3dThermal::revertToStart(void)
 
   kData[0] = 0.0; kData[1] = 0.0; kData[2] = 0.0; kData[3] = 0.0;
   kData[4] = 0.0; kData[5] = 0.0; kData[6] = 0.0; kData[7] = 0.0;
-  kData[8] = 0.0;
-  sData[0] = 0.0; sData[1] = 0.0;  sData[2] = 0.0;
+  kData[8] = 0.0; kData[15] = 0.0;
+  sData[0] = 0.0; sData[1] = 0.0;  sData[2] = 0.0; sData[3] = 0.0;
 
   int loc = 0;
 
@@ -813,10 +881,10 @@ FiberSection3dThermal::revertToStart(void)
     kData[1] += vas1;
     kData[2] += vas2;
 
-    kData[4] += vas1 * y;
-    kData[5] += vas1as2;
+    kData[5] += vas1 * y;
+    kData[6] += vas1as2;
 
-    kData[8] += vas2 * z;
+    kData[10] += vas2 * z;
 
     double fs0 = stress * A;
     sData[0] += fs0;
@@ -824,9 +892,18 @@ FiberSection3dThermal::revertToStart(void)
     sData[2] += fs0 * z;
   }
 
-  kData[3] = kData[1];
-  kData[6] = kData[2];
-  kData[7] = kData[5];
+  kData[4] = kData[1];
+  kData[8] = kData[2];
+  kData[9] = kData[6];
+
+  if (theTorsion != 0) {
+    err += theTorsion->revertToStart();
+    kData[15] = theTorsion->getTangent();
+    sData[3] = theTorsion->getStress();
+  } else {
+    kData[15] = 0.0;
+    sData[3] = 0.0;
+  }
 
   return err;
 }
@@ -838,19 +915,54 @@ FiberSection3dThermal::sendSelf(int commitTag, Channel &theChannel)
 
   // create an id to send objects tag and numFibers,
   //     size 3 so no conflict with matData below if just 1 fiber
-  static ID data(3);
+  static ID data(9);
   data(0) = this->getTag();
   data(1) = numFibers;
-  data(2) = computeCentroid ? 1 : 0; // Now the ID data is really 3
-  int dbTag = this->getDbTag();
-  res += theChannel.sendID(dbTag, commitTag, data);
-  if (res < 0) {
-    opserr << "FiberSection2d::sendSelf - failed to send ID data\n";
-    return res;
+  //data(2) = computeCentroid ? 1 : 0; // Now the ID data is really 3
+  data(2) = (theTorsion != 0) ? 1 : 0;
+  if (theTorsion != 0) {
+    data(3) = theTorsion->getClassTag();
+    int torsionDbTag = theTorsion->getDbTag();
+    if (torsionDbTag == 0) {
+      torsionDbTag = theChannel.getDbTag();
+      if (torsionDbTag != 0)
+	theTorsion->setDbTag(torsionDbTag);
+    }
+    data(4) = torsionDbTag;
+  }
+  data(5) = computeCentroid ? 1 : 0; // Now the ID data is really 5
+  data(6) = sectionIntegr != 0 ? 1 : 0;
+  if (sectionIntegr != 0) {
+    data(7) = sectionIntegr->getClassTag();
+    int sectionIntegrDbTag = sectionIntegr->getDbTag();
+    if (sectionIntegrDbTag == 0) {
+      sectionIntegrDbTag = theChannel.getDbTag();
+      if (sectionIntegrDbTag != 0)
+	sectionIntegr->setDbTag(sectionIntegrDbTag);
+    }
+    data(8) = sectionIntegrDbTag;
   }
 
-  if (numFibers != 0) {
+  int dbTag = this->getDbTag();  
+  res += theChannel.sendID(dbTag, commitTag, data);
+  if (res < 0) {
+    opserr << "FiberSection3d::sendSelf - failed to send ID data\n";
+    return res;
+  }    
 
+  if (theTorsion != 0)
+    theTorsion->sendSelf(commitTag, theChannel);
+
+  if (sectionIntegr != 0) {
+    res = sectionIntegr->sendSelf(commitTag, theChannel);
+    if (res < 0) {
+      opserr << "FiberSection3d::sendSelf - failed to send section integration" << endln;
+      return res;
+    }
+  }
+  
+  if (numFibers != 0) {
+    
     // create an id containingg classTag and dbTag for each material & send it
     ID materialData(2*numFibers);
     for (int i=0; i<numFibers; i++) {
@@ -863,13 +975,13 @@ FiberSection3dThermal::sendSelf(int commitTag, Channel &theChannel)
 	  theMat->setDbTag(matDbTag);
       }
       materialData(2*i+1) = matDbTag;
-    }
-
+    }    
+    
     res += theChannel.sendID(dbTag, commitTag, materialData);
     if (res < 0) {
-     opserr << "FiberSection2d::sendSelf - failed to send material data\n";
+     opserr << "FiberSection3d::sendSelf - failed to send material data\n";
      return res;
-    }
+    }    
 
     // send the fiber data, i.e. area and loc, T, and Tmax
     Vector fiberData(5*numFibers);
@@ -887,8 +999,14 @@ FiberSection3dThermal::sendSelf(int commitTag, Channel &theChannel)
     }
 
     // now invoke send(0 on all the materials
-    for (int j=0; j<numFibers; j++)
+    for (int j=0; j<numFibers; j++) {
       theMaterials[j]->sendSelf(commitTag, theChannel);
+      if (res < 0) {
+	opserr << "FiberSection3d::sendSelf - failed to send material with tag "
+	       << theMaterials[j]->getTag() << endln;
+	return res;
+      }
+    }
   }
 
   return res;
@@ -900,26 +1018,68 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
 {
   int res = 0;
 
-  static ID data(3);
-
+  static ID data(9);
+  
   int dbTag = this->getDbTag();
   res += theChannel.recvID(dbTag, commitTag, data);
-
   if (res < 0) {
-   opserr << "FiberSection2d::sendSelf - failed to recv ID data\n";
+   opserr << "FiberSection3d::recvSelf - failed to recv ID data\n";
    return res;
-  }
-
+  } 
   this->setTag(data(0));
 
+  if (data(2) == 1 && theTorsion == 0) {	
+    int torsionClassTag = data(3);
+    int torsionDbTag = data(4);
+    theTorsion = theBroker.getNewUniaxialMaterial(torsionClassTag);
+    if (theTorsion == 0) {
+      opserr << "FiberSection3d::recvSelf - failed to get torsion material \n";
+      return -1;
+    }
+    theTorsion->setDbTag(torsionDbTag);
+  }
+
+  if (theTorsion->recvSelf(commitTag, theChannel, theBroker) < 0) {
+	   opserr << "FiberSection3d::recvSelf - torsion failed to recvSelf \n";
+       return -2;
+  }
+
+  if (data(6) == 1) {
+    int sectionIntegrClassTag = data(7);
+    int sectionIntegrDbTag = data(8);
+
+    // create a new section integration object if one needed
+    if (sectionIntegr == 0 || sectionIntegr->getClassTag() != sectionIntegrClassTag) {
+      if (sectionIntegr != 0)
+	delete sectionIntegr;
+      
+      sectionIntegr = theBroker.getNewSectionIntegration(sectionIntegrClassTag);
+      
+      if (sectionIntegr == 0) {
+	opserr << "FiberSection3d::recvSelf() - failed to obtain a SectionIntegration object with classTag "
+	       << sectionIntegrClassTag << endln;
+	exit(-1);
+      }
+    }
+    
+    sectionIntegr->setDbTag(sectionIntegrDbTag);
+    
+    // invoke recvSelf on the section integration object
+    if (sectionIntegr->recvSelf(commitTag, theChannel, theBroker) < 0) {
+      opserr << "FiberSection3d::sendSelf() - failed to recv SectionIntegration\n";
+      return -3;
+    }      
+  } else
+    sectionIntegr = 0;
+  
   // recv data about materials objects, classTag and dbTag
   if (data(1) != 0) {
     ID materialData(2*data(1));
     res += theChannel.recvID(dbTag, commitTag, materialData);
     if (res < 0) {
-     opserr << "FiberSection2d::sendSelf - failed to send material data\n";
+     opserr << "FiberSection3d::recvSelf - failed to recv material data\n";
      return res;
-    }
+    }    
 
     // if current arrays not of correct size, release old and resize
     if (theMaterials == 0 || numFibers != data(1)) {
@@ -928,10 +1088,11 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
 	for (int i=0; i<numFibers; i++)
 	  delete theMaterials[i];
 	delete [] theMaterials;
-	theMaterials = 0;	
+	if (matData != 0)
+	  delete [] matData;
+	matData = 0;
+	theMaterials = 0;
       }
-      if (matData != 0)
-	delete [] matData;
       if (Fiber_T != 0)
 	delete [] Fiber_T;
       if (Fiber_TMax != 0)
@@ -942,22 +1103,23 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
 
       // create memory to hold material pointers and fiber data
       numFibers = data(1);
+      sizeFibers = data(1);
       if (numFibers != 0) {
 
 	theMaterials = new UniaxialMaterial *[numFibers];
-
+	
 	if (theMaterials == 0) {
-	  opserr << "FiberSection2d::recvSelf -- failed to allocate Material pointers\n";
+	  opserr << "FiberSection3d::recvSelf -- failed to allocate Material pointers\n";
 	  exit(-1);
 	}
 
 	for (int j=0; j<numFibers; j++)
 	  theMaterials[j] = 0;
-
+	
 	matData = new double [numFibers*3];
 
 	if (matData == 0) {
-	  opserr << "FiberSection2d::recvSelf  -- failed to allocate double array for material data\n";
+	  opserr << "FiberSection3d::recvSelf  -- failed to allocate double array for material data\n";
 	  exit(-1);
 	}
 
@@ -977,7 +1139,7 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
     Vector fiberData(5*numFibers);
     res += theChannel.recvVector(dbTag, commitTag, fiberData);
     if (res < 0) {
-     opserr << "FiberSection2d::sendSelf - failed to send material data\n";
+     opserr << "FiberSection3d::recvSelf - failed to recv fiber data\n";
      return res;
     }
     for (int i = 0; i < numFibers; i++) {
@@ -993,17 +1155,17 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
       int classTag = materialData(2*i);
       int dbTag = materialData(2*i+1);
 
-      // if material pointed to is blank or not of corrcet type,
+      // if material pointed to is blank or not of corrcet type, 
       // release old and create a new one
       if (theMaterials[i] == 0)
 	theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);
       else if (theMaterials[i]->getClassTag() != classTag) {
 	delete theMaterials[i];
-	theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);
+	theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);      
       }
 
       if (theMaterials[i] == 0) {
-	opserr << "FiberSection2d::recvSelf -- failed to allocate double array for material data\n";
+	opserr << "FiberSection3d::recvSelf -- failed to allocate double array for material data\n";
 	exit(-1);
       }
 
@@ -1015,8 +1177,23 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
     QyBar = 0.0;
     ABar = 0.0;
 
-    computeCentroid = data(2) ? true : false;
-    
+    computeCentroid = data(5) ? true : false;
+
+    if (sectionIntegr != 0) {
+      static double yLocs[10000];
+      static double zLocs[10000];
+      sectionIntegr->getFiberLocations(numFibers, yLocs, zLocs);
+      
+      static double fiberArea[10000];
+      sectionIntegr->getFiberWeights(numFibers, fiberArea);
+      
+      for (int i = 0; i < numFibers; i++) {
+		ABar  += fiberArea[i];
+		QzBar += yLocs[i]*fiberArea[i];
+		QyBar += zLocs[i]*fiberArea[i];
+      }
+    }
+    else {
     // Recompute centroid
     double yLoc, zLoc, Area;    
     for (i = 0; computeCentroid && i < numFibers; i++) {
@@ -1026,6 +1203,7 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
       ABar  += Area;
       QzBar += yLoc*Area;
       QyBar += zLoc*Area;
+    	}
     }
 
     if (computeCentroid) {
@@ -1033,9 +1211,9 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
       zBar = QyBar/ABar;
     } else {
       yBar = 0.0;
-      zBar = 0.0;
+      zBar = 0.0;      
     }
-  }
+  }   
 
   return res;
 }
@@ -1053,6 +1231,8 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
     s << "\tSection code: " << code;
     s << "\tNumber of Fibers: " << numFibers << endln;
     s << "\tCentroid: (" << yBar << ", " << zBar << ')' << endln;
+    if (theTorsion != 0)
+        theTorsion->Print(s, flag); 
 
     if (flag == 1) {
       for (int i = 0; i < numFibers; i++) {
@@ -1061,6 +1241,39 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
       theMaterials[i]->Print(s, flag);
       }
     }
+  }
+  if (flag == 3) {
+    for (int i = 0; i < numFibers; i++) {
+      s << theMaterials[i]->getTag() << " " << matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;
+      s << theMaterials[i]->getStress() << " "  << theMaterials[i]->getStrain() << endln;
+    } 
+  }
+    
+  if (flag == 4) {
+    for (int i = 0; i < numFibers; i++) {
+      s << "add fiber # " << i+1 << " using material # " << theMaterials[i]->getTag() << " to section # 1\n";
+      s << "fiber_cross_section = " << matData[3*i+2] << "*m^2\n";
+      s << "fiber_location = (" << matData[3*i] << "*m, " << matData[3*i+1] << "*m);\n\n";
+    }
+  }
+
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+	  s << "\t\t\t{";
+	  s << "\"name\": \"" << this->getTag() << "\", ";
+	  s << "\"type\": \"FiberSection3d\", ";
+	  if (theTorsion != 0)
+	    s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+	  s << "\"fibers\": [\n";
+	  for (int i = 0; i < numFibers; i++) {
+		  s << "\t\t\t\t{\"coord\": [" << matData[3*i] << ", " << matData[3*i+1] << "], ";
+		  s << "\"area\": " << matData[3*i+2] << ", ";
+		  s << "\"material\": \"" << theMaterials[i]->getTag() << "\"";
+		  if (i < numFibers - 1)
+			  s << "},\n";
+		  else
+			  s << "}\n";
+	  }
+	  s << "\t\t\t]}";
   }
 }
 
@@ -1073,7 +1286,7 @@ FiberSection3dThermal::setResponse(const char **argv, int argc, OPS_Stream &outp
 
     int key = numFibers;
     int passarg = 2;
-
+    
     if (argc <= 3)	{  // fiber number was input directly
       
       key = atoi(argv[1]);
@@ -1082,7 +1295,7 @@ FiberSection3dThermal::setResponse(const char **argv, int argc, OPS_Stream &outp
       int matTag = atoi(argv[3]);
       double yCoord = atof(argv[1]);
       double zCoord = atof(argv[2]);
-      double closestDist;
+      double closestDist = 0.0;
       double ySearch, zSearch, dy, dz;
       double distance;
       int j;
@@ -1153,14 +1366,14 @@ FiberSection3dThermal::setResponse(const char **argv, int argc, OPS_Stream &outp
       
       output.endTag();
     }
-
+  
   } else if (strcmp(argv[0],"fiberData") == 0) {
     int numData = numFibers*5;
     for (int j = 0; j < numFibers; j++) {
       output.tag("FiberOutput");
       output.attr("yLoc", matData[3*j]);
       output.attr("zLoc", matData[3*j+1]);
-      output.attr("area", matData[3*j+2]);
+      output.attr("area", matData[3*j+2]);    
       output.tag("ResponseType","yCoord");
       output.tag("ResponseType","zCoord");
       output.tag("ResponseType","area");
@@ -1189,7 +1402,7 @@ FiberSection3dThermal::getResponse(int responseID, Information &sectInfo)
     for (int j = 0; j < numFibers; j++) {
       double yLoc, zLoc, A, stress, strain;
       yLoc = -matData[3*j];
-      zLoc =  matData[3*j+1];
+      zLoc = matData[3*j+1];
       A = matData[3*j+2];
       stress = theMaterials[j]->getStress();
       strain = theMaterials[j]->getStrain();
@@ -1225,8 +1438,21 @@ FiberSection3dThermal::setParameter(const char **argv, int argc, Parameter &para
 	if (ok != -1)
 	  result = ok;
       }
-
+    
+    if (paramMatTag == theTorsion->getTag()) {
+	ok = theTorsion->setParameter(&argv[2], argc-2, param);
+	if (ok != -1)
+	  result = ok;
+    }
     return result;
+  }    
+
+  // Check if it belongs to the section integration
+  else if (strstr(argv[0],"integration") != 0) {
+    if (sectionIntegr != 0)
+      return sectionIntegr->setParameter(&argv[1], argc-1, param);
+    else
+      return -1;
   }
 
   int ok = 0;
@@ -1234,6 +1460,17 @@ FiberSection3dThermal::setParameter(const char **argv, int argc, Parameter &para
   // loop over every material
   for (int i = 0; i < numFibers; i++) {
     ok = theMaterials[i]->setParameter(argv, argc, param);
+    if (ok != -1)
+      result = ok;
+  }
+
+  // Don't really need to do this in "default" mode
+  //ok = theTorsion->setParameter(argv, argc, param);
+  //if (ok != -1)
+  //  result = ok;
+
+  if (sectionIntegr != 0) {
+    ok = sectionIntegr->setParameter(argv, argc, param);
     if (ok != -1)
       result = ok;
   }
@@ -1258,9 +1495,8 @@ FiberSection3dThermal::getSectionDeformationSensitivity(int gradIndex)
 const Vector &
 FiberSection3dThermal::getStressResultantSensitivity(int gradIndex, bool conditional)
 {
-
-  static Vector ds(3);
-
+  static Vector ds(4);
+  
   ds.Zero();
 
   double  stressGradient;
@@ -1278,6 +1514,8 @@ FiberSection3dThermal::getStressResultantSensitivity(int gradIndex, bool conditi
     ds(2) += stressGradient * z;
 
   }  //for
+  
+  ds(3) = theTorsion->getStressSensitivity(gradIndex, conditional);
 
   return ds;
 }
@@ -1285,10 +1523,12 @@ FiberSection3dThermal::getStressResultantSensitivity(int gradIndex, bool conditi
 const Matrix &
 FiberSection3dThermal::getSectionTangentSensitivity(int gradIndex)
 {
-  static Matrix something(3,3);
+  static Matrix something(4,4);
 
   something.Zero();
 
+  something(3,3) = theTorsion->getTangentSensitivity(gradIndex);
+  
   return something;
 }
 
@@ -1299,19 +1539,19 @@ FiberSection3dThermal::commitSensitivity(const Vector& defSens, int gradIndex, i
   // here add SHVs to store the strain sensitivity.
 
   if (SHVs == 0) {
-    SHVs = new Matrix(3,numGrads);
+    SHVs = new Matrix(4,numGrads);
   }
 
   (*SHVs)(0,gradIndex) = defSens(0);
   (*SHVs)(1,gradIndex) = defSens(1);
   (*SHVs)(2,gradIndex) = defSens(2);
-
+  (*SHVs)(3,gradIndex) = defSens(3);
   int loc = 0;
 
   double d0 = defSens(0);
   double d1 = defSens(1);
   double d2 = defSens(2);
-
+  double d3 = defSens(3);
   for (int i = 0; i < numFibers; i++) {
    	double y = matData[loc++] - yBar;
 	double z = matData[loc++] - zBar;
@@ -1321,6 +1561,8 @@ FiberSection3dThermal::commitSensitivity(const Vector& defSens, int gradIndex, i
 
 	theMaterials[i]->commitSensitivity(strainSens,gradIndex,numGrads);
   }
+
+  theTorsion->commitSensitivity(d3, gradIndex, numGrads);
 
   return 0;
 }
@@ -1393,7 +1635,7 @@ FiberSection3dThermal::determineFiberTemperature(const Vector& DataMixed, double
 			dataTempe[i] = DataMixed(i);
 		}
 
-		if ( fabs(dataTempe[0]) <= 1e-10 && fabs(dataTempe[10]) <= 1e-10 &&fabs(dataTempe[11]) <= 1e-10) //no tempe load
+		if ( fabs(dataTempe[0]) <= 1e-10 && fabs(dataTempe[2]) <= 1e-10 && fabs(dataTempe[10]) <= 1e-10 && fabs(dataTempe[11]) <= 1e-10) //no tempe load
 		{
 			return 0;
 		}

--- a/SRC/material/section/FiberSection3dThermal.h
+++ b/SRC/material/section/FiberSection3dThermal.h
@@ -30,7 +30,7 @@
 // 3d beam section discretized by fibers. The section stiffness and
 // stress resultants are obtained by summing fiber contributions.
 // Modified for SIF modelling by Jian Jiang,Liming Jiang [http://openseesforfire.github.io]
-
+// Corrected by Giovanni Rinaldin, 2024
 
 #ifndef FiberSection3dThermal_h
 #define FiberSection3dThermal_h
@@ -42,13 +42,15 @@
 class UniaxialMaterial;
 class Fiber;
 class Response;
+class SectionIntegration;
 
 class FiberSection3dThermal : public SectionForceDeformation
 {
   public:
     FiberSection3dThermal();
-    FiberSection3dThermal(int tag, int numFibers, Fiber **fibers, bool compCentroid=true);
-    FiberSection3dThermal(int tag, int numFibers, bool compCentroid=true);
+    FiberSection3dThermal(int tag, int numFibers, Fiber **fibers, 
+    				UniaxialMaterial &torsion, bool compCentroid=true);
+    FiberSection3dThermal(int tag, int numFibers, UniaxialMaterial &torsion, bool compCentroid=true);
     ~FiberSection3dThermal();
 
     const char *getClassType(void) const {return "FiberSection3dThermal";};
@@ -65,17 +67,17 @@ class FiberSection3dThermal : public SectionForceDeformation
     int   commitState(void);
     int   revertToLastCommit(void);
     int   revertToStart(void);
-
+ 
     SectionForceDeformation *getCopy(void);
     const ID &getType (void);
     int getOrder (void) const;
-
+    
     int sendSelf(int cTag, Channel &theChannel);
     int recvSelf(int cTag, Channel &theChannel,
 		 FEM_ObjectBroker &theBroker);
     void Print(OPS_Stream &s, int flag = 0);
-
-    Response *setResponse(const char **argv, int argc,
+	    
+    Response *setResponse(const char **argv, int argc, 
 			  OPS_Stream &s);
     int getResponse(int responseID, Information &info);
 
@@ -92,21 +94,23 @@ class FiberSection3dThermal : public SectionForceDeformation
     // AddingSensitivity:END ///////////////////////////////////////////
 
 	double determineFiberTemperature(const Vector& , double , double);
-
+    const Vector& getThermalElong(void);
   protected:
 
   private:
     int numFibers, sizeFibers;                   // number of fibers in the section
     UniaxialMaterial **theMaterials; // array of pointers to materials
-    double   *matData;               // data for the materials [yloc and area]
-    double   kData[9];               // data for ks matrix
-    double   sData[3];               // data for s vector
+    double   *matData;               // data for the materials [yloc, zloc, area]
+    double   kData[16];               // data for ks matrix
+    double   sData[4];               // data for s vector
 
     double QzBar, QyBar, ABar;
     double yBar;       // Section centroid
     double zBar;
     bool computeCentroid;
     
+    SectionIntegration *sectionIntegr;
+
     static ID code;
 
     Vector e;          // trial section deformations
@@ -114,11 +118,13 @@ class FiberSection3dThermal : public SectionForceDeformation
     Vector *s;         // section resisting forces  (axial force, bending moment)
     Matrix *ks;        // section stiffness
 
+    UniaxialMaterial *theTorsion;
     Vector sT;  // JZ  section resisting forces, caused by the temperature
+    Vector AverageThermalElong;
     //double  *TemperatureTangent; // JZ  the E of E*A*alpha*DeltaT
     double *Fiber_T;  //An array storing the TempT of the fibers.
     double *Fiber_TMax; //An array storing the TempTMax of the fibers.
-    
+
     // AddingSensitivity:BEGIN //////////////////////////////////////////
     int parameterID;
     Matrix *SHVs;

--- a/SRC/material/section/SectionForceDeformation.cpp
+++ b/SRC/material/section/SectionForceDeformation.cpp
@@ -933,6 +933,7 @@ SectionForceDeformation::getTemperatureStress(const Vector &tData) //PK
 
 const Vector& SectionForceDeformation::getThermalElong(void)
 {
-  errRes.resize(this->getStressResultant().Size());
-  return errRes;
+    opserr << "SectionForceDeformation::getThermalElong() - should not be called\n";
+    errRes.resize(this->getStressResultant().Size());
+    return errRes;
 }

--- a/SRC/material/section/TclModelBuilderSectionCommand.cpp
+++ b/SRC/material/section/TclModelBuilderSectionCommand.cpp
@@ -2531,7 +2531,8 @@ int buildSectionThermal(Tcl_Interp *interp, TclModelBuilder *theTclModelBuilder,
 			//SectionForceDeformation *section = new FiberSection(secTag, numFibers, fiber);
 
 			SectionForceDeformation *section = 0;
-			section = new FiberSection3dThermal(secTag, numFibers, fiber, currentSectionComputeCentroid);
+            section = new FiberSection3dThermal(secTag, numFibers, fiber, theTorsion, currentSectionComputeCentroid); // GR
+            // section = new FiberSection3dThermal(secTag, numFibers, fiber, currentSectionComputeCentroid);
 
 			// Delete fibers
 			for (i = 0; i < numFibers; i++)

--- a/SRC/material/uniaxial/SteelECThermal.h
+++ b/SRC/material/uniaxial/SteelECThermal.h
@@ -42,7 +42,7 @@
 class SteelECThermal : public UniaxialMaterial
 {
   public:
-    SteelECThermal(int tag, int typeTag, double fy, double E0, 
+    SteelECThermal(int tag, int typeTag, double fy, double E0, double b,
 		   double a1 = STEEL_01_DEFAULT_A1, double a2 = STEEL_01_DEFAULT_A2,
 		   double a3 = STEEL_01_DEFAULT_A3, double a4 = STEEL_01_DEFAULT_A4);
     SteelECThermal();
@@ -97,7 +97,7 @@ class SteelECThermal : public UniaxialMaterial
     double fyT;
     double E0T;
     double fp; 
-    double TemperautreC;
+    double TemperatureC;
     /////For Temperature-dependent properties///////////////////////////////////end 
     
     

--- a/SRC/modelbuilder/tcl/TclModelBuilder.cpp
+++ b/SRC/modelbuilder/tcl/TclModelBuilder.cpp
@@ -3098,11 +3098,11 @@ TclCommand_addElementalLoad(ClientData clientData, Tcl_Interp *interp, int argc,
 					  return TCL_ERROR;
 				  }
 				  if (Tcl_GetDouble(interp, argv[count + 2], &t5) != TCL_OK) {
-					  opserr << "WARNING eleLoad - invalid T1 " << argv[count] << " for -beamThermal\n";
+					  opserr << "WARNING eleLoad - invalid T5 " << argv[count] << " for -beamThermal\n";
 					  return TCL_ERROR;
 				  }
 				  if (Tcl_GetDouble(interp, argv[count + 3], &locY5) != TCL_OK) {
-					  opserr << "WARNING eleLoad - invalid LocY1 " << argv[count + 1] << " for -beamThermal\n";
+					  opserr << "WARNING eleLoad - invalid LocY5 " << argv[count + 1] << " for -beamThermal\n";
 					  return TCL_ERROR;
 				  }
 
@@ -3140,6 +3140,81 @@ TclCommand_addElementalLoad(ClientData clientData, Tcl_Interp *interp, int argc,
 				  return 0;
 			  }
 			  //end of  if (argc-count == 4){
+			  else if (argc - count == 8) {
+
+				  if (Tcl_GetDouble(interp, argv[count], &t1) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid T1 " << argv[count] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 1], &locY1) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid LocY1 " << argv[count + 1] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 2], &t5) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid T5 " << argv[count] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 3], &locY5) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid LocY5 " << argv[count + 1] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+
+				  if (Tcl_GetDouble(interp, argv[count + 4], &t6) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid T1 " << argv[count] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 5], &locZ1) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid LocZ1 " << argv[count + 1] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 6], &t10) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid T10 " << argv[count] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+				  if (Tcl_GetDouble(interp, argv[count + 7], &locZ5) != TCL_OK) {
+					  opserr << "WARNING eleLoad - invalid LocZ5 " << argv[count + 1] << " for -beamThermal\n";
+					  return TCL_ERROR;
+				  }
+
+				  locY2 = locY1 + (locY5 - locY1) / 4;
+				  locY3 = locY1 + (locY5 - locY1) / 2;
+				  locY4 = locY1 + 3 * (locY5 - locY1) / 4;
+				  t2 = t1 + (t5 - t1) / 4;
+				  t3 = t1 + (t5 - t1) / 2;
+				  t4 = t1 + 3 * (t5 - t1) / 4;
+
+				  locZ2 = locZ1 + (locZ5 - locZ1) / 4;
+				  locZ3 = locZ1 + (locZ5 - locZ1) / 2;
+				  locZ4 = locZ1 + 3 * (locZ5 - locZ1) / 4;
+				  t11 = t6; t15 = t10;
+				  t7 = t6 + (t10 - t6) / 4; t12 = t11 + (t15 - t11) / 4;
+				  t8 = t6 + (t10 - t6) / 2; t13 = t11 + (t15 - t11) / 2;
+				  t9 = t6 + 3*(t10 - t6) / 4; t14 = t11 + 3*(t15 - t11) / 4;
+
+				  for (int i = 0; i < theEleTags.Size(); i++) {
+					  theLoad = new Beam3dThermalAction(eleLoadTag,
+						  t1, locY1, t2, locY2, t3, locY3, t4, locY4,
+						  t5, locY5, t6, t7, locZ1, t8, t9, locZ2, t10, t11, locZ3,
+						  t12, t13, locZ4, t14, t15, locZ5, theEleTags(i));
+					  if (theLoad == 0) {
+						  opserr << "WARNING eleLoad - out of memory creating load of type " << argv[count];
+						  return TCL_ERROR;
+					  }
+					  // get the current pattern tag if no tag given in i/p
+					  int loadPatternTag = theTclLoadPattern->getTag();
+
+					  // add the load to the domain
+					  if (theTclDomain->addElementalLoad(theLoad, loadPatternTag) == false) {
+						  opserr << "WARNING eleLoad - could not add following load to domain:\n ";
+						  opserr << theLoad;
+						  delete theLoad;
+						  return TCL_ERROR;
+					  }
+					  eleLoadTag++;
+				  }
+				  return 0;
+			  }
+			  //end of  if (argc-count == 8){
 			  else {
 				  opserr << "WARNING eleLoad Beam3dThermalAction: invalid number of temperature arguments,/n looking for arguments for Temperatures and coordinates.\n";
 			  }

--- a/Win64/proj/element/element.vcxproj
+++ b/Win64/proj/element/element.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.cpp" />
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3dThermal.cpp" />
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.cpp" />
     <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.cpp" />
@@ -540,6 +541,7 @@
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.h" />
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.h" />
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3dThermal.h" />
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.h" />
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.h" />
     <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.h" />

--- a/Win64/proj/element/element.vcxproj.filters
+++ b/Win64/proj/element/element.vcxproj.filters
@@ -1,1913 +1,596 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{8dc53ba4-a20a-4427-bf11-babe5c15d07e}</UniqueIdentifier>
-      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{4c774e8e-ce1c-4ee6-a77b-796f64208534}</UniqueIdentifier>
-      <Extensions>h;hpp;hxx;hm;inl</Extensions>
-    </Filter>
-    <Filter Include="truss">
-      <UniqueIdentifier>{4d6200e6-10d3-4c65-9db2-8f4a128940f9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="feap">
-      <UniqueIdentifier>{d6824d8c-f5f0-449c-bc5c-4a55c342871e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="zeroLength">
-      <UniqueIdentifier>{c2413ced-fd89-47ec-a53c-7c50d9fbeda0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="crdTransf">
-      <UniqueIdentifier>{db97fed4-cb21-4af2-a581-225349957f04}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="quad">
-      <UniqueIdentifier>{59b81d90-87a0-4a4b-a9c5-18d28dd3042a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="elasticBeamColumn">
-      <UniqueIdentifier>{76b08a0c-6603-44ab-a9ab-0a7d7e6d2a8a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="brick">
-      <UniqueIdentifier>{16f81571-87c3-4448-8bca-9305cf114483}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="dispBeamColumn">
-      <UniqueIdentifier>{8035f8de-4409-40dd-86bf-4a2b940a4a15}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joint">
-      <UniqueIdentifier>{33c5b810-f197-4bf6-b6f1-bb4f417867dd}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ulBeamColumn">
-      <UniqueIdentifier>{3f3077a6-1e37-491e-899e-b5f6fd7b2c41}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="forceBeamColumn">
-      <UniqueIdentifier>{1ef69e6e-4d94-49bc-8bbb-a5cc9134a52b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="forceBeamColumn\beamIntegration">
-      <UniqueIdentifier>{c7b2f79d-b62a-4d66-b614-7ea05cad8aa9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="nonlinearBeamColumn">
-      <UniqueIdentifier>{1611a2ae-725f-481e-ba94-013664af7bb5}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="nonlinearBeamColumn\matrixutil">
-      <UniqueIdentifier>{608c6a97-eb5c-49d8-8b43-f44d9aac6eb3}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="nonlinearBeamColumn\quadrule">
-      <UniqueIdentifier>{dc875f73-4900-4ae7-a177-34d5a3f51385}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="up">
-      <UniqueIdentifier>{34b2aa0b-78b0-4d40-a9c5-459062d2f200}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="dispBeamColumnInt">
-      <UniqueIdentifier>{9fa61ba6-4a0d-419a-9757-c26843b63dbe}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="generic">
-      <UniqueIdentifier>{8835abac-54af-40b7-a9cb-01c1b0c1002d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="twoNodeLink">
-      <UniqueIdentifier>{f7afb4ff-8b91-4c4c-8013-ee37063f770b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="adapter">
-      <UniqueIdentifier>{77b7081d-75e4-4e7b-a201-33ff4cb77c42}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="elastomericBearing">
-      <UniqueIdentifier>{b4905908-3711-4bd7-8ad7-de7f01b668d2}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="frictionBearing">
-      <UniqueIdentifier>{301140e6-b43e-4fa5-a933-9b2ffa1a66a8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="frictionBearing\frictionModel">
-      <UniqueIdentifier>{af576cab-4129-41e3-87a4-e15de1de56c9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="pyMacro">
-      <UniqueIdentifier>{295b84c9-249b-459e-9834-ba15b4e56ead}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="surfaceLoad">
-      <UniqueIdentifier>{c4fc2b62-f666-4933-b1bc-0335ea53fb76}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="UWelements">
-      <UniqueIdentifier>{9717ffed-3174-4878-b385-940a387626a9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="triangle">
-      <UniqueIdentifier>{c1f531f9-4544-47ae-9c69-19ed46dd3e98}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="shell">
-      <UniqueIdentifier>{40ea145c-9bb4-4070-bfd4-f83f708d0c0d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="pfem">
-      <UniqueIdentifier>{00e72745-28b6-47a8-b8e1-04f2a25c02c1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="HUelements">
-      <UniqueIdentifier>{5098eaf3-05b5-4c65-8a81-a2b545b7482b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="XMUelements">
-      <UniqueIdentifier>{24473406-20f3-4a25-9f2b-1e4f17b774a0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="mvlem">
-      <UniqueIdentifier>{192f6adf-59e2-4e68-8259-4093172b605a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="componentElement">
-      <UniqueIdentifier>{3c5b233e-0ad7-418e-bf3b-9ad6e0c6e47c}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="catenaryCable">
-      <UniqueIdentifier>{1da57574-6bdf-44c2-b363-afb3d416e9ad}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="tetrahedron">
-      <UniqueIdentifier>{9ea02351-3bae-4523-b1f6-2a3ea9a7a393}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="absorbentBoundaries">
-      <UniqueIdentifier>{1b806f65-5bd2-4429-9294-d36935d459e3}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="gradientInelasticBeamColumn">
-      <UniqueIdentifier>{516fa8a8-dc2b-4a36-a664-8524314d4ce9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="mixedBeamColumn">
-      <UniqueIdentifier>{a6ea196c-ed72-411c-ad9b-6628b144ecaa}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="PML">
-      <UniqueIdentifier>{177437c1-92ba-4883-b10c-e8a9b85d02ae}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="RockingBC">
-      <UniqueIdentifier>{962a9734-043f-43c1-8e90-1a79eeef085f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="masonry">
-      <UniqueIdentifier>{61bce605-5c0a-4311-b059-28f47dbe6364}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="CEqElement">
-      <UniqueIdentifier>{44a1f5d6-7e75-44f5-a5a5-b79b65801b24}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="IGA">
-      <UniqueIdentifier>{3849edad-2941-4fc1-bec5-ebe8e05b7ba1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="damping">
-      <UniqueIdentifier>{d9c89d0b-b0ee-498a-bc11-9303c8b7338b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="mefi">
-      <UniqueIdentifier>{433d184e-6963-4d36-8e44-f5345a43fc5f}</UniqueIdentifier>
-    </Filter>
+    <ClCompile Include="..\..\..\OTHER\tetgen1.4.3\predicates.cxx" />
+    <ClCompile Include="..\..\..\OTHER\tetgen1.4.3\tetgen.cxx" />
+    <ClCompile Include="..\..\..\OTHER\Triangle\triangle.c" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\Damping.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\SecStifDamping.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\TclDampingCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\UniformDamping.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\URDDamping.cpp" />
+    <ClCompile Include="..\..\..\SRC\damping\URDDampingbeta.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\LysmerTriangle.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidElement2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIInterfaceElement2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidBoundaryElement2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\catenaryCable\CatenaryCable.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\CEqElement\ASDEmbeddedNodeElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\componentElement\ComponentElement2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\componentElement\ComponentElement3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\AxEqDispBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnAsym3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\Element.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\ElementalLoad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\ExternalElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ChebyshevBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedCurvatureBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\EightNodeQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FPBearingPTV.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulumX.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\TclGradientInelasticBeamColumnCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\IGA\IGAKLShell.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\IGA\IGAKLShell_BendingStrip.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\Information.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\Inno3DPnPJoint.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\LehighJoint2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\masonry\BeamGT.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\masonry\MasonPan12.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\masonry\MasonPan3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mefi\MEFI.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumnAsym3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\MVLEM.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\MVLEM_3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BCell.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BeamBrick.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BeamDisk.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BNode.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Flume.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\HigherOrder.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\LineMesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\LineMeshGenerator.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Mesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\MINI.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Particle.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\ParticleGroup.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMContact2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMContact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DFIC.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2Dmini.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DQuasi.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement3DBubble.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\QuadMesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\QuadMeshGenerator.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TaylorHood2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TetMesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TetMeshGenerator.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriangleMeshGenerator.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriGaussPoints.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriMesh.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_3.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_5.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_12.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PML\PML2DVISCOUS.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\RockingBC\RockingBC.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellANDeS.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellDKGQ.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellDKGT.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC4Thermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC9.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGQ.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGQThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGT.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\surfaceLoad\TriSurfaceLoad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\TclElementCommands.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\tetrahedron\FourNodeTetrahedron.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\tetrahedron\TenNodeTetrahedron.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\InertiaTruss.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\N4BiaxialTruss.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\Inerter.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\LinearElasticSpring.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceL.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedEPBeamInterface.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\QuadBeamEmbedContact.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\Tcl_generateInterfacePoints.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\WrapperElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\CorotTruss.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\CorotTruss2.cpp" />
+    <ClCompile Include="..\..\..\Src\element\truss\CorotTrussSection.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\Truss.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\Truss2.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\truss\TrussSection.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\feap\TclFeapElementCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\feap\fElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\feap\fElmt02.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\XMUelements\AC3D8HexWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\XMUelements\ASI3D8QuadWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\XMUelements\AV3D4QuadWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\XMUelements\VS3D4QuadWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\CoupledZeroLength.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\TclZeroLength.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLength.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthVG_HG.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactASDimplex.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactNTS2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthImpact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthInterface2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthND.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthRocking.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthSection.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransf2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransf3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\CrdTransf.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\LinearCrdTransf2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\LinearCrdTransf3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\coordTransformation\TclGeomTransfCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\ConstantPressureVolumeQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\EnhancedQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\BbarBrick.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\BbarBrickWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\Brick.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\TclBrickCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\TclTwenty_Node_BrickCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\Twenty_Node_Brick.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\brick\shp3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dWithSensitivity.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\BeamColumnJoint2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\BeamColumnJoint3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\ElasticTubularJoint.cpp" />
+    <ClCompile Include="..\..\..\Src\element\joint\Joint2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\Joint3D.cpp" />
+    <ClCompile Include="..\..\..\Src\element\joint\MP_Joint2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\MP_Joint3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\TclBeamColumnJointCommand.cpp" />
+    <ClCompile Include="..\..\..\Src\element\joint\TclJoint2dCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\joint\TclJoint3dCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\BilinearCyclic.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\CyclicModel.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Elastic2DGNL.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS01.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS02.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS03.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\InelasticYS2DGNL.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\LinearCyclic.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\QuadraticCyclic.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclCyclicModelCommands.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclElement2dGNL.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclElement2dYS.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\UpdatedLagrangianBeam2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\TclForceBeamColumnCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\BeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\CompositeSimpsonBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\DistHingeIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\FixedLocationBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeEndpointBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeMidpointBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauTwoBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LegendreBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LobattoBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LowOrderBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\MidDistanceBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\NewtonCotesBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\RadauBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\RegularizedHingeIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\TrapezoidalBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedBeamIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedHingeIntegration.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\nonlinearBeamColumn\matrixutil\MatrixUtil.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BBarBrickUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BBarFourNodeQuadUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BrickUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\FourNodeQuadUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\Nine_Four_Node_QuadUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\TclFourNodeQuadUPCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\Twenty_Eight_Node_BrickUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\shp3dv.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\DispBeamColumn2dInt.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dThermal.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\FiberSection2dInt.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\LinearCrdTransf2dInt.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\TclDispBeamColumnIntCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\generic\GenericClient.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\generic\GenericCopy.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLink.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLinkSection.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\adapter\Actuator.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\adapter\ActuatorCorot.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\adapter\Adapter.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingUFRP2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericX.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\HDR.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\LeadRubberX.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\MultiFP2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple3d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing2d.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TPB1D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulum.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\Coulomb.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionModel.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionResponse.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\TclModelBuilderFrictionModelCommand.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDepMultiLinear.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDependent.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelNormalFrcDep.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelPressureDep.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\pyMacro\PY_Macro2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\surfaceLoad\SurfaceLoad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact2Dp.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact3Dp.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamEndContact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamEndContact3Dp.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\Brick8FiberOverlay.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\PileToe3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\Quad4FiberOverlay.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPbrick.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPbrickUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPquad.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPquadUP.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SimpleContact2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\UWelements\SimpleContact3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\triangle\Tri31.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\R3vectors.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC4.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ASDShellQ4.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\shell\ASDShellT3.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DBubble.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DCompressible.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement3D.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TclModelBuilder_addPFEMElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\DBESI0.C" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\DBESI1.C" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\KikuchiBearing.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\MultipleNormalSpring.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\MultipleShearSpring.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\HUelements\YamamotoBiaxialHDR.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\NewElement.cpp" />
+    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3dThermal.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\SRC\element\Element.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\ElementalLoad.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\Information.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\TclElementCommands.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\WrapperElement.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\CorotTruss.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\CorotTruss2.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\Src\element\truss\CorotTrussSection.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\Truss.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\Truss2.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\TrussSection.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\feap\TclFeapElementCommand.cpp">
-      <Filter>feap</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\feap\fElement.cpp">
-      <Filter>feap</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\feap\fElmt02.cpp">
-      <Filter>feap</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\CoupledZeroLength.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\TclZeroLength.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLength.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthVG_HG.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact2D.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact3D.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactASDimplex.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactNTS2D.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthImpact3D.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthInterface2D.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthND.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthRocking.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\zeroLength\ZeroLengthSection.cpp">
-      <Filter>zeroLength</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransf2d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransf3d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\CrdTransf.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\LinearCrdTransf2d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\LinearCrdTransf3d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf2d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf3d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\TclGeomTransfCommand.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\ConstantPressureVolumeQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\EnhancedQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML2D.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML3D.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_3.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_5.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML2D_12.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PML\PML2DVISCOUS.cpp">
-      <Filter>PML</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\TclFourNodeQuadCommand.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam3d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam2d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\BbarBrick.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\BbarBrickWithSensitivity.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\Brick.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\TclBrickCommand.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\TclTwenty_Node_BrickCommand.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\Twenty_Node_Brick.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\brick\shp3d.cpp">
-      <Filter>brick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dWithSensitivity.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dWithSensitivity.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\BeamColumnJoint2d.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\BeamColumnJoint3d.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\ElasticTubularJoint.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\Src\element\joint\Joint2D.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\Joint3D.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\Src\element\joint\MP_Joint2D.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\MP_Joint3D.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\TclBeamColumnJointCommand.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\Src\element\joint\TclJoint2dCommand.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\TclJoint3dCommand.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\BilinearCyclic.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\CyclicModel.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Elastic2DGNL.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS01.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS02.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS03.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\InelasticYS2DGNL.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\LinearCyclic.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\QuadraticCyclic.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclCyclicModelCommands.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclElement2dGNL.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\TclElement2dYS.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\UpdatedLagrangianBeam2D.cpp">
-      <Filter>ulBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn2d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn3d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI2d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\TclForceBeamColumnCommand.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\BeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\CompositeSimpsonBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\DistHingeIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\FixedLocationBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeEndpointBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeMidpointBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauTwoBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LegendreBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LobattoBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\LowOrderBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\MidDistanceBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\NewtonCotesBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\RadauBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\RegularizedHingeIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\TrapezoidalBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedHingeIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\nonlinearBeamColumn\matrixutil\MatrixUtil.cpp">
-      <Filter>nonlinearBeamColumn\matrixutil</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BBarBrickUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BBarFourNodeQuadUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\BrickUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\FourNodeQuadUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\Nine_Four_Node_QuadUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\TclFourNodeQuadUPCommand.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\Twenty_Eight_Node_BrickUP.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UP-ucsd\shp3dv.cpp">
-      <Filter>up</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\DispBeamColumn2dInt.cpp">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\FiberSection2dInt.cpp">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\LinearCrdTransf2dInt.cpp">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumnInt\TclDispBeamColumnIntCommand.cpp">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\generic\GenericClient.cpp">
-      <Filter>generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\generic\GenericCopy.cpp">
-      <Filter>generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLink.cpp">
-      <Filter>twoNodeLink</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLinkSection.cpp">
-      <Filter>twoNodeLink</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\adapter\Actuator.cpp">
-      <Filter>adapter</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\adapter\ActuatorCorot.cpp">
-      <Filter>adapter</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\adapter\Adapter.cpp">
-      <Filter>adapter</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen2d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen3d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity2d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity3d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingUFRP2d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericX.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\HDR.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\LeadRubberX.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple2d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple3d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\MultiFP2d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS2d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS3d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple2d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple3d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing2d.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TPB1D.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulum.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\Coulomb.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionModel.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionResponse.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\TclModelBuilderFrictionModelCommand.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDepMultiLinear.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDependent.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelNormalFrcDep.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelPressureDep.cpp">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\pyMacro\PY_Macro2D.cpp">
-      <Filter>pyMacro</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\surfaceLoad\SurfaceLoad.cpp">
-      <Filter>surfaceLoad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact2D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact2Dp.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact3D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamContact3Dp.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamEndContact3D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\BeamEndContact3Dp.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\Brick8FiberOverlay.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\PileToe3D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\Quad4FiberOverlay.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPbrick.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPbrickUP.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPquad.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SSPquadUP.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SimpleContact2D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\SimpleContact3D.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\triangle\Tri31.cpp">
-      <Filter>triangle</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\R3vectors.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC4.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC9.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ASDShellQ4.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ASDShellT3.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2D.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DBubble.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DCompressible.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement3D.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TclModelBuilder_addPFEMElement.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\DBESI0.C">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\DBESI1.C">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\KikuchiBearing.cpp">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\MultipleNormalSpring.cpp">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\MultipleShearSpring.cpp">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\HUelements\YamamotoBiaxialHDR.cpp">
-      <Filter>HUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\NewElement.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\FPBearingPTV.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\N4BiaxialTruss.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellDKGQ.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGQ.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\XMUelements\AC3D8HexWithSensitivity.cpp">
-      <Filter>XMUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\XMUelements\ASI3D8QuadWithSensitivity.cpp">
-      <Filter>XMUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\XMUelements\AV3D4QuadWithSensitivity.cpp">
-      <Filter>XMUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\XMUelements\VS3D4QuadWithSensitivity.cpp">
-      <Filter>XMUelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\QuadBeamEmbedContact.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\MVLEM.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\MVLEM_3D.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\componentElement\ComponentElement2d.cpp">
-      <Filter>componentElement</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.cpp">
-      <Filter>elastomericBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping2d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\LineMesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriMesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriangleMeshGenerator.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\ParticleGroup.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2Dmini.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Particle.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DFIC.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\OTHER\Triangle\triangle.c">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellDKGT.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGT.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\catenaryCable\CatenaryCable.cpp">
-      <Filter>catenaryCable</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dThermal.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellMITC4Thermal.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellNLDKGQThermal.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\shell\ShellANDeS.cpp">
-      <Filter>shell</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\AxEqDispBeamColumn2d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\surfaceLoad\TriSurfaceLoad.cpp">
-      <Filter>surfaceLoad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\tetrahedron\FourNodeTetrahedron.cpp">
-      <Filter>tetrahedron</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\tetrahedron\TenNodeTetrahedron.cpp">
-      <Filter>tetrahedron</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceL.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceP.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\EmbeddedEPBeamInterface.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\UWelements\Tcl_generateInterfacePoints.cpp">
-      <Filter>UWelements</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\HigherOrder.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\LineMeshGenerator.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Mesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\MINI.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DQuasi.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMElement3DBubble.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\QuadMesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\QuadMeshGenerator.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TaylorHood2D.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TetMesh.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TetMeshGenerator.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\TriGaussPoints.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\OTHER\tetgen1.4.3\predicates.cxx">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\OTHER\tetgen1.4.3\tetgen.cxx">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\LysmerTriangle.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary2D.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary3D.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidElement2D.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIInterfaceElement2D.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidBoundaryElement2D.cpp">
-      <Filter>absorbentBoundaries</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\LinearElasticSpring.cpp">
-      <Filter>twoNodeLink</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\twoNodeLink\Inerter.cpp">
-      <Filter>twoNodeLink</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\ExternalElement.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn2d.cpp">
-      <Filter>gradientInelasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn3d.cpp">
-      <Filter>gradientInelasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\gradientInelasticBeamColumn\TclGradientInelasticBeamColumnCommand.cpp">
-      <Filter>gradientInelasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\LehighJoint2d.cpp">
-      <Filter>joint</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn2d.cpp">
-      <Filter>mixedBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn3d.cpp">
-      <Filter>mixedBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMContact2D.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.cpp">
-      <Filter>forceBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\EightNodeQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\NineNodeQuad.cpp">
-      <Filter>quad</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.cpp">
-      <Filter>triangle</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\RockingBC\RockingBC.cpp">
-      <Filter>RockingBC</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\CEqElement\ASDEmbeddedNodeElement.cpp">
-      <Filter>CEqElement</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping3d.cpp">
-      <Filter>crdTransf</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL3d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BCell.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BNode.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnAsym3d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumnAsym3d.cpp">
-      <Filter>mixedBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\masonry\BeamGT.cpp">
-      <Filter>masonry</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\masonry\MasonPan3D.cpp">
-      <Filter>masonry</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\masonry\MasonPan12.cpp">
-      <Filter>masonry</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ChebyshevBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\truss\InertiaTruss.cpp">
-      <Filter>truss</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\IGA\IGAKLShell.cpp">
-      <Filter>IGA</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\IGA\IGAKLShell_BendingStrip.cpp">
-      <Filter>IGA</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.cpp">
-      <Filter>dispBeamColumn</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\Damping.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\SecStifDamping.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\TclDampingCommand.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\UniformDamping.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\URDDamping.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\damping\URDDampingbeta.cpp">
-      <Filter>damping</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BeamBrick.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\Flume.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\PFEMContact3D.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\componentElement\ComponentElement3d.cpp">
-      <Filter>componentElement</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedCurvatureBeamIntegration.cpp">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\PFEMElement\BeamDisk.cpp">
-      <Filter>pfem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulumX.cpp">
-      <Filter>frictionBearing</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.cpp">
-      <Filter>mvlem</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\joint\Inno3DPnPJoint.cpp">
-      <Filter>joint</Filter>
-     </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\mefi\MEFI.cpp">
-      <Filter>mefi</Filter>
-     </ClCompile>
-    <ClCompile Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.cpp">
-      <Filter>elasticBeamColumn</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\..\SRC\element\Element.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\ElementalLoad.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\Information.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\WrapperElement.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\api\elementAPI.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\CorotTruss.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\CorotTruss2.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\Src\element\truss\CorotTrussSection.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\Truss.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\Truss2.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\TrussSection.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\feap\fElement.h">
-      <Filter>feap</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\feap\fElmt02.h">
-      <Filter>feap</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\CoupledZeroLength.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLength.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact2D.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact3D.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactASDimplex.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactNTS2D.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthImpact3D.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthInterface2D.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthND.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthRocking.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthSection.h">
-      <Filter>zeroLength</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransf2d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransf3d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\CrdTransf.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\LinearCrdTransf2d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\LinearCrdTransf3d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf2d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf3d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\ConstantPressureVolumeQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\EnhancedQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam3d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam2d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\brick\BbarBrick.h">
-      <Filter>brick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\brick\BbarBrickWithSensitivity.h">
-      <Filter>brick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\brick\Brick.h">
-      <Filter>brick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\brick\Twenty_Node_Brick.h">
-      <Filter>brick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\BeamColumnJoint2d.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\BeamColumnJoint3d.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\ElasticTubularJoint.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\Src\element\joint\Joint2D.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\Joint3D.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\Src\element\joint\MP_Joint2D.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\MP_Joint3D.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\BilinearCyclic.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\CyclicModel.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Elastic2DGNL.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS01.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS02.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS03.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\InelasticYS2DGNL.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\LinearCyclic.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\QuadraticCyclic.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\UpdatedLagrangianBeam2D.h">
-      <Filter>ulBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn2d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn3d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI2d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\BeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\CompositeSimpsonBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\DistHingeIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\FixedLocationBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeEndpointBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeMidpointBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauTwoBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LegendreBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LobattoBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LowOrderBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\MidDistanceBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\NewtonCotesBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\RadauBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\RegularizedHingeIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\TrapezoidalBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedHingeIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\nonlinearBeamColumn\matrixutil\MatrixUtil.h">
-      <Filter>nonlinearBeamColumn\matrixutil</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BBarBrickUP.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BBarFourNodeQuadUP.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BrickUP.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\FourNodeQuadUP.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\Nine_Four_Node_QuadUP.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\shp3dv.h">
-      <Filter>up</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\DispBeamColumn2dInt.h">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\FiberSection2dInt.h">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\LinearCrdTransf2dInt.h">
-      <Filter>dispBeamColumnInt</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\generic\GenericClient.h">
-      <Filter>generic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\generic\GenericCopy.h">
-      <Filter>generic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLink.h">
-      <Filter>twoNodeLink</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLinkSection.h">
-      <Filter>twoNodeLink</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\adapter\Actuator.h">
-      <Filter>adapter</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\adapter\ActuatorCorot.h">
-      <Filter>adapter</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\adapter\Adapter.h">
-      <Filter>adapter</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen2d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen3d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity2d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity3d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingUFRP2d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericX.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\HDR.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\LeadRubberX.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple2d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple3d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\MultiFP2d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS2d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS3d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple2d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple3d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing2d.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TPB1D.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulum.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\Coulomb.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionModel.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionResponse.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDepMultiLinear.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDependent.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelNormalFrcDep.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelPressureDep.h">
-      <Filter>frictionBearing\frictionModel</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\pyMacro\PY_Macro2D.h">
-      <Filter>pyMacro</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\surfaceLoad\SurfaceLoad.h">
-      <Filter>surfaceLoad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact2D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact2Dp.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact3D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact3Dp.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamEndContact3D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamEndContact3Dp.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\Brick8FiberOverlay.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\PileToe3D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\Quad4FiberOverlay.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPbrick.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPbrickUP.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPquad.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPquadUP.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SimpleContact2D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\SimpleContact3D.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\triangle\Tri31.h">
-      <Filter>triangle</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\R3vectors.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC4.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC9.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ASDShellQ4.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ASDShellT3.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2D.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DBubble.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DCompressible.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement3D.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TclModelBuilder_addPFEMElement.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\HUelements\KikuchiBearing.h">
-      <Filter>HUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\HUelements\MultipleNormalSpring.h">
-      <Filter>HUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\HUelements\MultipleShearSpring.h">
-      <Filter>HUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\HUelements\YamamotoBiaxialHDR.h">
-      <Filter>HUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\NewElement.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FPBearingPTV.h">
-      <Filter>frictionBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\N4BiaxialTruss.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellDKGQ.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGQ.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\XMUelements\AC3D8HexWithSensitivity.h">
-      <Filter>XMUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\XMUelements\ASI3D8QuadWithSensitivity.h">
-      <Filter>XMUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\XMUelements\AV3D4QuadWithSensitivity.h">
-      <Filter>XMUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\XMUelements\VS3D4QuadWithSensitivity.h">
-      <Filter>XMUelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\QuadBeamEmbedContact.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\MVLEM.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\MVLEM_3D.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\componentElement\ComponentElement2d.h">
-      <Filter>componentElement</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.h">
-      <Filter>elastomericBearing</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping2d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\LineMesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriMesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriangleMeshGenerator.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\ParticleGroup.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2Dmini.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\Particle.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DFIC.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\OTHER\Triangle\triangle.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellDKGT.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGT.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\catenaryCable\CatenaryCable.h">
-      <Filter>catenaryCable</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dThermal.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC4Thermal.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGQThermal.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dWithSensitivity.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dWithSensitivity.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\shell\ShellANDeS.h">
-      <Filter>shell</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\AxEqDispBeamColumn2d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\surfaceLoad\TriSurfaceLoad.h">
-      <Filter>surfaceLoad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\tetrahedron\FourNodeTetrahedron.h">
-      <Filter>tetrahedron</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\tetrahedron\TenNodeTetrahedron.h">
-      <Filter>tetrahedron</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceL.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceP.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedEPBeamInterface.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\UWelements\Tcl_generateInterfacePoints.h">
-      <Filter>UWelements</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\HigherOrder.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\LineMeshGenerator.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\Mesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\MINI.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DQuasi.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement3DBubble.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\QuadMesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\QuadMeshGenerator.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TaylorHood2D.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TetMesh.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TetMeshGenerator.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriGaussPoints.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\OTHER\tetgen1.4.3\tetgen.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\LysmerTriangle.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary2D.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary3D.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidElement2D.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIInterfaceElement2D.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidBoundaryElement2D.h">
-      <Filter>absorbentBoundaries</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\LinearElasticSpring.h">
-      <Filter>twoNodeLink</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\Inerter.h">
-      <Filter>twoNodeLink</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\ExternalElement.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn2d.h">
-      <Filter>gradientInelasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn3d.h">
-      <Filter>gradientInelasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\LehighJoint2d.h">
-      <Filter>joint</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn2d.h">
-      <Filter>mixedBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn3d.h">
-      <Filter>mixedBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMContact2D.h">
-      <Filter>pfem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.h">
-      <Filter>forceBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\EightNodeQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeQuad.h">
-      <Filter>quad</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h">
-      <Filter>triangle</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2D.h">
-      <Filter>PML</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML3D.h">
-      <Filter>PML</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_3.h">
-      <Filter>PML</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_5.h">
-      <Filter>PML</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2DVISCOUS.h">
-      <Filter>PML</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\RockingBC\RockingBC.h">
-      <Filter>RockingBC</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\CEqElement\ASDEmbeddedNodeElement.h">
-      <Filter>CEqElement</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping3d.h">
-      <Filter>crdTransf</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnAsym3d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumnAsym3d.h">
-      <Filter>mixedBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\truss\InertiaTruss.h">
-      <Filter>truss</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\masonry\BeamGT.h">
-      <Filter>masonry</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\masonry\MasonPan3D.h">
-      <Filter>masonry</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\masonry\MasonPan12.h">
-      <Filter>masonry</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\IGA\IGAKLShell.h">
-      <Filter>IGA</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\IGA\IGAKLShell_BendingStrip.h">
-      <Filter>IGA</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.h">
-      <Filter>dispBeamColumn</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedCurvatureBeamIntegration.h">
-      <Filter>forceBeamColumn\beamIntegration</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h">
-      <Filter>mvlem</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_12.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\SRC\element\joint\Inno3DPnPJoint.h">
-      <Filter>joint</Filter>
-     </ClCompile>
-    <ClInclude Include="..\..\..\SRC\element\mefi\MEFI.h">
-      <Filter>mefi</Filter>
-      </ClCompile>
-    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h">
-      <Filter>elasticBeamColumn</Filter>
-    </ClInclude>
+    <ClInclude Include="..\..\..\OTHER\tetgen1.4.3\tetgen.h" />
+    <ClInclude Include="..\..\..\OTHER\Triangle\triangle.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping2d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransfWarping3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\LysmerTriangle.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\ASDAbsorbingBoundary3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidElement2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIInterfaceElement2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\absorbentBoundaries\FSIFluidBoundaryElement2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\catenaryCable\CatenaryCable.h" />
+    <ClInclude Include="..\..\..\SRC\element\CEqElement\ASDEmbeddedNodeElement.h" />
+    <ClInclude Include="..\..\..\SRC\element\componentElement\ComponentElement2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\AxEqDispBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dThermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3dWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnAsym3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnNL2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumnWarping3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\TimoshenkoBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeamWarping3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\WheelRail.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWenMod3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\Element.h" />
+    <ClInclude Include="..\..\..\SRC\element\ElementalLoad.h" />
+    <ClInclude Include="..\..\..\SRC\element\ExternalElement.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedCurvatureBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ConcentratedPlasticityBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumnWarping2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2dThermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnWarping2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\SimpsonBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\EightNodeQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\SixNodeTri.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FPBearingPTV.h" />
+    <ClInclude Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\gradientInelasticBeamColumn\GradientInelasticBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\IGA\IGAKLShell.h" />
+    <ClInclude Include="..\..\..\SRC\element\IGA\IGAKLShell_BendingStrip.h" />
+    <ClInclude Include="..\..\..\SRC\element\Information.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\Inno3DPnPJoint.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\LehighJoint2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\masonry\BeamGT.h" />
+    <ClInclude Include="..\..\..\SRC\element\masonry\MasonPan12.h" />
+    <ClInclude Include="..\..\..\SRC\element\masonry\MasonPan3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\mefi\MEFI.h" />
+    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\mixedBeamColumn\MixedBeamColumnAsym3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\E_SFI_MVLEM_3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\MVLEM.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\MVLEM_3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\mvlem\SFI_MVLEM_3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundDef.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\BackgroundMesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\HigherOrder.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\LineMesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\LineMeshGenerator.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\Mesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\MINI.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\Particle.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\ParticleGroup.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMContact2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DFIC.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2Dmini.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DQuasi.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement3DBubble.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\QuadMesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\QuadMeshGenerator.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TaylorHood2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TetMesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TetMeshGenerator.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriangleMeshGenerator.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriGaussPoints.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TriMesh.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_3.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_5.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2D_12.h" />
+    <ClInclude Include="..\..\..\SRC\element\PML\PML2DVISCOUS.h" />
+    <ClInclude Include="..\..\..\SRC\element\RockingBC\RockingBC.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellANDeS.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellDKGQ.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellDKGT.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC4Thermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC9.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGQ.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGQThermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellNLDKGT.h" />
+    <ClInclude Include="..\..\..\SRC\element\surfaceLoad\TriSurfaceLoad.h" />
+    <ClInclude Include="..\..\..\SRC\element\tetrahedron\FourNodeTetrahedron.h" />
+    <ClInclude Include="..\..\..\SRC\element\tetrahedron\TenNodeTetrahedron.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\InertiaTruss.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\N4BiaxialTruss.h" />
+    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\Inerter.h" />
+    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\LinearElasticSpring.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceL.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedBeamInterfaceP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\EmbeddedEPBeamInterface.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\QuadBeamEmbedContact.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\Tcl_generateInterfacePoints.h" />
+    <ClInclude Include="..\..\..\SRC\element\WrapperElement.h" />
+    <ClInclude Include="..\..\..\SRC\api\elementAPI.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\CorotTruss.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\CorotTruss2.h" />
+    <ClInclude Include="..\..\..\Src\element\truss\CorotTrussSection.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\Truss.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\Truss2.h" />
+    <ClInclude Include="..\..\..\SRC\element\truss\TrussSection.h" />
+    <ClInclude Include="..\..\..\SRC\element\feap\fElement.h" />
+    <ClInclude Include="..\..\..\SRC\element\feap\fElmt02.h" />
+    <ClInclude Include="..\..\..\SRC\element\XMUelements\AC3D8HexWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\XMUelements\ASI3D8QuadWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\XMUelements\AV3D4QuadWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\XMUelements\VS3D4QuadWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\CoupledZeroLength.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLength.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContact3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactASDimplex.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthContactNTS2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthImpact3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthInterface2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthND.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthRocking.h" />
+    <ClInclude Include="..\..\..\SRC\element\zeroLength\ZeroLengthSection.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransf2d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\CorotCrdTransf3d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\CrdTransf.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\LinearCrdTransf2d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\LinearCrdTransf3d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf2d.h" />
+    <ClInclude Include="..\..\..\SRC\coordTransformation\PDeltaCrdTransf3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\ConstantPressureVolumeQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\EnhancedQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuad3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\FourNodeQuadWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\fourNodeQuad\NineNodeMixedQuad.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticBeam3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ElasticTimoshenkoBeam3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elasticBeamColumn\ModElasticBeam2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\brick\BbarBrick.h" />
+    <ClInclude Include="..\..\..\SRC\element\brick\BbarBrickWithSensitivity.h" />
+    <ClInclude Include="..\..\..\SRC\element\brick\Brick.h" />
+    <ClInclude Include="..\..\..\SRC\element\brick\Twenty_Node_Brick.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\BeamColumnJoint2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\BeamColumnJoint3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\ElasticTubularJoint.h" />
+    <ClInclude Include="..\..\..\Src\element\joint\Joint2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\Joint3D.h" />
+    <ClInclude Include="..\..\..\Src\element\joint\MP_Joint2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\joint\MP_Joint3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\BilinearCyclic.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\CyclicModel.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Elastic2DGNL.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS01.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS02.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\Inelastic2DYS03.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\InelasticYS2DGNL.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\LinearCyclic.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\QuadraticCyclic.h" />
+    <ClInclude Include="..\..\..\SRC\element\updatedLagrangianBeamColumn\UpdatedLagrangianBeam2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ElasticForceBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumnCBDI2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\BeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\CompositeSimpsonBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\DistHingeIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\FixedLocationBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeEndpointBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeMidpointBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\HingeRadauTwoBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LegendreBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LobattoBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\LowOrderBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\MidDistanceBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\NewtonCotesBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\RadauBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\RegularizedHingeIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\TrapezoidalBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedBeamIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\UserDefinedHingeIntegration.h" />
+    <ClInclude Include="..\..\..\SRC\element\nonlinearBeamColumn\matrixutil\MatrixUtil.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BBarBrickUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BBarFourNodeQuadUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\BrickUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\FourNodeQuadUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\Nine_Four_Node_QuadUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UP-ucsd\shp3dv.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\DispBeamColumn2dInt.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumn\DispBeamColumn2dThermal.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\FiberSection2dInt.h" />
+    <ClInclude Include="..\..\..\SRC\element\dispBeamColumnInt\LinearCrdTransf2dInt.h" />
+    <ClInclude Include="..\..\..\SRC\element\generic\GenericClient.h" />
+    <ClInclude Include="..\..\..\SRC\element\generic\GenericCopy.h" />
+    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLink.h" />
+    <ClInclude Include="..\..\..\SRC\element\twoNodeLink\TwoNodeLinkSection.h" />
+    <ClInclude Include="..\..\..\SRC\element\adapter\Actuator.h" />
+    <ClInclude Include="..\..\..\SRC\element\adapter\ActuatorCorot.h" />
+    <ClInclude Include="..\..\..\SRC\element\adapter\Adapter.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingBoucWen3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingPlasticity3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericBearingUFRP2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\ElastomericX.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\HDR.h" />
+    <ClInclude Include="..\..\..\SRC\element\elastomericBearing\LeadRubberX.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\FlatSliderSimple3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\MultiFP2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\RJWatsonEQS3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\SingleFPSimple3d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TFP_Bearing2d.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TPB1D.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\TripleFrictionPendulum.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\Coulomb.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionModel.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\FrictionResponse.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDepMultiLinear.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelDependent.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelNormalFrcDep.h" />
+    <ClInclude Include="..\..\..\SRC\element\frictionBearing\frictionModel\VelPressureDep.h" />
+    <ClInclude Include="..\..\..\SRC\element\pyMacro\PY_Macro2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\surfaceLoad\SurfaceLoad.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact2Dp.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamContact3Dp.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamEndContact3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\BeamEndContact3Dp.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\Brick8FiberOverlay.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\PileToe3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\Quad4FiberOverlay.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPbrick.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPbrickUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPquad.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SSPquadUP.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SimpleContact2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\UWelements\SimpleContact3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\triangle\Tri31.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\R3vectors.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ShellMITC4.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ASDShellQ4.h" />
+    <ClInclude Include="..\..\..\SRC\element\shell\ASDShellT3.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DBubble.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement2DCompressible.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\PFEMElement3D.h" />
+    <ClInclude Include="..\..\..\SRC\element\PFEMElement\TclModelBuilder_addPFEMElement.h" />
+    <ClInclude Include="..\..\..\SRC\element\HUelements\KikuchiBearing.h" />
+    <ClInclude Include="..\..\..\SRC\element\HUelements\MultipleNormalSpring.h" />
+    <ClInclude Include="..\..\..\SRC\element\HUelements\MultipleShearSpring.h" />
+    <ClInclude Include="..\..\..\SRC\element\HUelements\YamamotoBiaxialHDR.h" />
+    <ClInclude Include="..\..\..\SRC\element\NewElement.h" />
+    <ClInclude Include="..\..\..\SRC\element\forceBeamColumn\ForceBeamColumn3dThermal.h" />
   </ItemGroup>
 </Project>

--- a/Win64/proj/openSees/OpenSees.vcxproj
+++ b/Win64/proj/openSees/OpenSees.vcxproj
@@ -109,7 +109,7 @@
       <AdditionalDependencies>actor.lib;analysis.lib;arpack.lib;blas.lib;cblas.lib;convergence.lib;cssparse.lib;damage.lib;database.lib;DoddRestrepo.lib;domain.lib;drain.lib;element.lib;feap.lib;fedeas.lib;glu32.lib;graph.lib;handler.lib;ifconsol.lib;lapack.lib;libifcoremt.lib;libmmt.lib;material.lib;matrix.lib;modelbuilder.lib;opengl32.lib;optimization.lib;PML.lib;recorder.lib;reliability.lib;renderer.lib;sdmuc.lib;superLU.lib;system.lib;tagged.lib;tcl.lib;tcl86t.lib;tk86t.lib;umfpackC.lib;utility.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)OpenSees.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\compiler\lib\intel64_win;c:\Program Files\tcl\lib;..\..\lib;..\..\lib\release;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\compiler\lib\intel64_win</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\compiler\lib\intel64_win;c:\Program Files\tcl\lib;..\..\lib;..\..\lib\release;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ProgramDatabaseFile>$(IntDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -155,7 +155,7 @@
       <AdditionalDependencies>actor.lib;analysis.lib;arpack.lib;blas.lib;cblas.lib;convergence.lib;cssparse.lib;damage.lib;database.lib;DoddRestrepo.lib;domain.lib;drain.lib;element.lib;feap.lib;fedeas.lib;glu32.lib;graph.lib;handler.lib;ifconsol.lib;lapack.lib;libifcoremt.lib;libmmt.lib;material.lib;matrix.lib;modelbuilder.lib;opengl32.lib;optimization.lib;PML.lib;recorder.lib;reliability.lib;renderer.lib;sdmuc.lib;superLU.lib;system.lib;tagged.lib;tcl.lib;tcl86t.lib;tk86t.lib;umfpackC.lib;utility.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\..\..\bin\OpenSees.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\release;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\compiler\lib\intel64_win</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\release;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ProgramDatabaseFile>.\..\..\bin\OpenSees.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -197,7 +197,7 @@
       <AdditionalDependencies>actor.lib;analysis.lib;arpack.lib;blas.lib;cblas.lib;convergence.lib;cssparse.lib;damage.lib;database.lib;DoddRestrepo.lib;domain.lib;drain.lib;element.lib;feap.lib;fedeas.lib;glu32.lib;graph.lib;handler.lib;ifconsol.lib;lapack.lib;libifcoremt.lib;libmmt.lib;material.lib;matrix.lib;modelbuilder.lib;opengl32.lib;optimization.lib;PML.lib;recorder.lib;reliability.lib;renderer.lib;sdmuc.lib;superLU.lib;system.lib;tagged.lib;tcl.lib;tcl86t.lib;tk86t.lib;umfpackC.lib;utility.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)OpenSees.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\debug;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\compiler\lib\intel64_win</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\debug;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib\intel64_win</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
@@ -241,7 +241,7 @@
       <AdditionalDependencies>actor.lib;analysis.lib;arpack.lib;blas.lib;cblas.lib;convergence.lib;cssparse.lib;damage.lib;database.lib;DoddRestrepo.lib;domain.lib;drain.lib;element.lib;feap.lib;fedeas.lib;glu32.lib;graph.lib;handler.lib;ifconsol.lib;lapack.lib;libifcoremt.lib;libmmt.lib;material.lib;matrix.lib;modelbuilder.lib;opengl32.lib;optimization.lib;PML.lib;recorder.lib;reliability.lib;renderer.lib;sdmuc.lib;superLU.lib;system.lib;tagged.lib;tcl.lib;tcl86t.lib;tk86t.lib;umfpackC.lib;utility.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\..\..\bin\OpenSees.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\debug;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\compiler\lib\intel64_win</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>c:\Program Files\tcl\lib;..\..\lib;..\..\lib\debug;%(AdditionalLibraryDirectories);C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>.\..\..\bin\OpenSees.pdb</ProgramDatabaseFile>


### PR DESCRIPTION
In this PR:
- new `ForceBeamColumn3dThermal` has been added, with the same loading handling as in dispBeamColumn3dThermal
- added support for torsion in `FiberSection3dThermal`
- new shortened command for temperature in elements to include also z-axis temperatura gradient with the syntax 
`eleLoad -range 1 10 -type -beamThermal Ty1 y1 Ty2 y2 <Tz1 z1 Tz2 z2>`
in which **Tz1 z1 Tz2 z2** is the added (optional) part
- support for hardening in `SteelECThermal` avoinding to use the hardcoded one; new syntax is `uniaxialMaterial SteelECThermal $matTag <$steelType> $Fy $E0 $b`
- several typos corrected and warning message added to `SectionForceDeformation`.

In revision, please refer to issue #1468. Tests have been conducted on new and corrected code.

In addition, the path of Fortran libraries (like `ifconsol.lib`) has been corrected in OpenSees.vcxproj for OneAPI support, by mantaining the latest version installed on the system.