### PR TITLE
cmp - Fix Ubuntu build, create `BLAS/CMakeLists.txt`

### DIFF
--- a/OTHER/BLAS/CMakeLists.txt
+++ b/OTHER/BLAS/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_library(BLAS OBJECT)
+
+target_sources(BLAS
+    PRIVATE
+        dasum.f
+        daxpy.f
+        dcopy.f
+        ddot.f
+        dgbmv.f
+        dgeev.f
+        dgemm.f
+        dgemv.f
+        dger.f
+        dnrm2.f
+        dpotrf.f
+        drot.f
+        drotg.f
+        dscal.f
+        dswap.f
+        dsymm.f
+        dsymv.f
+        dsyr2.f
+        dsyr2k.f
+        dsyr.f
+        dsyrk.f
+        dtbsv.f
+        dtrmm.f
+        dtrmv.f
+        dtrsm.f
+        dtrsv.f
+        dtrtrs.f
+        dzasum.f
+        dznrm2.f
+        icamax.f
+        idamax.f
+        isamax.f
+        izamax.f
+)
+

--- a/OTHER/LAPACK/CMakeLists.txt
+++ b/OTHER/LAPACK/CMakeLists.txt
@@ -148,7 +148,7 @@ target_sources(LAPACK_C PUBLIC
   BLAS_error.c
 )
 
-target_link_libraries(LAPACK PUBLIC LAPACK_C)
+target_link_libraries(LAPACK PUBLIC LAPACK_C BLAS)
 
 
 

--- a/OTHER/LAPACK/CMakeLists.txt
+++ b/OTHER/LAPACK/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(LAPACK PUBLIC
   lsame.f
   xerbla.f
   ilaenv.f
+  ieeeck.f
   dgeqr2.f
   dlabad.f
   dlacon.f

--- a/OTHER/LAPACK/CMakeLists.txt
+++ b/OTHER/LAPACK/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_library(LAPACK)
 
 target_sources(LAPACK PUBLIC
+  lsame.f
+  xerbla.f
   dgeqr2.f
   dlabad.f
   dlacon.f

--- a/OTHER/LAPACK/CMakeLists.txt
+++ b/OTHER/LAPACK/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(LAPACK)
 target_sources(LAPACK PUBLIC
   lsame.f
   xerbla.f
+  ilaenv.f
   dgeqr2.f
   dlabad.f
   dlacon.f

--- a/OTHER/LAPACK/CMakeLists.txt
+++ b/OTHER/LAPACK/CMakeLists.txt
@@ -16,9 +16,12 @@ add_library(LAPACK)
 
 target_sources(LAPACK PUBLIC
   lsame.f
+  lsamen.f
   xerbla.f
   ilaenv.f
+  xlaenv.f
   ieeeck.f
+
   dgeqr2.f
   dlabad.f
   dlacon.f


### PR DESCRIPTION
This fixes the CI build on Ubuntu. For some reason CMake is no longer finding BLAS/LAPACK, so this PR finishes the CMake scripts for the versions in the `OTHER/` directory. Everything was already setup to fallback to these, so none of the main CMake scripts had to be changed. It may also be good to configure the Ubuntu build to compile against system-provided BLAS/LAPACK. To this end, we could add something like the following to the `.yml` file:
```yml
  - name: Install BLAS and LAPACK
    run:  sudo apt-get install libblas-dev liblapack-dev
```

**Edit** Ubuntu build is working again, it may have been a problem on GitHub's end. This pull request is still useful however, as it will allow builds when BLAS and LAPACK are not installed.