### PR TITLE
Allowing Newmark to accept gamma, beta or deltaT = 0.0 when -form A is used + bug fix to KRAlpha

### DIFF
--- a/SRC/analysis/integrator/KRAlphaExplicit.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit.cpp
@@ -151,10 +151,13 @@ int KRAlphaExplicit::newStep(double _deltaT)
         return -2;
     }
     
-    if (initAlphaMatrices || _deltaT != deltaT)  {
-        
+    // initialize the integration matrices
+    if (_deltaT != deltaT) {
         // update time step increment
         deltaT = _deltaT;
+        initAlphaMatrices = 1;
+    }
+    if (initAlphaMatrices)  {
         if (deltaT <= 0.0)  {
             opserr << "WARNING KRAlphaExplicit::newStep() - error in variable\n";
             opserr << "dT = " << deltaT << endln;

--- a/SRC/analysis/integrator/KRAlphaExplicit_TP.cpp
+++ b/SRC/analysis/integrator/KRAlphaExplicit_TP.cpp
@@ -140,10 +140,12 @@ int KRAlphaExplicit_TP::newStep(double _deltaT)
     }
     
     // initialize the integration matrices
-    if (initAlphaMatrices || _deltaT != deltaT)  {
-        
+    if (_deltaT != deltaT) {
         // update time step increment
         deltaT = _deltaT;
+        initAlphaMatrices = 1;
+    }
+    if (initAlphaMatrices)  {
         if (deltaT <= 0.0)  {
             opserr << "WARNING KRAlphaExplicit_TP::newStep() - error in variable\n";
             opserr << "dT = " << deltaT << endln;

--- a/SRC/analysis/integrator/Newmark.cpp
+++ b/SRC/analysis/integrator/Newmark.cpp
@@ -224,7 +224,7 @@ int Newmark::newStep(double deltaT)
         // set the trial response quantities
         theModel->setVel(*Udot);
         theModel->setAccel(*Udotdot);
-    } if (displ == 2) {
+    } else if (displ == 2) {
         // determine new displacements and accelerations at t+deltaT
         double a1 = deltaT * deltaT * (0.5 - beta / gamma);
         U->addVector(1.0, *Utdot, deltaT);

--- a/SRC/analysis/integrator/Newmark.cpp
+++ b/SRC/analysis/integrator/Newmark.cpp
@@ -104,7 +104,7 @@ OPS_Newmark(void)
 
 Newmark::Newmark(int classTag)
     : TransientIntegrator(classTag),
-      displ(true), gamma(0), beta(0), 
+      displ(1), gamma(0), beta(0), 
       c1(0.0), c2(0.0), c3(0.0), 
       Ut(0), Utdot(0), Utdotdot(0), U(0), Udot(0), Udotdot(0),
       determiningMass(false),
@@ -116,7 +116,7 @@ Newmark::Newmark(int classTag)
 }
 
 
-Newmark::Newmark(double _gamma, double _beta, bool dispFlag, bool aflag, int classTag_)
+Newmark::Newmark(double _gamma, double _beta, int dispFlag, bool aflag, int classTag_)
     : TransientIntegrator(classTag_),
       displ(dispFlag), gamma(_gamma), beta(_beta), 
       c1(0.0), c2(0.0), c3(0.0), 
@@ -211,7 +211,7 @@ int Newmark::newStep(double deltaT)
     (*Utdot) = *Udot;  
     (*Utdotdot) = *Udotdot;
     
-    if (displ == 1 || displ == 2)  {    
+    if (displ == 1)  {    
         // determine new velocities and accelerations at t+deltaT
         double a1 = (1.0 - gamma/beta); 
         double a2 = (deltaT)*(1.0 - 0.5*gamma/beta);
@@ -223,6 +223,18 @@ int Newmark::newStep(double deltaT)
 
         // set the trial response quantities
         theModel->setVel(*Udot);
+        theModel->setAccel(*Udotdot);
+    } if (displ == 2) {
+        // determine new displacements and accelerations at t+deltaT
+        double a1 = deltaT * deltaT * (0.5 - beta / gamma);
+        U->addVector(1.0, *Utdot, deltaT);
+        U->addVector(1.0, *Utdotdot, a1);
+
+        double a2 = 1.0 - 1.0 / gamma;
+        Udotdot->addVector(0.0, *Utdotdot, a2);
+
+        // set the trial response quantities
+        theModel->setDisp(*U);
         theModel->setAccel(*Udotdot);
     } else  {
         // determine new displacements and velocities at t+deltaT      

--- a/SRC/analysis/integrator/Newmark.cpp
+++ b/SRC/analysis/integrator/Newmark.cpp
@@ -156,13 +156,13 @@ Newmark::~Newmark()
 
 int Newmark::newStep(double deltaT)
 {
-    if (beta == 0 || gamma == 0)  {
+    if ((beta == 0 || gamma == 0) && displ != 3)  {
         opserr << "Newmark::newStep() - error in variable\n";
         opserr << "gamma = " << gamma << " beta = " << beta << endln;
         return -1;
     }
     
-    if (deltaT <= 0.0)  {
+    if (deltaT < 0.0 || (displ != 3 && deltaT == 0.0))  {
         opserr << "Newmark::newStep() - error in variable\n";
         opserr << "dT = " << deltaT << endln;
         return -2;	
@@ -593,7 +593,8 @@ int Newmark::formEleResidual(FE_Element* theEle)
 	// So, the constants can be computed as follows:
 	if (displ != 1) {
 	    opserr << "ERROR: Newmark::formEleResidual() -- the implemented"
-		   << " scheme only works if the displ variable is set to true." << endln;
+		   << " scheme only works if the displ variable is set to 1." << endln;
+        return 0;
 	}
 	double a2 = -c3;
 	double a3 = -c2/gamma;
@@ -698,6 +699,12 @@ Newmark::formNodUnbalance(DOF_Group *theDof)
 
     }
     else {  // ASSEMBLE ALL TERMS
+
+    if (displ != 1) {
+	    opserr << "ERROR: Newmark::formNodUnbalance() -- the implemented"
+		   << " scheme only works if the displ variable is set to 1." << endln;
+        return 0;
+	}
 
 	theDof->zeroUnbalance();
 
@@ -831,6 +838,12 @@ Newmark::formIndependentSensitivityRHS()
 int 
 Newmark::saveSensitivity(const Vector & vNew,int gradNum,int numGrads)
 {
+
+    if (displ != 1) {
+	    opserr << "ERROR: Newmark::saveSensitivity() -- the implemented"
+		   << " scheme only works if the displ variable is set to 1." << endln;
+        return 0;
+	}
 
     // Compute Newmark parameters in general notation
     double a1 = c3;

--- a/SRC/analysis/integrator/Newmark.h
+++ b/SRC/analysis/integrator/Newmark.h
@@ -48,7 +48,7 @@ class Newmark : public TransientIntegrator
 public:
     // constructors
     Newmark(int classTag=INTEGRATOR_TAGS_Newmark);
-    Newmark(double gamma, double beta, bool disp = true, bool aflag=false, int classTag=INTEGRATOR_TAGS_Newmark);
+    Newmark(double gamma, double beta, int disp = 1, bool aflag=false, int classTag=INTEGRATOR_TAGS_Newmark);
 
     // destructor
     ~Newmark();


### PR DESCRIPTION
## Changes to `Newmark`
This PR modifies `Newmark` to accept `gamma`, `beta` or `deltaT = 0.0` when `-form A` is passed as argument, addressing #1529. This makes the integrator more general. Potential uses include:

1. Computing the initial acceleration given initial displacement and velocity conditions, or pulse like forces.
```python
# define model with initial conditions and loads

# solve for acceleration at t = 0.0
ops.integrator("Newmark", 0.5, 0.25, "-form", "A")
ops.analysis("Transient")
ops.analyze(1, 0.0)
ops.wipeAnalysis() 

# continue with the main analysis
```
2. Turning Newmark into its explicit version by setting `beta = 0.0`, which is numerically equivalent to the `CentralDifference` method.
```python
# Option 1 (documented):
ops.integrator("Newmark", 0.5, 0.0, "-form", "A") 
# Option 2 (not documented):
ops.integrator("NewmarkExplicit", 0.5) 
```
Additionally, I fixed a bug in the `Newmark` constructor definition that mishandled the `dispFlag` set by the user as a `bool` rather than an `int`. This bug forced `Newmark` to always run the `-form D` implementation regardless of the arguments set by the user.

I have tested these changes with both a single- and a multiple-degree-of-freedom model. Some examples for an elastic SDOF system are provided below, where the exact solution is depicted in gray for reference. A relatively large value of `deltaT` was used to make differences more evident.

| Default `Newmark` | `Newmark` `-form A` |
|---------|---------|
| ![image](https://github.com/user-attachments/assets/6e6d55bd-5c43-4cf8-9595-f49b1ba4645b) | ![image](https://github.com/user-attachments/assets/cb177e9b-e431-45db-a1c0-00e8e517f55e) |

| `Newmark` with `beta = 0.0` | `NewmarkExplicit` |
|---------|---------|
| ![image](https://github.com/user-attachments/assets/7bea370d-86d6-4e49-ba6f-20f06d22c4ac) | ![image](https://github.com/user-attachments/assets/a670c954-daa3-4a9f-b783-dcb94b0c0af0) |

## Changes to `KRAlphaExplicit`
I fixed a bug that I had introduced in the `KRAlphaExplicit` integrator, which caused `newStep()` not to update the method's `alpha` matrices when `deltaT` was updated. This went unnoticed because `KRAlphaExplicit` is an explicit integrator, making changes to `deltaT` during an analysis less common. I included this fix in this PR as it involved only a minor code change.