### PR TITLE
element api fix, re-enabling ops_TheActiveDomain

### DIFF
--- a/SRC/api/win32Functions.cpp
+++ b/SRC/api/win32Functions.cpp
@@ -41,7 +41,7 @@ BOOL APIENTRY DllMain(HANDLE hModule,
 
 OPS_Stream* opserrPtr = 0;
 SimulationInformation* theSimulationInfo = 0;
-//Domain *ops_TheActiveDomain = 0;
+Domain *ops_TheActiveDomain = 0;
 
 typedef int(*OPS_ErrorPtrType)(char*, int);
 typedef int(*OPS_GetNumRemainingInputArgsType)();


### PR DESCRIPTION
Fixing issue in element API by re-enabling ops_TheActiveDomain.
Actually, all the functions related to the domain returned 0.
This is also generally required to compile against fortran elements.