### PR TITLE
linking-missing-uniaxial-materials

### DIFF
--- a/Win32/proj/material/material.vcxproj
+++ b/Win32/proj/material/material.vcxproj
@@ -270,6 +270,8 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMP.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMPF.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\DuctileFracture.cpp" />
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\QbSandCPT.cpp" />
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\TzSandCPT.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.cpp" />
@@ -696,6 +698,8 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMP.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMPF.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\DuctileFracture.h" />
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\QbSandCPT.h" />
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\TzSandCPT.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.h" />

--- a/Win32/proj/material/material.vcxproj.filters
+++ b/Win32/proj/material/material.vcxproj.filters
@@ -373,6 +373,12 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\pyUCLA.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\QbSandCPT.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\TzSandCPT.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\fedeas\FedeasBond1Material.cpp">
       <Filter>uniaxial\fedeas</Filter>
     </ClCompile>
@@ -1637,6 +1643,12 @@
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\pyUCLA.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\QbSandCPT.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\SRC\material\uniaxial\TzSandCPT.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\fedeas\FedeasBond1Material.h">

--- a/Win64/proj/material/material.vcxproj
+++ b/Win64/proj/material/material.vcxproj
@@ -414,6 +414,8 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelFractureDI.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMP.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\SteelMPF.cpp" />
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\QbSandCPT.cpp" />
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\TzSandCPT.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.cpp" />
     <ClCompile Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.cpp" />
@@ -860,6 +862,8 @@
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelFractureDI.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMP.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\SteelMPF.h" />
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\QbSandCPT.h" />
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\TzSandCPT.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\ConstantStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\DuctilityStiffnessDegradation.h" />
     <ClInclude Include="..\..\..\SRC\material\uniaxial\stiffness\EnergyStiffnessDegradation.h" />

--- a/Win64/proj/material/material.vcxproj.filters
+++ b/Win64/proj/material/material.vcxproj.filters
@@ -379,6 +379,12 @@
     <ClCompile Include="..\..\..\SRC\material\uniaxial\pyUCLA.cpp">
       <Filter>uniaxial</Filter>
     </ClCompile>
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\QbSandCPT.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
+	<ClCompile Include="..\..\..\SRC\material\uniaxial\TzSandCPT.cpp">
+      <Filter>uniaxial</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\SRC\material\uniaxial\fedeas\FedeasBond1Material.cpp">
       <Filter>uniaxial\fedeas</Filter>
     </ClCompile>
@@ -1802,6 +1808,12 @@
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\pyUCLA.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\QbSandCPT.h">
+      <Filter>uniaxial</Filter>
+    </ClInclude>
+	<ClInclude Include="..\..\..\SRC\material\uniaxial\TzSandCPT.h">
       <Filter>uniaxial</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\SRC\material\uniaxial\fedeas\FedeasBond1Material.h">


### PR DESCRIPTION
Dear @mhscott and @fmckenna,

The compilation fails in Visual Studio (Win32/Win64) due to missing vcxproj links for the QbSandCPT and TzSandCPT uniaxial materials.

**Fix:**
Added missing .h and .cpp file links to:

material.vcxproj
material.vcxproj.filters

**Files linked:**
QbSandCPT.h, QbSandCPT.cpp
TzSandCPT.h, TzSandCPT.cpp

Compilation in Visual Studio is now successful after this fix.

Best regards,
Deniz