### PR TITLE
Build fixes

### DIFF
--- a/OTHER/METIS/minitpart.c
+++ b/OTHER/METIS/minitpart.c
@@ -14,7 +14,7 @@
  */
 
 #include <metis.h>
-
+int SelectQueueOneWay(int ncon, float *npwgts, float *tpwgts, int from, PQueueType queues[MAXNCON][2]);
 /*************************************************************************
 * This function computes the initial bisection of the coarsest graph
 **************************************************************************/

--- a/OTHER/SuperLU_5.1.1/SRC/dutil.c
+++ b/OTHER/SuperLU_5.1.1/SRC/dutil.c
@@ -460,7 +460,7 @@ dPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_double_vec(char *what, int n, double *vec)
 {
     int i;


### PR DESCRIPTION
Fix for issue  #1458. Compile time errors resulting from stricter adherence to ISO C standard (1999 rev) by gcc14. For details, see "Porting to GCC 14"