### PR TITLE
Fix memory leak in ElementStateParameter

### DIFF
--- a/SRC/domain/component/ElementStateParameter.cpp
+++ b/SRC/domain/component/ElementStateParameter.cpp
@@ -35,7 +35,7 @@ ElementStateParameter::ElementStateParameter(int tag, double value,
   :Parameter(tag,PARAMETER_TAG_ElementStateParameter),
    currentValue(value),
    flag(Flag),
-   argc(Argc), fromFree(1)
+   argc(Argc), fromFree(0)    // We own memory if this constructor is called
 {
   if (theEle != 0)
     theEleIDs = new ID(*theEle);
@@ -53,7 +53,7 @@ ElementStateParameter::ElementStateParameter()
   :Parameter(0,PARAMETER_TAG_ElementStateParameter),
    currentValue(0.0),
    theEleIDs(0), flag(0),
-   argv(0), argc(0), fromFree(1)
+   argv(0), argc(0), fromFree(0)
 {
 
 }
@@ -195,7 +195,7 @@ ElementStateParameter::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBr
   theChannel.recvVector(commitTag, 0, dData);
   currentValue = dData(0);
 
-  fromFree = 1;
+  fromFree = 0;
 
   if (theEleIDs != 0) 
     delete theEleIDs;

--- a/SRC/domain/component/ElementStateParameter.cpp
+++ b/SRC/domain/component/ElementStateParameter.cpp
@@ -60,16 +60,16 @@ ElementStateParameter::ElementStateParameter()
 
 ElementStateParameter::~ElementStateParameter()
 {
-  if (fromFree == 0) {
+  if (fromFree==0)
+  {
     if (argc != 0) {
       for (int i=0; i<argc; i++)
-	delete argv[i];
-
+        delete [] argv[i];
       delete [] argv;
-      
-      if (theEleIDs != 0)
-	delete theEleIDs;
     }
+
+    if (theEleIDs != 0)
+      delete theEleIDs;
   }
 }
 

--- a/SRC/recorder/Makefile
+++ b/SRC/recorder/Makefile
@@ -23,7 +23,9 @@ OBJS       = Recorder.o \
 	RemoveRecorder.o \
 	DamageRecorder.o $(GRAPHIC_OBJECTS) \
 	PVDRecorder.o MPCORecorder.o GmshRecorder.o \
-	VTK_Recorder.o
+	VTK_Recorder.o \
+	VTKHDF_Recorder.o 
+
 
 
 # Compilation control


### PR DESCRIPTION
Hi,

This commit fixes a memory leak in `ElementStateParameter`. There is a `fromFree` variable that is supposed to handle the case when memory ownership is external, but it is always set to 1 (which disables freeing memory in the destructor); however, the class always owns its memory. I decided to remove the `fromFree` variable altogether and maintain the behavior of always owning the memory. 

JAA