### PR TITLE
Fixed bug in time used for applied load in KRAlphaExplicit.cpp

### DIFF
--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -241,7 +241,7 @@ int KRAlphaExplicit::newStep(double _deltaT)
     
     Udot->addVector(1.0, *Utdothat, 1.0);
     
-    // determine the response at t+alpha*deltaT
+    // determine the response at t+(1-alpha)*deltaT
     Ualpha->addVector(0.0, *Ut, (1.0-alphaF));
     Ualpha->addVector(1.0, *U, alphaF);
     
@@ -253,9 +253,9 @@ int KRAlphaExplicit::newStep(double _deltaT)
     // set the trial response quantities
     theModel->setResponse(*Ualpha, *Ualphadot, *Ualphadotdot);
     
-    // increment the time to t+alpha*deltaT and apply the load
+    // increment the time to t+(1-alpha)*deltaT and apply the load
     double time = theModel->getCurrentDomainTime();
-    time += alphaF*deltaT;
+    time += (1-alphaF)*deltaT;
     if (theModel->updateDomain(time, deltaT) < 0)  {
         opserr << "WARNING KRAlphaExplicit::newStep() - failed to update the domain\n";
         return -7;

--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -255,7 +255,7 @@ int KRAlphaExplicit::newStep(double _deltaT)
     
     // increment the time to t+(1-alpha)*deltaT and apply the load
     double time = theModel->getCurrentDomainTime();
-    time += (1-alphaF)*deltaT;
+    time += (1.0-alphaF)*deltaT;
     if (theModel->updateDomain(time, deltaT) < 0)  {
         opserr << "WARNING KRAlphaExplicit::newStep() - failed to update the domain\n";
         return -7;


### PR DESCRIPTION
In the original paper, the applied force $F_{i + 1 - \alpha_f}$ (as defined in Equation 24 in the image below) should be computed at the time $t_{i + 1 - \alpha_f} = t_i + (1 - \alpha_f) \Delta t$. However, the current implementation of `KRAlphaExplicit::newStep()` computes the force at $t = t_i + \alpha_f \Delta t$, leading to an inconsistency in the unbalance vector. Although I have not personally tested the impact of this discrepancy, I have corrected the issue in this pull request.

![image](https://github.com/user-attachments/assets/f6b284a8-e848-43cf-9787-94be23b93729)
