### PR TITLE
Fixes for Node XMLRecorder

### DIFF
--- a/SRC/recorder/EnvelopeNodeRecorder.cpp
+++ b/SRC/recorder/EnvelopeNodeRecorder.cpp
@@ -1169,7 +1169,7 @@ EnvelopeNodeRecorder::initialize(void)
 	theHandler->endTag();
       }
 
-      sprintf(outputData, "%s%d", dataType, j+1);
+      sprintf(outputData, "%s%d", dataType, (*theDofs)(j)+1);
       theHandler->tag("ResponseType",outputData);
     }
 

--- a/SRC/recorder/NodeRecorder.cpp
+++ b/SRC/recorder/NodeRecorder.cpp
@@ -1287,7 +1287,7 @@ NodeRecorder::initialize(void)
     }
 
     for (int k=0; k<theDofs->Size(); k++) {
-      sprintf(outputData, "%s%d", dataType, k+1);
+      sprintf(outputData, "%s%d", dataType, (*theDofs)(k)+1);
       theOutputHandler->tag("ResponseType",outputData);
     }
 

--- a/SRC/recorder/NodeRecorder.cpp
+++ b/SRC/recorder/NodeRecorder.cpp
@@ -1264,11 +1264,9 @@ NodeRecorder::initialize(void)
   sprintf(nodeCrdData,"coord");
 
   if (echoTimeFlag == true) {
-    if (theNodalTags != 0 && addColumnInfo == 1) {
       theOutputHandler->tag("TimeOutput");
       theOutputHandler->tag("ResponseType", "time");
       theOutputHandler->endTag();
-    }
   }
 
   for (int i=0; i<numValidNodes; i++) {


### PR DESCRIPTION
1. Fix missing TimeOutput tag from XML format Node recorder.
    -> Please confirm the necessity of addColumnInfo before merging. I could not find its purpose.
2. Fix incorrect DOF number in XML ResponseType label.

Compare output of nodeDispY.xml from the test script below:

```model BasicBuilder -ndm 2 -ndf 3;
uniaxialMaterial Elastic 130 725000 0 29;
uniaxialMaterial Steel02 121 63 29000 0.0105746 18 0.925 0.15 0 1 0 1 0;
uniaxialMaterial Series 131 130 121; 
node	1	0.0 0.0;
node	2	1.0 0.0;
fix		1	1 1 1;
fix		2	0 1 1;
element truss 1	1	2	1	131;

set dt	1.0
set dispTag		22
set pathTSTag	22
timeSeries Trig 		$pathTSTag	0.0 [expr 2.0*acos(-1.0)] 0.25

pattern Plain $dispTag $pathTSTag {
	sp 2 1 0.05;
}


recorder Element -file stressOut.txt			-ele	1	axialForce
recorder Element -file strainOut.txt			-ele	1	deformations
recorder Element -xml  strains.xml				-ele	1	material 1 strains
recorder Node 	 -xml  nodeDispX.xml		-time 	-node	1 2	-dof 1 disp
recorder Node 	 -xml  nodeDispY.xml		-time 	-node	1 2	-dof 2 disp
record
constraints Transformation;
numberer Plain
system UmfPack;
test NormDispIncr  1.0e-6 100
algorithm Newton;
integrator LoadControl 0.001;
analysis Static
for {set stepCtr 1} {$stepCtr<=999} {incr stepCtr} {
	set ok [analyze 1];
	if {$ok!=0} {break;};
}
puts $ok
