### PR TITLE
JSON output for IMK materials

### DIFF
--- a/SRC/material/uniaxial/IMKBilin.cpp
+++ b/SRC/material/uniaxial/IMKBilin.cpp
@@ -719,5 +719,32 @@ int IMKBilin::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroke
 
 void IMKBilin::Print(OPS_Stream &s, int flag)
 {
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+       s << "\t\t\t{";
+       s << "\"name\": \"" << this->getTag() << "\", ";
+       s << "\"type\": \"IMKPeakOriented\", ";
+       s << "\"Ke\": " << Ke << ", ";
+       s << "\"dp_pos\": " << posUp_0 << ", ";
+       s << "\"dpc_pos\": " << posUpc_0 << ", ";
+       s << "\"du_pos\": " << posUu_0 << ", ";
+       s << "\"Fy_pos\": " << posFy_0 << ", ";
+       s << "\"FmaxFy_pos\": " << posFcapFy_0 << ", ";
+       s << "\"FresFy_pos\": " << posFresFy_0 << ", ";
+       s << "\"dp_neg\": " << negUp_0 << ", ";
+       s << "\"dpc_neg\": " << negUpc_0 << ", ";
+       s << "\"du_neg\": " << negUu_0 << ", ";    
+       s << "\"Fy_neg\": " << negFy_0 << ", ";    
+       s << "\"FmaxFy_neg\": " << negFcapFy_0 << ", ";    
+       s << "\"FresFy_neg\": " << negFresFy_0 << ", ";    
+       s << "\"Lamda_S\": " << LAMBDA_S << ", ";    
+       s << "\"Lamda_C\": " << LAMBDA_C << ", ";  
+       s << "\"Lamda_K\": " << LAMBDA_K << ", ";    
+       s << "\"c_S\": " << c_S << ", ";    
+       s << "\"c_C\": " << c_C << ", ";    
+       s << "\"c_K\": " << c_K << ", ";    
+       s << "\"D_pos\": " << D_pos << ", ";
+       s << "\"D_neg\": " << D_neg << "}";
+       return;
+  }
     cout << "IMKBilin tag: " << this->getTag() << endln;
 }

--- a/SRC/material/uniaxial/IMKPeakOriented.cpp
+++ b/SRC/material/uniaxial/IMKPeakOriented.cpp
@@ -858,5 +858,34 @@ int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &t
 
 void IMKPeakOriented::Print(OPS_Stream &s, int flag)
 {
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+       s << "\t\t\t{";
+       s << "\"name\": \"" << this->getTag() << "\", ";
+       s << "\"type\": \"IMKPeakOriented\", ";
+       s << "\"Ke\": " << Ke << ", ";
+       s << "\"dp_pos\": " << posUp_0 << ", ";
+       s << "\"dpc_pos\": " << posUpc_0 << ", ";
+       s << "\"du_pos\": " << posUu_0 << ", ";
+       s << "\"Fy_pos\": " << posFy_0 << ", ";
+       s << "\"FmaxFy_pos\": " << posFcapFy_0 << ", ";
+       s << "\"FresFy_pos\": " << posFresFy_0 << ", ";
+       s << "\"dp_neg\": " << negUp_0 << ", ";
+       s << "\"dpc_neg\": " << negUpc_0 << ", ";
+       s << "\"du_neg\": " << negUu_0 << ", ";    
+       s << "\"Fy_neg\": " << negFy_0 << ", ";    
+       s << "\"FmaxFy_neg\": " << negFcapFy_0 << ", ";    
+       s << "\"FresFy_neg\": " << negFresFy_0 << ", ";    
+       s << "\"Lamda_S\": " << LAMBDA_S << ", ";    
+       s << "\"Lamda_C\": " << LAMBDA_C << ", ";    
+       s << "\"Lamda_A\": " << LAMBDA_A << ", ";    
+       s << "\"Lamda_K\": " << LAMBDA_K << ", ";    
+       s << "\"c_S\": " << c_S << ", ";    
+       s << "\"c_C\": " << c_C << ", ";    
+       s << "\"c_A\": " << c_A << ", ";    
+       s << "\"c_K\": " << c_K << ", ";    
+       s << "\"D_pos\": " << D_pos << ", ";
+       s << "\"D_neg\": " << D_neg << "}";
+       return;
+  }
     cout << "IMKPeakOriented tag: " << this->getTag() << endln;
 }

--- a/SRC/material/uniaxial/IMKPinching.cpp
+++ b/SRC/material/uniaxial/IMKPinching.cpp
@@ -936,5 +936,36 @@ int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBr
 
 void IMKPinching::Print(OPS_Stream &s, int flag)
 {
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+       s << "\t\t\t{";
+       s << "\"name\": \"" << this->getTag() << "\", ";
+       s << "\"type\": \"IMKPinching\", ";
+       s << "\"Ke\": " << Ke << ", ";
+       s << "\"dp_pos\": " << posUp_0 << ", ";
+       s << "\"dpc_pos\": " << posUpc_0 << ", ";
+       s << "\"du_pos\": " << posUu_0 << ", ";
+       s << "\"Fy_pos\": " << posFy_0 << ", ";
+       s << "\"FmaxFy_pos\": " << posFcapFy_0 << ", ";
+       s << "\"FresFy_pos\": " << posFresFy_0 << ", ";
+       s << "\"dp_neg\": " << negUp_0 << ", ";
+       s << "\"dpc_neg\": " << negUpc_0 << ", ";
+       s << "\"du_neg\": " << negUu_0 << ", ";    
+       s << "\"Fy_neg\": " << negFy_0 << ", ";    
+       s << "\"FmaxFy_neg\": " << negFcapFy_0 << ", ";    
+       s << "\"FresFy_neg\": " << negFresFy_0 << ", ";    
+       s << "\"Lamda_S\": " << LAMBDA_S << ", ";    
+       s << "\"Lamda_C\": " << LAMBDA_C << ", ";    
+       s << "\"Lamda_A\": " << LAMBDA_A << ", ";    
+       s << "\"Lamda_K\": " << LAMBDA_K << ", ";    
+       s << "\"c_S\": " << c_S << ", ";    
+       s << "\"c_C\": " << c_C << ", ";    
+       s << "\"c_A\": " << c_A << ", ";    
+       s << "\"c_K\": " << c_K << ", ";    
+       s << "\"D_pos\": " << D_pos << ", ";
+       s << "\"D_neg\": " << D_neg << ", ";
+       s << "\"kappaF\": " << kappaF << ", ";
+       s << "\"kappaD\": " << kappaD << "}";
+       return;
+  }
     cout << "IMKPinching tag: " << this->getTag() << endln;
 }


### PR DESCRIPTION
Add missing json output for IMK materials.
Example script:
```
model BasicBuilder -ndm 1 -ndf 1;
set Ke      10000.;
set dp      0.01;
set dpc     0.05;
set du      0.08;
set My      100.;
set Mc_My   1.10;
set Mres_My 0.10;
set lambda  0.50;
set c_S     1.00;
set c_C     1.00;
set c_K     1.00;
set c_A     1.00;
set D_pos   1.00;
set D_neg   1.00;
set kappaF  0.50;
set kappaD  0.50;
uniaxialMaterial IMKPinching       1 $Ke $dp $dpc $du $My $Mc_My $Mres_My $dp $dpc $du $My $Mc_My $Mres_My $lambda $lambda $lambda $lambda $c_S $c_S $c_A $c_K $D_pos $D_neg $kappaF $kappaD;
uniaxialMaterial IMKBilin          2 $Ke $dp $dpc $du $My $Mc_My $Mres_My $dp $dpc $du $My $Mc_My $Mres_My $lambda $lambda $lambda $c_S $c_S $c_K $D_pos $D_neg;
uniaxialMaterial IMKPeakOriented   3 $Ke $dp $dpc $du $My $Mc_My $Mres_My $dp $dpc $du $My $Mc_My $Mres_My $lambda $lambda $lambda $lambda $c_S $c_S $c_A $c_K $D_pos $D_neg;

node	1	0.0;
node	2	1.0;
fix		1	1;
element truss 1	1	2	1	1;
element truss 2	1	2	1	2;
element truss 3	1	2	1	3;
print -JSON -file imk.json
```
