### PR TITLE
Allow quad mesh generator to work with two-node line meshes

### DIFF
--- a/SRC/element/PFEMElement/QuadMeshGenerator.cpp
+++ b/SRC/element/PFEMElement/QuadMeshGenerator.cpp
@@ -127,7 +127,7 @@ QuadMeshGenerator::mesh(double size)
     }
 
     // create points
-    if (m<=1 || n<=1) return 0;
+    if (m<1 || n<1) return 0;
     Matrix grid(m+1, n+1);
 
     for (int i=0; i<m+1; ++i) {


### PR DESCRIPTION
This PR corrects an issue in the quad mesh generator where it prematurely exited and failed to populate `quadout` (the quad nodal connectivity) if any input line mesh had only two nodes (a single segment). The underlying meshing logic is fully capable of handling two-node line meshes as well, so this change simply relaxes that unnecessary early exit condition.