### PR TITLE
Correct response attributes for SeriesMaterial

### DIFF
--- a/SRC/material/uniaxial/SeriesMaterial.cpp
+++ b/SRC/material/uniaxial/SeriesMaterial.cpp
@@ -641,8 +641,8 @@ SeriesMaterial::setResponse(const char **argv, int argc, OPS_Stream &theOutput)
   if (strcmp(argv[0],"strains") == 0) {
     for (int i=0; i<numMaterials; i++) {
       theOutput.tag("UniaxialMaterialOutput");
-      theOutput.attr("matType", this->getClassType());
-      theOutput.attr("matTag", this->getTag());
+      theOutput.attr("matType", theModels[i]->getClassType());
+      theOutput.attr("matTag", theModels[i]->getTag());
       theOutput.tag("ResponseType", "eps11");
       theOutput.endTag();
     }


### PR DESCRIPTION
Correctly set matType and matTag attributes to match the materials forming the series material.
If "strains" is requested as a response type, the attributes for each output tag were incorrectly set to be that of the SeriesMaterial, instead of the member material.