### PR TITLE
[FIX] PVD eleResponse behavior, JSON print flag

### DIFF
--- a/SRC/material/nD/J2PlateFibre.cpp
+++ b/SRC/material/nD/J2PlateFibre.cpp
@@ -887,16 +887,27 @@ J2PlateFibre::recvSelf (int commitTag, Channel &theChannel,
 }
 
 void
-J2PlateFibre::Print (OPS_Stream &s, int flag)
+J2PlateFibre::Print(OPS_Stream &s, int flag)
 {
-  s << "J2 Plate Fibre Material Model" << endln;
-  s << "\tE:  " << E << endln;
-  s << "\tnu:  " << nu << endln;
-  s << "\tsigmaY:  " << sigmaY << endln;
-  s << "\tHiso:  " << Hiso << endln;
-  s << "\tHkin:  " << Hkin << endln;
-  
-  return;
+    if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+        s << "J2 Plate Fibre Material Model" << endln;
+        s << "\tE:  " << E << endln;
+        s << "\tnu:  " << nu << endln;
+        s << "\tsigmaY:  " << sigmaY << endln;
+        s << "\tHiso:  " << Hiso << endln;
+        s << "\tHkin:  " << Hkin << endln;
+    }
+
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+        s << "\t\t\t{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"J2PlateFibre\", ";
+        s << "\"E\": " << E << ", ";
+        s << "\"nu\": " << nu << ", ";
+        s << "\"fy\": " << sigmaY << ", ";
+        s << "\"Hiso\": " << Hiso << ", ";
+        s << "\"Hkin\": " << Hkin << "}";
+    }
 }
 
 int

--- a/SRC/material/section/MembranePlateFiberSection.cpp
+++ b/SRC/material/section/MembranePlateFiberSection.cpp
@@ -512,14 +512,32 @@ const Matrix&  MembranePlateFiberSection::getSectionTangent( )
 //print out data
 void  MembranePlateFiberSection::Print( OPS_Stream &s, int flag )
 {
-  s << "MembranePlateFiberSection: \n " ;
-  s <<  "  Thickness h = "        <<  h  <<  endln ;
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+        s << "\t\t\t{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"PlateFiber\", ";
+        s << "\"thickness\": \"" << h << "\", ";
+        s << "\"fibers\": [\n";
+        for (int i = 0; i < numFibers; i++) {
+            s << "\t\t\t\t{\"centroid\": " << (i+0.5) * h / numFibers << ", ";
+            s << "\"material\": \"" << theFibers[i]->getTag() << "\"";
+            if (i < numFibers - 1)
+                s << "},\n";
+            else
+                s << "}\n";
+        }
+        s << "\t\t\t]}";
+    }
+    else {
+        s << "MembranePlateFiberSection: \n ";
+        s << "  Thickness h = " << h << endln;
 
-  for (int i = 0; i < numFibers; i++) {
-    theFibers[i]->Print( s, flag ) ;
-  }
+        for (int i = 0; i < numFibers; i++) {
+            theFibers[i]->Print(s, flag);
+        }
 
-  return ;
+        return;
+    }
 }
 
 int 

--- a/SRC/recorder/PVDRecorder.cpp
+++ b/SRC/recorder/PVDRecorder.cpp
@@ -111,10 +111,9 @@ void* OPS_PVDRecorder()
 	    }
 	    PVDRecorder::EleData edata;
 	    numdata = OPS_GetNumRemainingInputArgs();
-	    edata.resize(numdata);
-	    for(int i=0; i<numdata; i++) {
-		edata[i] = OPS_GetString();
-	    }
+	    edata.resize(1);
+	    edata[0] = OPS_GetString();
+	    // opserr << "WARNING - EDATA[i]="<< edata[0].c_str() << "\n";
 	    eledata.push_back(edata);
 	} else if(strcmp(type, "-dT") == 0) {
 	    numdata = OPS_GetNumRemainingInputArgs();


### PR DESCRIPTION
[FIX]

- Update PVD recorder behavior to allow multiple 'eleResponse' inputs. Previous implementation only allowed a single response to be output, and would concatenate the additional requests but not output them. This implementation searches for a single response after the 'eleResponse' string is found. The usage would be ` [..., 'eleResponse', 'forces', 'eleResponse', 'stresses'] `
- Added JSON flags and logic to the J2PlateFibre material and MembranePlateFiberSection `Print` methods to properly print to JSON format.