### PR TITLE
cmp - fix broken JSON output

### DIFF
--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1222,63 +1222,66 @@ void
 FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 {
   if (flag == 2) {
-    for (int i = 0; i < numFibers; i++) {
-      s << -matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;
-      s << theMaterials[i]->getStress() << " "  << theMaterials[i]->getStrain() << endln;
+    for (int i = 0; i < fibers.size(); i++) {
+      s << -fibers[i].y << " "  << fibers[i].z << " "  << fibers[i].area << " " ;
+      s << fibers[i].material->getStress() << " "  << fibers[i].material->getStrain() << endln;
     }
-  } else {
+  }
+
+  else if (flag == 3) {
+    for (int i = 0; i < fibers.size(); i++) {
+      s << fibers[i].material->getTag() << " " << fibers[i].y << " "  << fibers[i].z << " "  << fibers[i].area << " " ;
+      s << fibers[i].material->getStress() << " "  << fibers[i].material->getStrain() << endln;
+    } 
+  }
+    
+  else if (flag == 4) {
+    for (int i = 0; i < fibers.size(); i++) {
+      s << "add fiber # " << i+1 << " using material # " << fibers[i].material->getTag() << " to section # 1\n";
+      s << "fiber_cross_section = " << fibers[i].area << "*m^2\n";
+      s << "fiber_location = (" << fibers[i].y << "*m, " << fibers[i].z << "*m);\n\n";
+    }
+  }
+
+  else if (flag == OPS_PRINT_PRINTMODEL_JSON) { 
+      s << TaggedObject::JsonPropertyIndent << "{";
+      s << "\"name\": \"" << this->getTag() << "\", ";
+      s << "\"type\": \"" << this->getClassType() << "\", ";
+
+      if (theTorsion != 0)
+        s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+
+      s << "\"fibers\": [\n";
+      for (int i = 0; i < fibers.size(); i++) {
+            s << TaggedObject::JsonPropertyIndent 
+              << "\t{\"coord\": [" << fibers[i].y << ", " 
+                                   << fibers[i].z << "], ";
+            s << "\"area\": " << fibers[i].area << ", ";
+            s << "\"material\": " << fibers[i].material->getTag();
+            if (i < fibers.size() - 1)
+                  s << "},\n";
+            else
+                  s << "}\n";
+      }
+      s << TaggedObject::JsonPropertyIndent << "]}";
+      return;
+  }
+
+  else {
     s << "\nFiberSection3dThermal, tag: " << this->getTag() << endln;
     s << "\tSection code: " << code;
-    s << "\tNumber of Fibers: " << numFibers << endln;
+    s << "\tNumber of Fibers: " << fibers.size() << endln;
     s << "\tCentroid: (" << yBar << ", " << zBar << ')' << endln;
     if (theTorsion != 0)
         theTorsion->Print(s, flag); 
 
     if (flag == 1) {
-      for (int i = 0; i < numFibers; i++) {
-	s << "\nLocation (y, z) = (" << -matData[3*i] << ", " << matData[3*i+1] << ")";
-	s << "\nArea = " << matData[3*i+2] << endln;
-      theMaterials[i]->Print(s, flag);
+      for (int i = 0; i < fibers.size(); i++) {
+        s << "\nLocation (y, z) = (" << -fibers[i].y << ", " << fibers[i].z << ")";
+        s << "\nArea = " << fibers[i].area << endln;
+      fibers[i].material->Print(s, flag);
       }
     }
-  }
-  if (flag == 3) {
-    for (int i = 0; i < numFibers; i++) {
-      s << theMaterials[i]->getTag() << " " << matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;
-      s << theMaterials[i]->getStress() << " "  << theMaterials[i]->getStrain() << endln;
-    } 
-  }
-    
-  if (flag == 4) {
-    for (int i = 0; i < numFibers; i++) {
-      s << "add fiber # " << i+1 << " using material # " << theMaterials[i]->getTag() << " to section # 1\n";
-      s << "fiber_cross_section = " << matData[3*i+2] << "*m^2\n";
-      s << "fiber_location = (" << matData[3*i] << "*m, " << matData[3*i+1] << "*m);\n\n";
-    }
-  }
-
-  if (flag == OPS_PRINT_PRINTMODEL_JSON) { 
-        s << TaggedObject::JsonPropertyIndent << "{";
-        s << "\"name\": \"" << this->getTag() << "\", ";
-        s << "\"type\": \"" << this->getClassType() << "\", ";
-
-        if (theTorsion != 0)
-          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
-
-        s << "\"fibers\": [\n";
-        for (int i = 0; i < numFibers; i++) {
-              s << TaggedObject::JsonPropertyIndent 
-                << "\t{\"coord\": [" << matData[3*i] << ", " 
-                                     << matData[3*i+1] << "], ";
-              s << "\"area\": " << matData[3*i+2] << ", ";
-              s << "\"material\": " << theMaterials[i]->getTag();
-              if (i < numFibers - 1)
-                    s << "},\n";
-              else
-                    s << "}\n";
-        }
-        s << TaggedObject::JsonPropertyIndent << "]}";
-        return;
   }
 }
 

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1221,29 +1221,6 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
 void
 FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 {
-  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-        s << TaggedObject::JsonPropertyIndent << "{";
-        s << "\"name\": \"" << this->getTag() << "\", ";
-        s << "\"type\": \"" << this->getClassType() << "\", ";
-
-        if (theTorsion != 0)
-          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
-
-        s << "\"fibers\": [\n";
-        for (int i = 0; i < numFibers; i++) {
-              s << TaggedObject::JsonPropertyIndent 
-                << "\t{\"coord\": [" << matData[3*i] << ", " 
-                                     << matData[3*i+1] << "], ";
-              s << "\"area\": " << matData[3*i+2] << ", ";
-              s << "\"material\": " << theMaterials[i]->getTag();
-              if (i < numFibers - 1)
-                    s << "},\n";
-              else
-                    s << "}\n";
-        }
-        s << TaggedObject::JsonPropertyIndent << "]}";
-        return;
-  }
   if (flag == 2) {
     for (int i = 0; i < numFibers; i++) {
       s << -matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1221,6 +1221,29 @@ FiberSection3dThermal::recvSelf(int commitTag, Channel &theChannel,
 void
 FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 {
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+        s << OPS_PRINT_JSON_MATE_INDENT << "{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"" << this->getClassType() << "\", ";
+
+        if (theTorsion != 0)
+          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+
+        s << "\"fibers\": [\n";
+        for (int i = 0; i < numFibers; i++) {
+              s << OPS_PRINT_JSON_MATE_INDENT 
+                << "\t{\"coord\": [" << matData[3*i] << ", " 
+                                     << matData[3*i+1] << "], ";
+              s << "\"area\": " << matData[3*i+2] << ", ";
+              s << "\"material\": " << theMaterials[i]->getTag();
+              if (i < numFibers - 1)
+                    s << "},\n";
+              else
+                    s << "}\n";
+        }
+        s << OPS_PRINT_JSON_MATE_INDENT << "]}";
+        return;
+  }
   if (flag == 2) {
     for (int i = 0; i < numFibers; i++) {
       s << -matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -48,6 +48,8 @@
 #include <math.h>
 #include <elementAPI.h>
 
+using namespace OpenSees;
+
 ID FiberSection3dThermal::code(4);
 
 void* OPS_FiberSection3dThermal()
@@ -1244,7 +1246,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
   }
 
   else if (flag == OPS_PRINT_PRINTMODEL_JSON) { 
-        s << TaggedObject::JsonPropertyIndent << "{";
+        s << Printing::JsonPropertyIndent << "{";
         s << "\"name\": \"" << this->getTag() << "\", ";
         s << "\"type\": \"" << this->getClassType() << "\", ";
 
@@ -1253,7 +1255,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 
         s << "\"fibers\": [\n";
         for (int i = 0; i < numFibers; i++) {
-              s << TaggedObject::JsonPropertyIndent 
+              s << Printing::JsonPropertyIndent 
                 << "\t{\"coord\": [" << matData[3*i] << ", " 
                                      << matData[3*i+1] << "], ";
               s << "\"area\": " << matData[3*i+2] << ", ";
@@ -1263,7 +1265,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
               else
                     s << "}\n";
         }
-        s << TaggedObject::JsonPropertyIndent << "]}";
+        s << Printing::JsonPropertyIndent << "]}";
         return;
   }
 

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1248,7 +1248,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
         s << "\"name\": \"" << this->getTag() << "\", ";
         s << "\"type\": \"" << this->getClassType() << "\", ";
 
-        if (theTorsion != 0)
+        if (theTorsion != nullptr)
           s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
 
         s << "\"fibers\": [\n";

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1257,23 +1257,28 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
     }
   }
 
-  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-	  s << "\t\t\t{";
-	  s << "\"name\": \"" << this->getTag() << "\", ";
-	  s << "\"type\": \"FiberSection3d\", ";
-	  if (theTorsion != 0)
-	    s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
-	  s << "\"fibers\": [\n";
-	  for (int i = 0; i < numFibers; i++) {
-		  s << "\t\t\t\t{\"coord\": [" << matData[3*i] << ", " << matData[3*i+1] << "], ";
-		  s << "\"area\": " << matData[3*i+2] << ", ";
-		  s << "\"material\": \"" << theMaterials[i]->getTag() << "\"";
-		  if (i < numFibers - 1)
-			  s << "},\n";
-		  else
-			  s << "}\n";
-	  }
-	  s << "\t\t\t]}";
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) { 
+        s << TaggedObject::JsonPropertyIndent << "{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"" << this->getClassType() << "\", ";
+
+        if (theTorsion != 0)
+          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+
+        s << "\"fibers\": [\n";
+        for (int i = 0; i < numFibers; i++) {
+              s << TaggedObject::JsonPropertyIndent 
+                << "\t{\"coord\": [" << matData[3*i] << ", " 
+                                     << matData[3*i+1] << "], ";
+              s << "\"area\": " << matData[3*i+2] << ", ";
+              s << "\"material\": " << theMaterials[i]->getTag();
+              if (i < numFibers - 1)
+                    s << "},\n";
+              else
+                    s << "}\n";
+        }
+        s << TaggedObject::JsonPropertyIndent << "]}";
+        return;
   }
 }
 

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1222,7 +1222,7 @@ void
 FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 {
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-        s << OPS_PRINT_JSON_MATE_INDENT << "{";
+        s << TaggedObject::JsonPropertyIndent << "{";
         s << "\"name\": \"" << this->getTag() << "\", ";
         s << "\"type\": \"" << this->getClassType() << "\", ";
 
@@ -1231,7 +1231,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 
         s << "\"fibers\": [\n";
         for (int i = 0; i < numFibers; i++) {
-              s << OPS_PRINT_JSON_MATE_INDENT 
+              s << TaggedObject::JsonPropertyIndent 
                 << "\t{\"coord\": [" << matData[3*i] << ", " 
                                      << matData[3*i+1] << "], ";
               s << "\"area\": " << matData[3*i+2] << ", ";
@@ -1241,7 +1241,7 @@ FiberSection3dThermal::Print(OPS_Stream &s, int flag)
               else
                     s << "}\n";
         }
-        s << OPS_PRINT_JSON_MATE_INDENT << "]}";
+        s << TaggedObject::JsonPropertyIndent << "]}";
         return;
   }
   if (flag == 2) {

--- a/SRC/material/section/FiberSection3dThermal.cpp
+++ b/SRC/material/section/FiberSection3dThermal.cpp
@@ -1222,64 +1222,64 @@ void
 FiberSection3dThermal::Print(OPS_Stream &s, int flag)
 {
   if (flag == 2) {
-    for (int i = 0; i < fibers.size(); i++) {
-      s << -fibers[i].y << " "  << fibers[i].z << " "  << fibers[i].area << " " ;
-      s << fibers[i].material->getStress() << " "  << fibers[i].material->getStrain() << endln;
+    for (int i = 0; i < numFibers; i++) {
+      s << -matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;
+      s << theMaterials[i]->getStress() << " "  << theMaterials[i]->getStrain() << endln;
     }
-  }
+  } 
 
   else if (flag == 3) {
-    for (int i = 0; i < fibers.size(); i++) {
-      s << fibers[i].material->getTag() << " " << fibers[i].y << " "  << fibers[i].z << " "  << fibers[i].area << " " ;
-      s << fibers[i].material->getStress() << " "  << fibers[i].material->getStrain() << endln;
+    for (int i = 0; i < numFibers; i++) {
+      s << theMaterials[i]->getTag() << " " << matData[3*i] << " "  << matData[3*i+1] << " "  << matData[3*i+2] << " " ;
+      s << theMaterials[i]->getStress() << " "  << theMaterials[i]->getStrain() << endln;
     } 
   }
     
   else if (flag == 4) {
-    for (int i = 0; i < fibers.size(); i++) {
-      s << "add fiber # " << i+1 << " using material # " << fibers[i].material->getTag() << " to section # 1\n";
-      s << "fiber_cross_section = " << fibers[i].area << "*m^2\n";
-      s << "fiber_location = (" << fibers[i].y << "*m, " << fibers[i].z << "*m);\n\n";
+    for (int i = 0; i < numFibers; i++) {
+      s << "add fiber # " << i+1 << " using material # " << theMaterials[i]->getTag() << " to section # 1\n";
+      s << "fiber_cross_section = " << matData[3*i+2] << "*m^2\n";
+      s << "fiber_location = (" << matData[3*i] << "*m, " << matData[3*i+1] << "*m);\n\n";
     }
   }
 
   else if (flag == OPS_PRINT_PRINTMODEL_JSON) { 
-      s << TaggedObject::JsonPropertyIndent << "{";
-      s << "\"name\": \"" << this->getTag() << "\", ";
-      s << "\"type\": \"" << this->getClassType() << "\", ";
+        s << TaggedObject::JsonPropertyIndent << "{";
+        s << "\"name\": \"" << this->getTag() << "\", ";
+        s << "\"type\": \"" << this->getClassType() << "\", ";
 
-      if (theTorsion != 0)
-        s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
+        if (theTorsion != 0)
+          s << "\"torsion\": " << theTorsion->getInitialTangent() << ", ";
 
-      s << "\"fibers\": [\n";
-      for (int i = 0; i < fibers.size(); i++) {
-            s << TaggedObject::JsonPropertyIndent 
-              << "\t{\"coord\": [" << fibers[i].y << ", " 
-                                   << fibers[i].z << "], ";
-            s << "\"area\": " << fibers[i].area << ", ";
-            s << "\"material\": " << fibers[i].material->getTag();
-            if (i < fibers.size() - 1)
-                  s << "},\n";
-            else
-                  s << "}\n";
-      }
-      s << TaggedObject::JsonPropertyIndent << "]}";
-      return;
+        s << "\"fibers\": [\n";
+        for (int i = 0; i < numFibers; i++) {
+              s << TaggedObject::JsonPropertyIndent 
+                << "\t{\"coord\": [" << matData[3*i] << ", " 
+                                     << matData[3*i+1] << "], ";
+              s << "\"area\": " << matData[3*i+2] << ", ";
+              s << "\"material\": " << theMaterials[i]->getTag();
+              if (i < numFibers - 1)
+                    s << "},\n";
+              else
+                    s << "}\n";
+        }
+        s << TaggedObject::JsonPropertyIndent << "]}";
+        return;
   }
 
   else {
     s << "\nFiberSection3dThermal, tag: " << this->getTag() << endln;
     s << "\tSection code: " << code;
-    s << "\tNumber of Fibers: " << fibers.size() << endln;
+    s << "\tNumber of Fibers: " << numFibers << endln;
     s << "\tCentroid: (" << yBar << ", " << zBar << ')' << endln;
     if (theTorsion != 0)
         theTorsion->Print(s, flag); 
 
     if (flag == 1) {
-      for (int i = 0; i < fibers.size(); i++) {
-        s << "\nLocation (y, z) = (" << -fibers[i].y << ", " << fibers[i].z << ")";
-        s << "\nArea = " << fibers[i].area << endln;
-      fibers[i].material->Print(s, flag);
+      for (int i = 0; i < numFibers; i++) {
+	s << "\nLocation (y, z) = (" << -matData[3*i] << ", " << matData[3*i+1] << ")";
+	s << "\nArea = " << matData[3*i+2] << endln;
+      theMaterials[i]->Print(s, flag);
       }
     }
   }

--- a/SRC/material/uniaxial/Steel01Thermal.cpp
+++ b/SRC/material/uniaxial/Steel01Thermal.cpp
@@ -974,7 +974,7 @@ int Steel01Thermal::recvSelf (int commitTag, Channel& theChannel,
 void Steel01Thermal::Print (OPS_Stream& s, int flag)
 {
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << OPS_PRINT_JSON_MATE_INDENT << "{";
+    s << TaggedObject::JsonPropertyIndent << "{";
     s << "\"name\": \"" << this->getTag() << "\", ";
     s << "\"type\": \"" << this->getClassType() << "\", ";
     s << "\"E\": " << E0 << ", ";

--- a/SRC/material/uniaxial/Steel01Thermal.cpp
+++ b/SRC/material/uniaxial/Steel01Thermal.cpp
@@ -973,6 +973,20 @@ int Steel01Thermal::recvSelf (int commitTag, Channel& theChannel,
 
 void Steel01Thermal::Print (OPS_Stream& s, int flag)
 {
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << OPS_PRINT_JSON_MATE_INDENT << "{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+    s << "\"type\": \"" << this->getClassType() << "\", ";
+    s << "\"E\": " << E0 << ", ";
+    s << "\"fy\": " << fy << ", ";
+    s << "\"b\": " << b << ", ";
+    s << "\"a1\": " << a1 << ", ";
+    s << "\"a2\": " << a2 << ", ";
+    s << "\"a3\": " << a3 << ", ";
+    s << "\"a4\": " << a4 << "}";
+    return;
+  }
+  else {
    s << "Steel01Thermal tag: " << this->getTag() << endln;
    s << "  fy: " << fy << " ";
    s << "  E0: " << E0 << " ";
@@ -981,6 +995,7 @@ void Steel01Thermal::Print (OPS_Stream& s, int flag)
    s << "  a2: " << a2 << " ";
    s << "  a3: " << a3 << " ";
    s << "  a4: " << a4 << " ";
+  }
 }
 
 

--- a/SRC/material/uniaxial/Steel01Thermal.cpp
+++ b/SRC/material/uniaxial/Steel01Thermal.cpp
@@ -974,7 +974,7 @@ int Steel01Thermal::recvSelf (int commitTag, Channel& theChannel,
 void Steel01Thermal::Print (OPS_Stream& s, int flag)
 {
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << Printing::JsonPropertyIndent << "{";
+    s << OpenSees::Printing::JsonPropertyIndent << "{";
     s << "\"name\": \"" << this->getTag() << "\", ";
     s << "\"type\": \"" << this->getClassType() << "\", ";
     s << "\"E\": " << E0 << ", ";

--- a/SRC/material/uniaxial/Steel01Thermal.cpp
+++ b/SRC/material/uniaxial/Steel01Thermal.cpp
@@ -974,7 +974,7 @@ int Steel01Thermal::recvSelf (int commitTag, Channel& theChannel,
 void Steel01Thermal::Print (OPS_Stream& s, int flag)
 {
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << TaggedObject::JsonPropertyIndent << "{";
+    s << Printing::JsonPropertyIndent << "{";
     s << "\"name\": \"" << this->getTag() << "\", ";
     s << "\"type\": \"" << this->getClassType() << "\", ";
     s << "\"E\": " << E0 << ", ";

--- a/SRC/material/uniaxial/Steel01Thermal.h
+++ b/SRC/material/uniaxial/Steel01Thermal.h
@@ -42,7 +42,7 @@ class Steel01Thermal : public UniaxialMaterial
     Steel01Thermal();
     ~Steel01Thermal();
 
-    const char *getClassType(void) const {return "Steel01Thermal";};
+    const char *getClassType(void) const {return "Steel01Thermal";}
 
 
     double getThermalElongation(void); //***JZ

--- a/SRC/tagged/TaggedObject.h
+++ b/SRC/tagged/TaggedObject.h
@@ -43,6 +43,15 @@
 
 class Domain;
 
+
+namespace OpenSees {
+namespace Printing {
+    constexpr static char JsonGeometryIndent[] = "\t\t\t";
+    constexpr static char JsonPropertyIndent[] = "\t\t\t";
+}
+}
+    
+
 class TaggedObject 
 {
   public:
@@ -57,9 +66,6 @@ class TaggedObject
   protected:
     void setTag(int newTag);  // CAUTION: this is a dangerous method to call
                               //
-    constexpr static char JsonGeometryIndent[] = "\t\t\t";
-    constexpr static char JsonPropertyIndent[] = "\t\t\t";
-    
   private:    
     int theTag;    
 };

--- a/SRC/tagged/TaggedObject.h
+++ b/SRC/tagged/TaggedObject.h
@@ -26,9 +26,6 @@
 #ifndef TaggedObject_h
 #define TaggedObject_h
 
-#define OPS_PRINT_JSON_ELEM_INDENT "\t\t\t"
-#define OPS_PRINT_JSON_NODE_INDENT "\t\t\t"
-#define OPS_PRINT_JSON_MATE_INDENT "\t\t\t"
 
 // File: ~/tagged/TaggedObject.h
 //
@@ -59,6 +56,9 @@ class TaggedObject
 
   protected:
     void setTag(int newTag);  // CAUTION: this is a dangerous method to call
+                              //
+    constexpr static char[] JsonGeometryIndent = "\t\t\t";
+    constexpr static char[] JsonPropertyIndent = "\t\t\t";
     
   private:    
     int theTag;    

--- a/SRC/tagged/TaggedObject.h
+++ b/SRC/tagged/TaggedObject.h
@@ -57,8 +57,8 @@ class TaggedObject
   protected:
     void setTag(int newTag);  // CAUTION: this is a dangerous method to call
                               //
-    constexpr static char[] JsonGeometryIndent = "\t\t\t";
-    constexpr static char[] JsonPropertyIndent = "\t\t\t";
+    constexpr static char JsonGeometryIndent[] = "\t\t\t";
+    constexpr static char JsonPropertyIndent[] = "\t\t\t";
     
   private:    
     int theTag;    

--- a/SRC/tagged/TaggedObject.h
+++ b/SRC/tagged/TaggedObject.h
@@ -26,6 +26,10 @@
 #ifndef TaggedObject_h
 #define TaggedObject_h
 
+#define OPS_PRINT_JSON_ELEM_INDENT "\t\t\t"
+#define OPS_PRINT_JSON_NODE_INDENT "\t\t\t"
+#define OPS_PRINT_JSON_MATE_INDENT "\t\t\t"
+
 // File: ~/tagged/TaggedObject.h
 //
 // Written: fmk 


### PR DESCRIPTION
- JSON output has been added to `Steel01Thermal`. 
- `FiberSection3dThermal::Print` wasn't handling the print flag correctly and was producing non-JSON output, even when JSON was requested.
- `FiberSection3dThermal` incorrectly identified itself as `"FiberSection3d"`. The `getClassType()` method is used to prevent similar copy-paste errors in the future.
- Constants are defined that eliminate the need for hard-coding indentation depths in JSON output. Two constants are added that refer to the `"properties"` and `"geometry"` sections of the JSON output, respectively. The constants are implemented as protected constant-expression static members of `TaggedObject`, which defines the `Print()` abstract method. 

