### PR TITLE
Fixing bug in KRAlphaExplicit_TP and minor modification to KRAlphaExplicit

### DIFF
--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -219,6 +219,9 @@ int KRAlphaExplicit::newStep(double _deltaT)
         // switch the SOE back to the user specified one
         this->IncrementalIntegrator::setLinks(*theModel, *theLinSOE, theTest);
         
+        // formTangent only when initAlphaMatrices is set to true
+        this->KRAlphaExplicit::formTangent(INITIAL_TANGENT);
+        // set flag that initializations are done
         initAlphaMatrices = 0;
     }
     
@@ -282,27 +285,29 @@ int KRAlphaExplicit::formTangent(int statFlag)
 {
     statusFlag = statFlag;
     
-    LinearSOE *theLinSOE = this->getLinearSOE();
-    AnalysisModel *theModel = this->getAnalysisModel();
-    if (theLinSOE == 0 || theModel == 0)  {
-        opserr << "WARNING KRAlphaExplicit::formTangent() - ";
-        opserr << "no LinearSOE or AnalysisModel has been set\n";
-        return -1;
+    // only update tangent if domain has changed
+    if (initAlphaMatrices) {
+        LinearSOE *theLinSOE = this->getLinearSOE();
+        AnalysisModel *theModel = this->getAnalysisModel();
+        if (theLinSOE == 0 || theModel == 0)  {
+            opserr << "WARNING KRAlphaExplicit::formTangent() - ";
+            opserr << "no LinearSOE or AnalysisModel has been set\n";
+            return -1;
+        }
+        
+        theLinSOE->zeroA();
+        
+        int size = theLinSOE->getNumEqn();
+        ID id(size);
+        for (int i=1; i<size; i++)  {
+            id(i) = id(i-1) + 1;
+        }
+        if (theLinSOE->addA(*Mhat, id) < 0)  {
+            opserr << "WARNING KRAlphaExplicit::formTangent() - ";
+            opserr << "failed to add Mhat to A\n";
+            return -2;
+        }
     }
-    
-    theLinSOE->zeroA();
-    
-    int size = theLinSOE->getNumEqn();
-    ID id(size);
-    for (int i=1; i<size; i++)  {
-        id(i) = id(i-1) + 1;
-    }
-    if (theLinSOE->addA(*Mhat, id) < 0)  {
-        opserr << "WARNING KRAlphaExplicit::formTangent() - ";
-        opserr << "failed to add Mhat to A\n";
-        return -2;
-    }
-    
     return 0;
 }
 
@@ -615,4 +620,22 @@ void KRAlphaExplicit::Print(OPS_Stream &s, int flag)
             s << "  updateElemDisp: no\n";
     } else
         s << "KRAlphaExplicit - no associated AnalysisModel\n";
+}
+
+int KRAlphaExplicit::revertToStart()
+{
+    if (Ut != 0) 
+        Ut->Zero();
+    if (Utdot != 0) 
+        Utdot->Zero();
+    if (Utdotdot != 0) 
+        Utdotdot->Zero();
+    if (U != 0) 
+        U->Zero();
+    if (Udot != 0) 
+        Udot->Zero();
+    if (Udotdot != 0) 
+        Udotdot->Zero();
+    
+    return 0;
 }

--- a/SRC/analysis/integrator/KRAlphaExplicit.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit.h
@@ -37,7 +37,7 @@
 // Reference: Kolay, C. and J. Ricles (2014). "Development of a family of
 // unconditionally stable explicit direct integration algorithms with
 // controllable numerical energy dissipation." Earthquake Engineering and
-// Structural Dynamics, 43(9):1361�1380.
+// Structural Dynamics, 43(9):1361-1380.
 
 #include <TransientIntegrator.h>
 

--- a/SRC/analysis/integrator/KRAlphaExplicit.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit.h
@@ -37,7 +37,7 @@
 // Reference: Kolay, C. and J. Ricles (2014). "Development of a family of
 // unconditionally stable explicit direct integration algorithms with
 // controllable numerical energy dissipation." Earthquake Engineering and
-// Structural Dynamics, 43(9):1361–1380.
+// Structural Dynamics, 43(9):1361ï¿½1380.
 
 #include <TransientIntegrator.h>
 
@@ -78,7 +78,8 @@ public:
     virtual int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
     
     void Print(OPS_Stream &s, int flag = 0);
-    
+    int revertToStart();
+
 protected:
     
 private:

--- a/SRC/analysis/integrator/KRAlphaExplicit.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit.h
@@ -72,6 +72,9 @@ public:
     int update(const Vector &aiPlusOne);
     int commit(void);
 
+    // modalDamping
+    double getCFactor(void) {return c2;}
+
     const Vector &getVel(void);
     
     virtual int sendSelf(int commitTag, Channel &theChannel);

--- a/SRC/analysis/integrator/KRAlphaExplicit_TP.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit_TP.h
@@ -37,7 +37,7 @@
 // Reference: Kolay, C. and J. Ricles (2014). "Development of a family of
 // unconditionally stable explicit direct integration algorithms with
 // controllable numerical energy dissipation." Earthquake Engineering and
-// Structural Dynamics, 43(9):1361�1380.
+// Structural Dynamics, 43(9):1361-1380.
 
 #include <TransientIntegrator.h>
 

--- a/SRC/analysis/integrator/KRAlphaExplicit_TP.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit_TP.h
@@ -74,6 +74,9 @@ public:
     int update(const Vector &aiPlusOne);
     int commit(void);
 
+    // modalDamping
+    double getCFactor(void) {return c2;}
+
     const Vector &getVel(void);
     
     virtual int sendSelf(int commitTag, Channel &theChannel);

--- a/SRC/analysis/integrator/KRAlphaExplicit_TP.h
+++ b/SRC/analysis/integrator/KRAlphaExplicit_TP.h
@@ -37,7 +37,7 @@
 // Reference: Kolay, C. and J. Ricles (2014). "Development of a family of
 // unconditionally stable explicit direct integration algorithms with
 // controllable numerical energy dissipation." Earthquake Engineering and
-// Structural Dynamics, 43(9):1361–1380.
+// Structural Dynamics, 43(9):1361ï¿½1380.
 
 #include <TransientIntegrator.h>
 
@@ -80,7 +80,8 @@ public:
     virtual int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
     
     void Print(OPS_Stream &s, int flag = 0);
-    
+    int revertToStart();
+
 protected:
     
 private:


### PR DESCRIPTION
This pull request addresses the issues discussed in #1505, particularly with the computation of the unbalance vector in `KRAlphaExplicit_TP`.

To contextualize, the linear system of equations for KRAlpha looks like this:

$$M(I - \alpha_3) \ddot U_{t+\Delta t} =F_{t + \alpha_f \Delta t} - C \dot U_{t + \alpha_f \Delta t} - R( U_{t + \alpha_f \Delta t}) - M \alpha_3 \ddot U_t$$

where $x_{t + \alpha_f \Delta t}$ may be estimated using a trapezoidal or midpoint rule. `KRAlphaExplicit_TP` is the trapezoidal version, where 
$$x_{t + \alpha_f \Delta t} = (1 - \alpha_f) x_t + (1 - \alpha_f) x_{t + \Delta t}$$.

The implementation of `KRAlphaExplicit_TP` had the following issues:
- (a) `Ut` and `Utdot` were not initialized correctly, causing a delay in the response.
- (b) The modal damping forces in the unbalance vector were not multiplied by `alphaD` like Rayleigh damping forces.
- (c) `theModel->updateDomain(time, deltaT)` must be called before invoking this->TransientIntegrator::formUnbalance() at the moment of computing `Put`.

To fix these issues, I followed the steps below to assemble the right-hand side (weighted unbalance) vector:

1. Compute the unbalance at time t `Put` without multiplying by `(1.0 - alphaF)` with acceleration set to zero.
2. Update `U`, `Udot`, and `Udotdot` (predictor) for the next step. Ensure the domain is updated, including advancing the time to `t + deltaT`. `Udotdot` here is initially set to `alpha3` * `Utdotdot` / `alphaF`
3. Compute the unbalance at `time t + deltaT`.
4. Set the weighted unbalance vector as:
`weightedUnbalance = (1.0 - alphaF) * (unbalance at time t) + alphaF * (unbalance at time t + deltaT)`.

I also implemented `revertToStart()` and modified `KRAlphaExplicit::formTangent()` to only form the tangent if the domain has changed, since $M(I - \alpha_3)$ is constant in that case.

The response for an undamped SDOF system with initial displacement and initial velocity now looks like this (with $\rho_{\infty} = 1.0$):

| ![image](https://github.com/user-attachments/assets/9bf59fa0-776a-4f37-87ff-9a89ab82e916) | ![image](https://github.com/user-attachments/assets/e13d6174-0540-4ab8-bcfb-47d55f36f242) |
|:--------------------------------------------:|:--------------------------------------------:|
| Figure 1 Initial displacement | Figure 2 initial velocity                       |

In addition, I tested `KRAlphaExplicit_TP` with a nonlinear frame model as described in Kolay and Ricles (2016).

| ![Two-story MRF model.](https://github.com/user-attachments/assets/d548d34e-c2a2-49ca-83bf-2dd6540101b1) |
|:--------------------------------------------------------------------------:|
| **Figure 3**: Original two-story MRF model used by Kolay and Ricles (2016).|


Kolay, C., & Ricles, J. M. (2016). Assessment of explicit and semi-explicit classes of model-based algorithms for direct integration in structural dynamics. International Journal for Numerical Methods in Engineering, 107(1), 49–73. https://doi.org/10.1002/nme.5153

In tests with $\rho_{\infty} < 1$, the response matches well with Newmark's method. However, `KRAlphaExplicit_TP` still exhibits instability for $\rho_{\infty} = 1$, while `KRAlphaExplicit` does not. This could be due to the trapezoidal rule being unstable, but let me know if you think it's a bug.

| ![image](https://github.com/user-attachments/assets/35cf5a86-4b87-446a-8f04-c2d0289917cb) | ![image](https://github.com/user-attachments/assets/3d4cd47e-04f5-4e67-88ff-137a4dd3be0a) |
|:--------------------------------------------:|:--------------------------------------------:|
| Figure 4 `KRAlphaExplicit` | Figure 5 `KRAlphaExplicit_TP`                     |