### PR TITLE
Fixed bug in `KRAlphaExplicit::getVel()`

### DIFF
--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -561,7 +561,7 @@ int KRAlphaExplicit::commit(void)
 const Vector &
 KRAlphaExplicit::getVel()
 {
-  return *Udot;
+  return *Ualphadot;
 }
 
 int KRAlphaExplicit::sendSelf(int cTag, Channel &theChannel)


### PR DESCRIPTION
An issue (#233) raised by another user 4 years ago regarding the implementation of `KRAlphaExplicit::getVel()` is finally fixed.