### PR TITLE
attempt to fix bug in duplicated loads added to `dispBeamColumnThermal` (2D version only)

### DIFF
--- a/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.cpp
+++ b/SRC/element/dispBeamColumn/DispBeamColumn2dThermal.cpp
@@ -815,9 +815,9 @@ DispBeamColumn2dThermal::addLoad(ElementalLoad *theLoad, double loadFactor)
 
     }
     
-    q0[0] -= q0Temperature[0];
-    q0[1] -= q0Temperature[1];
-    q0[2] -= q0Temperature[2];
+    // q0[0] -= q0Temperature[0];
+    // q0[1] -= q0Temperature[1];
+    // q0[2] -= q0Temperature[2];
 
   }
   else if(type == LOAD_TAG_NodalThermalAction) {
@@ -902,9 +902,9 @@ DispBeamColumn2dThermal::addLoad(ElementalLoad *theLoad, double loadFactor)
 	  }
     }
     
-    q0[0] -= q0Temperature[0];
-    q0[1] -= q0Temperature[1];
-    q0[2] -= q0Temperature[2];
+    // q0[0] -= q0Temperature[0];
+    // q0[1] -= q0Temperature[1];
+    // q0[2] -= q0Temperature[2];
 }
 //----------------------------------------------
   else if(type == LOAD_TAG_ThermalActionWrapper) {
@@ -979,9 +979,9 @@ DispBeamColumn2dThermal::addLoad(ElementalLoad *theLoad, double loadFactor)
     }
 	//end of for loop
     
-    q0[0] -= q0Temperature[0];
-    q0[1] -= q0Temperature[1];
-    q0[2] -= q0Temperature[2];
+    // q0[0] -= q0Temperature[0];
+    // q0[1] -= q0Temperature[1];
+    // q0[2] -= q0Temperature[2];
 }
  //----------------------------------------
 else {
@@ -1096,9 +1096,9 @@ DispBeamColumn2dThermal::addLoad(ElementalLoad *theLoad, const Vector &factors)
       }   
     }
     
-    q0[0] -= 0;
-    q0[1] -= 0;
-    q0[2] -= 0;
+    // q0[0] -= 0;
+    // q0[1] -= 0;
+    // q0[2] -= 0;
 	
   }  
   else {


### PR DESCRIPTION
## Overview
This pull request attempts to address an issue in the implementation of `dispBeamColumnThermal` previously raised by @mhscott in his [blog post](https://portwooddigital.com/2024/01/24/minimal-thermal-example/). For the 2D case, which is easier to debug, I identified that the issue appears to stem from thermal loads being added twice to the `q0` vector. By commenting out specific lines of code in `addLoad()` and leaving the thermal force addition to be handled solely by `getResistingForce()`, the behavior of `dispBeamColumnThermal` now aligns with that of `forceBeamColumnThermal`, providing the correct solution for the minimal working example (MWE) tested by Michael. Please let me know if this fix makes sense, or it works just out of lucky guess.

## Remaining issues
### 1. Multiple `eleLoad(..., '-beamThermal', ...)` instances:
   When applying several `eleLoad(..., '-beamThermal', ...)` instances to the same element, `dispBeamColumnThermal` and `forceBeamColumnThermal` behave differently:
   - In `dispBeamColumnThermal`, only the last instance of `eleLoad(..., '-beamThermal', ...)` is considered.
   - In `forceBeamColumnThermal`, only the first instance is considered.
   
   I am unsure of the expected behavior in this case. 

### 2. 3D Version of `dispBeamColumnThermal`:
   The 3D version of the displacement-based does not provide the correct results for the MWE. While the elongation is correctly computed, regardless of the number of analysis steps, the model reports a fictitious reaction force. I suspect the issue arises because thermal stresses (`residThermal`) are being added to `q0` instead of basic forces ([see here](https://github.com/OpenSees/OpenSees/blob/b68b0c59762e76aff5658fb17da7b0d79ecb6e1a/SRC/element/dispBeamColumn/DispBeamColumn3dThermal.cpp#L1185C9-L1185C10)), but please confirm this. 

### 3. 3D Version of `forceBeamColumnThermal`:
   The 3D version of the force-based formulation only gives the correct result when using `"NormUnbalance"` as the convergence test. When using `"NormDispIncr"`, the solution converges in one iteration to an erroneous state due to an incorrect report of `deltaX = 0`. This issue does not affect the 2D version of `forceBeamColumnThermal`.

## MWE Code in 2D and 3D (adapted from Michael)

### 2D Example
```
import openseespy.opensees as ops

L = 2 * 12
alpha = 6.6e-6 # coefficient 
E = 29000
b = 0.5
d = 0.5

deltaT = 60

ops.wipe()
ops.model('basic','-ndm',2,'-ndf',3)
 
ops.node(1,0,0); ops.fix(1,1,1,1)
ops.node(2,L,0); ops.fix(2,0,1,1)
 
ops.uniaxialMaterial('ElasticThermal',1,E,alpha)
  
ops.section('FiberThermal',1)
ops.patch('rect',1,2,2,-d/2,-b/2,d/2,b/2)
 
ops.beamIntegration('Lobatto',1,1,3)
 
ops.geomTransf('Linear',1)
#ops.element('forceBeamColumnThermal',1,1,2,1,1)
ops.element('dispBeamColumnThermal',1,1,2,1,1)


ops.timeSeries('Linear',1)
ops.pattern('Plain',1,1)
ops.eleLoad('-ele',1,'-type','-beamThermal',deltaT,-d/2,deltaT,d/2)
#ops.eleLoad('-ele',1,'-type','-beamThermal',0.5*deltaT,-d/2,0.5*deltaT,d/2)
 
Nsteps = 1
flag = 1

ops.system("Umfpack")
#ops.test("NormUnbalance", 1e-8, 25, flag)
ops.test("NormDispIncr", 1e-8, 25, flag)
ops.algorithm("Newton")
ops.integrator('LoadControl',1/Nsteps)
ops.analysis('Static','-noWarnings')
 
ops.analyze(Nsteps)

print(f"Disp OpenSees = {ops.nodeDisp(2)}. Should be {[alpha * deltaT * L, 0, 0]}")

ops.reactions()

print(f"Reaction 1 = {ops.nodeReaction(1)}. Should be {[0, 0, 0]}")
print(f"Reaction 2 = {ops.nodeReaction(2)}. Should be {[0, 0, 0]}")
```

### 3D Example
```
import openseespy.opensees as ops

L = 2 * 12
alpha = 6.6e-6 # coefficient 
E = 29000
b = 0.5
d = 0.5

deltaT = 60

ops.wipe()
ops.model('basic','-ndm',3,'-ndf',6)
 
ops.node(1,0,0,0); ops.fix(1,1,1,1,1,1,1)
ops.node(2,L,0,0); ops.fix(2,0,1,1,1,1,1)
 
ops.uniaxialMaterial('ElasticThermal',1,E,alpha)
  
ops.section('FiberThermal',1,'-GJ', 1e10)
ops.patch('rect',1,2,2,-d/2,-b/2,d/2,b/2)
 
ops.beamIntegration('Lobatto',1,1,3)
 
ops.geomTransf('Linear',1, 0, 0, 1)
#ops.element('forceBeamColumnThermal',1,1,2,1,1)
ops.element('dispBeamColumnThermal',1,1,2,1,1)


ops.timeSeries('Linear',1)
ops.pattern('Plain',1,1)
ops.eleLoad('-ele',1,'-type','-beamThermal',deltaT,-d/2,deltaT,d/2)
#ops.eleLoad('-ele',1,'-type','-beamThermal',0.5*deltaT,-d/2,0.5*deltaT,d/2)
 
Nsteps = 1
flag = 1

ops.system("Umfpack")
ops.test("NormUnbalance", 1e-8, 25, flag)
#ops.test("NormDispIncr", 1e-8, 25, flag)
ops.algorithm("Newton")
ops.integrator('LoadControl',1/Nsteps)
ops.analysis('Static','-noWarnings')
 
ops.analyze(Nsteps)

print(f"Disp OpenSees = {ops.nodeDisp(2)}. Should be {[alpha * deltaT * L, 0, 0, 0, 0, 0]}")

ops.reactions()

print(f"Reaction 1 = {ops.nodeReaction(1)}. Should be {[0, 0, 0, 0, 0, 0]}")
print(f"Reaction 2 = {ops.nodeReaction(2)}. Should be {[0, 0, 0, 0, 0, 0]}")
```