### PR TITLE
Editing makefile for Ubuntu and adding HOME directory

### DIFF
--- a/MAKES/Makefile.def.EC2-UBUNTU
+++ b/MAKES/Makefile.def.EC2-UBUNTU
@@ -89,6 +89,9 @@ RELIABILITY_FLAG = -D_RELIABILITY
 # remove the directory from DIRS.
 
 BASE		= ./usr/local
+# Uncomment the HOME directory and if OpnSees is cloned to the 
+# path /home/ubuntu/OpenSees the HOME directory should be /home/ubuntu
+# HOME		= /home/ubuntu
 FE		= $(HOME)/OpenSees/SRC
 
 AMDdir       = $(HOME)/OpenSees/OTHER/AMD

--- a/MAKES/Makefile.def.Ubuntu20.04
+++ b/MAKES/Makefile.def.Ubuntu20.04
@@ -62,6 +62,9 @@ RELIABILITY = NO_RELIABILITY
 # remove the directory from DIRS.
 
 BASE		= ./usr/local
+# Uncomment the HOME directory and if OpnSees is cloned to the 
+# path /home/ubuntu/OpenSees the HOME directory should be /home/ubuntu
+# HOME		= /home/ubuntu
 FE		= $(HOME)/OpenSees/SRC
 
 AMDdir       = $(HOME)/OpenSees/OTHER/AMD


### PR DESCRIPTION
It seems that the HOME directory in the Makefile for Ubuntu (both for Ubuntu 20.04 and EC2) was missing. I could find it out from the Debian Makefile. I added this line as a comment. I also added the description on how to uncomment and the path it should point to. I can compile on my Ubuntu machine successfully.