### PR TITLE
Fix overflow int bug in Py Qz Tz Simple 1 and 2 materials

### DIFF
--- a/SRC/material/uniaxial/PY/PySimple1.cpp
+++ b/SRC/material/uniaxial/PY/PySimple1.cpp
@@ -397,10 +397,26 @@ PySimple1::setTrialStrain (double newy, double yRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dp/pult) > 0.5) numSteps = 1 + int(fabs(dp/(0.5*pult)));
-	if(fabs(dy/y50)  > 1.0 ) numSteps = 1 + int(fabs(dy/(1.0*y50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dp/pult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dy/y50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
+
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dy = stepSize * dy;
 

--- a/SRC/material/uniaxial/PY/PySimple2.cpp
+++ b/SRC/material/uniaxial/PY/PySimple2.cpp
@@ -390,10 +390,26 @@ PySimple2::setTrialStrain (double newy, double yRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dp/pult) > 0.5) numSteps = 1 + int(fabs(dp/(0.5*pult)));
-	if(fabs(dy/y50)  > 1.0 ) numSteps = 1 + int(fabs(dy/(1.0*y50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dp/pult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dy/y50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
+
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dy = stepSize * dy;
 

--- a/SRC/material/uniaxial/PY/QzSimple1.cpp
+++ b/SRC/material/uniaxial/PY/QzSimple1.cpp
@@ -386,10 +386,26 @@ QzSimple1::setTrialStrain (double newz, double zRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dQ/Qult) > 0.5) numSteps = 1 + int(fabs(dQ/(0.5*Qult)));
-	if(fabs(dz/z50)  > 1.0 ) numSteps = 1 + int(fabs(dz/(1.0*z50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dQ/Qult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dz/z50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
+
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dz = stepSize * dz;
 	const int QZmaxIterations = 20;

--- a/SRC/material/uniaxial/PY/QzSimple2.cpp
+++ b/SRC/material/uniaxial/PY/QzSimple2.cpp
@@ -387,10 +387,25 @@ QzSimple2::setTrialStrain (double newz, double zRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dQ/Qult) > 0.5) numSteps = 1 + int(fabs(dQ/(0.5*Qult)));
-	if(fabs(dz/z50)  > 1.0 ) numSteps = 1 + int(fabs(dz/(1.0*z50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dQ/Qult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dz/z50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dz = stepSize * dz;
 

--- a/SRC/material/uniaxial/PY/TzSimple1.cpp
+++ b/SRC/material/uniaxial/PY/TzSimple1.cpp
@@ -236,10 +236,25 @@ TzSimple1::setTrialStrain (double newz, double zRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dt/tult) > 0.5)  numSteps = 1 + int(fabs(dt/(0.5*tult)));
-	if(fabs(dz/z50)  > 1.0 ) numSteps = 1 + int(fabs(dz/(1.0*z50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dt/tult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dz/z50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dz = stepSize * dz;
 	const int TZmaxIterations = 20;

--- a/SRC/material/uniaxial/PY/TzSimple2.cpp
+++ b/SRC/material/uniaxial/PY/TzSimple2.cpp
@@ -232,10 +232,25 @@ TzSimple2::setTrialStrain (double newz, double zRate)
 	//
 	int numSteps = 1;
 	double stepSize = 1.0;
-	if(fabs(dt/tult) > 0.5)  numSteps = 1 + int(fabs(dt/(0.5*tult)));
-	if(fabs(dz/z50)  > 1.0 ) numSteps = 1 + int(fabs(dz/(1.0*z50)));
-	stepSize = 1.0/float(numSteps);
+	double temp = fabs(dt/tult);
+	if(temp > 0.5) {
+		if (temp > 50) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp * 2.0);
+		}
+	}
+
+	temp = fabs(dz/z50);
+	if(temp > 1.0) {
+		if (temp > 100) {
+			numSteps = 100;
+		} else {
+			numSteps = 1 + int(temp);
+		}
+	}
 	if(numSteps > 100) numSteps = 100;
+	stepSize = 1.0/double(numSteps);
 
 	dz = stepSize * dz;
 


### PR DESCRIPTION
when dp or dy is very large, numSteps may overflow and cause infinite loop