### PR TITLE
Adding LU factorization caching for the Matrix class

### DIFF
--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -202,7 +202,8 @@ int KRAlphaExplicit::newStep(double _deltaT)
         // solve [M + gamma*deltaT*C + beta*deltaT^2*K]*[alpha3] = 
         // [alphaM*M + alphaF*gamma*deltaT*C + alphaF*beta*deltaT^2*K] for alpha3
         A.Solve(B3, *alpha3);
-        
+        A.activateLUCache();
+
         c1 = 0.0;
         c2 = 0.0;
         c3 = 1.0;
@@ -211,6 +212,7 @@ int KRAlphaExplicit::newStep(double _deltaT)
         
         // solve [M + gamma*deltaT*C + beta*deltaT^2*K]*[alpha1] = [M] for alpha1
         A.Solve(B1, *alpha1);
+        A.deactivateLUCache();
         
         // calculate the effective mass matrix Mhat
         Mhat->addMatrix(0.0, B1, 1.0);

--- a/SRC/analysis/integrator/KRAlphaExplicit_TP.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit_TP.cpp
@@ -180,7 +180,8 @@ int KRAlphaExplicit_TP::newStep(double _deltaT)
         c3 = 1.0;
         this->TransientIntegrator::formTangent(INITIAL_TANGENT);
         Matrix A(*tmp);
-        
+        A.activateLUCache();
+
         c1 *= (1.0 - alphaF);
         c2 *= (1.0 - alphaF);
         c3 = (1.0 - alphaI);
@@ -199,6 +200,7 @@ int KRAlphaExplicit_TP::newStep(double _deltaT)
         
         // solve [M + gamma*deltaT*C + beta*deltaT^2*K]*[alpha1] = [M] for alpha1
         A.Solve(B1, *alpha1);
+        A.deactivateLUCache();
         
         // calculate the effective mass matrix Mhat
         Mhat->addMatrix(0.0, B1, 1.0);

--- a/SRC/matrix/Matrix.cpp
+++ b/SRC/matrix/Matrix.cpp
@@ -1430,7 +1430,6 @@ Matrix::operator=(const Matrix &other)
 	  delete [] this->data;
           this->data = 0;
       }
-      this->clearLUCache();
 
       int theSize = other.numCols*other.numRows;
       
@@ -1448,8 +1447,9 @@ Matrix::operator=(const Matrix &other)
   for (int i=0; i<dataSize; i++)
       *dataPtr++ = *otherDataPtr++;
   
-  // Clear LU cache for the current object since we're not copying the cache
-  this->clearLUCache();
+  // Deactivate LU cache for the current object by default
+  // Users need to call Matrix::copyWithCache() for LU cache to be copied
+  this->deactivateLUCache();
 
   return *this;
 }
@@ -1514,6 +1514,8 @@ Matrix::operator+=(double fact)
   for (int i=0; i<dataSize; i++)
     *dataPtr++ += fact;
   
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
   return *this;
 }
 
@@ -1531,6 +1533,8 @@ Matrix::operator-=(double fact)
   for (int i=0; i<dataSize; i++)
     *dataPtr++ -= fact;
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
   return *this;
 }
 
@@ -1546,6 +1550,8 @@ Matrix::operator*=(double fact)
   for (int i=0; i<dataSize; i++)
     *dataPtr++ *= fact;
   
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
   return *this;
 }
 
@@ -1555,6 +1561,9 @@ Matrix::operator/=(double fact)
     // check if quick return
     if (fact == 1.0)
 	return *this;
+
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
 
     if (fact != 0.0) {
       double val = 1.0/fact;
@@ -1787,7 +1796,9 @@ Matrix::operator+=(const Matrix &M)
   double *otherData = M.data;
   for (int i=0; i<dataSize; i++)
     *dataPtr++ += *otherData++;
-  
+
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;  
   return *this;
 }
 
@@ -1807,7 +1818,9 @@ Matrix::operator-=(const Matrix &M)
   double *otherData = M.data;
   for (int i=0; i<dataSize; i++)
     *dataPtr++ -= *otherData++;
-  
+
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;   
   return *this;
 }
 
@@ -1891,6 +1904,8 @@ Matrix::Assemble(const Matrix &V, int init_row, int init_col, double fact)
      res = -1;
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return res;
 }
 
@@ -1927,6 +1942,8 @@ Matrix::Assemble(const Vector &V, int init_row, int init_col, double fact)
      res = -1;
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return res;
 }
 
@@ -1963,6 +1980,8 @@ Matrix::AssembleTranspose(const Matrix &V, int init_row, int init_col, double fa
      res = -1;
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return res;
 }
 
@@ -1999,6 +2018,8 @@ Matrix::AssembleTranspose(const Vector &V, int init_row, int init_col, double fa
      res = -1;
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return res;
 }
 
@@ -2035,6 +2056,8 @@ Matrix::Extract(const Matrix &V, int init_row, int init_col, double fact)
      res = -1;
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return res;
 }
 
@@ -2246,6 +2269,8 @@ Matrix::Eigen3(const Matrix &M)
   data[4]=dd(1);
   data[8]=dd(0);
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false; 
   return 0;
 }
 

--- a/SRC/matrix/Matrix.cpp
+++ b/SRC/matrix/Matrix.cpp
@@ -948,6 +948,8 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
       }
     } 
 
+    // reset factorization flag, but keep cache data structures
+    isLUFactorized = false;
     // successful
     return 0;
 }
@@ -1024,6 +1026,8 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       }
     } 
 
+    // reset factorization flag, but keep cache data structures
+    isLUFactorized = false;
     // successful
     return 0;
 }
@@ -1100,6 +1104,8 @@ Matrix::addMatrixProduct(double thisFact,
       }
     } 
 
+    // reset factorization flag, but keep cache data structures
+    isLUFactorized = false;
     return 0;
 }
 
@@ -1164,6 +1170,8 @@ Matrix::addMatrixTransposeProduct(double thisFact,
     } 
   }
 
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
   return 0;
 }
 
@@ -1259,6 +1267,8 @@ Matrix::addMatrixTripleProduct(double thisFact,
       }
     }
 
+    // reset factorization flag, but keep cache data structures
+    isLUFactorized = false;
     return 0;
 }
 
@@ -1359,6 +1369,8 @@ Matrix::addMatrixTripleProduct(double thisFact,
       }
     }
 
+    // reset factorization flag, but keep cache data structures
+    isLUFactorized = false;
     return 0;
 }
 

--- a/SRC/matrix/Matrix.h
+++ b/SRC/matrix/Matrix.h
@@ -72,7 +72,12 @@ class Matrix
     int Solve(const Vector &V, Vector &res) const;
     int Solve(const Matrix &M, Matrix &res) const;
     int Invert(Matrix &res) const;
-
+    
+    // methods to cache LU factorization
+    void activateLUCache() const;
+    void deactivateLUCache() const;
+    Matrix copyWithCache() const;
+    
     int addMatrix(double factThis, const Matrix &other, double factOther);
     int addMatrixTranspose(double factThis, const Matrix &other, double factOther);
     int addMatrixProduct(double factThis, const Matrix &A, const Matrix &B, double factOther); // AB
@@ -166,6 +171,15 @@ class Matrix
     int dataSize;
     double *data;
     int fromFree;
+
+    // cached LU factorization
+    int computeLU() const;
+    void clearLUCache() const;
+    mutable double *cachedLUFactor;
+    mutable int *cachedPivot;
+    mutable bool isLUFactorized;
+    mutable bool isLUCacheEnabled;
+
 };
 
 

--- a/SRC/matrix/Matrix.h
+++ b/SRC/matrix/Matrix.h
@@ -77,7 +77,7 @@ class Matrix
     void activateLUCache() const;
     void deactivateLUCache() const;
     Matrix copyWithCache() const;
-    
+
     int addMatrix(double factThis, const Matrix &other, double factOther);
     int addMatrixTranspose(double factThis, const Matrix &other, double factOther);
     int addMatrixProduct(double factThis, const Matrix &A, const Matrix &B, double factOther); // AB
@@ -209,6 +209,9 @@ Matrix::operator()(int row, int col)
     return MATRIX_NOT_VALID_ENTRY;
   }
 #endif
+
+  // reset factorization flag, but keep cache data structures
+  isLUFactorized = false;
   return data[col*numRows + row];
 }
 


### PR DESCRIPTION
This PR introduces the ability to cache LU factors computed by LAPACK subroutines. The caching mechanism is activated when the user calls `Matrix::activateLUcache()`, which stores the LU factors as private data to be reused in subsequent calls to `Matrix::Solve()` and `Matrix::Inverse()`. When the cached factors are no longer needed, users should call `Matrix::deactivateLUcache()` to release the dynamically allocated memory for the LU factorization. If LU caching is disabled, `Matrix::Solve()` and `Matrix::Inverse()` will revert to their previous behavior, using the static workspace allocated by the `Matrix` class. To test this functionality, LU caching has been integrated into the implementation of the `KRAlphaExplicit` integrator, which makes a couple of calls to `A.Solve(B, x)` on the same matrix `A`. 

If this PR is accepted, similar revisions could be made to formulations like the `mixedBeamColumn` element, which currently computes a matrix inverse and reuses it several times across multiple operations, example below:

https://github.com/OpenSees/OpenSees/blob/cd09d91ec15328e18573885cec04a342e8469035/SRC/element/mixedBeamColumn/MixedBeamColumn2d.cpp#L968C3-L981C4 

The idea for this PR was inspired by [this blog post](https://portwooddigital.com/2022/11/18/dont-invert-the-matrix/) by @mhscott. 