### PR TITLE
Add PythonSparse interface for Python-based linear and eigen solvers

### DIFF
--- a/EXAMPLES/SolverBenchmark/benchmark_python_sparse.py
+++ b/EXAMPLES/SolverBenchmark/benchmark_python_sparse.py
@@ -341,24 +341,15 @@ def main():
         ("CuPyCG", setup_cupy_cg, "RCM"),
     ]
 
-    # Known problematic solver/mesh factor combinations that cause segmentation faults or are too large
-    # Format: (solver_name, mesh_factor)
-    SKIP_COMBINATIONS = {
-        ("UmfPack", 14.0),
-        ("UmfPack", 16.0),
-        ("UmfPack", 18.0),
-        ("UmfPack", 20.0),
-        ("UmfPack", 22.0),
-        ("UmfPack", 24.0),
-        ("UmfPack", 26.0),
-        ("BandSPD", 20.0),
-        ("BandSPD", 22.0),
-        ("BandSPD", 24.0),
-        ("BandSPD", 26.0),
+    # Known problematic solver/mesh factor thresholds that cause segmentation faults or are too large
+    # Format: solver_name -> mesh_factor limit (skip if mesh_factor >= limit)
+    SKIP_LIMITS = {
+        "UmfPack": 14.0,
+        "BandSPD": 20.0,
     }
 
     # Mesh refinement factors
-    mesh_factors = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0]
+    mesh_factors = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0]
 
     print("\n=== Python Sparse Solver Benchmark ===")
     print(f"Comparing: {[s[0] for s in solvers]}")
@@ -374,8 +365,9 @@ def main():
             mesh_info_printed = False
 
             for solver_name, solver_setup, numberer in solvers:
-                # Skip known problematic combinations
-                if (solver_name, mesh_factor) in SKIP_COMBINATIONS:
+                # Skip if mesh_factor exceeds the limit for this solver
+                limit = SKIP_LIMITS.get(solver_name, float('inf'))
+                if mesh_factor >= limit:
                     # Write skipped row
                     writer.writerow((
                         solver_name,

--- a/EXAMPLES/SolverBenchmark/benchmark_python_sparse.py
+++ b/EXAMPLES/SolverBenchmark/benchmark_python_sparse.py
@@ -1,0 +1,465 @@
+"""
+Simple benchmark comparing CuPyCG solver with native OpenSees solvers.
+
+Model geometry from Michael H. Scott's blog post:
+https://portwooddigital.com/2021/12/19/three-dimensional-meshing/
+
+
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+
+# Import OpenSeesPy
+SCRIPT_PATH = Path(__file__).resolve()
+FILENAME = SCRIPT_PATH.name
+SCRIPT_DIR = SCRIPT_PATH.parent
+REPO_ROOT = SCRIPT_PATH.parents[2]
+OPENSEESPY_BUILD = REPO_ROOT / "build"
+print(f"[{FILENAME}] Importing OpenSeesPy from: {OPENSEESPY_BUILD}")
+sys.path.append(str(OPENSEESPY_BUILD))
+import opensees as ops
+
+# Import CuPy for GPU solvers
+import cupy as cp
+import cupyx.scipy.sparse.linalg
+
+
+# -----------------------------------------------------------------------------
+# CuPy CG Solver Definition
+# -----------------------------------------------------------------------------
+
+
+class CuPyCGSolver:
+    """CuPy-based conjugate gradient solver for linear systems."""
+    
+    def __init__(self, rtol=1e-5, atol=1e-12, maxiter=None):
+        self.rtol = rtol
+        self.atol = atol
+        self.maxiter = maxiter
+        self.A = None  # Cache the sparse matrix
+    
+    def solve(self, **kwargs):
+        # Extract buffers from kwargs
+        index_ptr: memoryview = kwargs['index_ptr']  # int32, read-only memoryview
+        indices: memoryview = kwargs['indices']  # int32, read-only memoryview
+        values: memoryview = kwargs['values']  # float64, read-only memoryview
+        rhs: memoryview = kwargs['rhs']  # float64, read-only memoryview
+        x: memoryview = kwargs['x']  # float64, writeable memoryview
+        num_eqn: int = kwargs['num_eqn']
+        nnz: int = kwargs['nnz']
+        matrix_status: str = kwargs['matrix_status']  # UNCHANGED, STRUCTURE_CHANGED, COEFFICIENTS_CHANGED
+        
+        # Wrap memoryviews using zero-copy numpy views
+        indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
+        idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
+        vals = np.frombuffer(values, dtype=np.float64, count=nnz)
+        
+        # Rebuild matrix if structure changed, update values if coefficients changed
+        if matrix_status == 'STRUCTURE_CHANGED' or self.A is None:
+            # Copy the entire CSR matrix to the GPU
+            values_gpu = cp.asarray(vals)
+            indices_gpu = cp.asarray(idx)
+            index_ptr_gpu = cp.asarray(indptr)
+            self.A = cp.sparse.csr_matrix((values_gpu, indices_gpu, index_ptr_gpu), shape=(num_eqn, num_eqn))
+        elif matrix_status == 'COEFFICIENTS_CHANGED':
+            # Update the values of the CSR matrix on the GPU
+            values_gpu = cp.asarray(vals)
+            self.A.data[:] = values_gpu  # in-place update
+        else:
+            # If UNCHANGED, do nothing
+            pass
+        
+        # Wrap RHS for solving
+        rhs_buf = np.frombuffer(rhs, dtype=np.float64, count=num_eqn)
+        rhs_gpu = cp.asarray(rhs_buf)
+        
+        # Solve using conjugate gradient (without preconditioning) on the GPU
+        x_gpu, info = cupyx.scipy.sparse.linalg.cg(self.A, rhs_gpu, tol=self.rtol, atol=self.atol, maxiter=self.maxiter)
+        
+        # Copy result back to CPU buffer
+        x_buf = np.frombuffer(x, dtype=np.float64, count=num_eqn)
+        x_buf[:] = cp.asnumpy(x_gpu)  # in-place update
+        return -int(info)  # Return the info from the solver
+
+
+# -----------------------------------------------------------------------------
+# Model Geometry and Material Properties
+# -----------------------------------------------------------------------------
+
+BAR_LENGTH = 10.0  # inches
+BAR_HEIGHT = 2.0  # inches
+BAR_THICKNESS = 1.0  # inches
+
+ELASTIC_MODULUS = 29_000.0  # kip / in^2
+POISSON_RATIO = 0.3
+STEEL_DENSITY = 0.284e-3 / 386.4  # kip s^2 / in^4
+YIELD_STRESS = 50.0  # kip / in^2
+
+# -----------------------------------------------------------------------------
+# Model Building Functions
+# -----------------------------------------------------------------------------
+
+
+def build_solid_bar_model(nx: int, ny: int, nz: int) -> None:
+    """Create a structured hexahedral mesh using block3D."""
+    ops.wipe()
+    ops.model("basic", "-ndm", 3, "-ndf", 3)
+    ops.nDMaterial("ElasticIsotropic", 1, ELASTIC_MODULUS, POISSON_RATIO, STEEL_DENSITY)
+
+    eleType = "stdBrick"
+    eleArgs = 1
+    ops.block3D(
+        nx, ny, nz, 1, 1, eleType, eleArgs,
+        1, 0.0, -BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        2, BAR_LENGTH, -BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        3, BAR_LENGTH, BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        4, 0.0, BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        5, 0.0, -BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        6, BAR_LENGTH, -BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        7, BAR_LENGTH, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        8, 0.0, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+    )
+
+    ops.fixX(0.0, 1, 1, 1)
+
+
+def apply_load_pattern(total_load: float) -> None:
+    """Apply a vertical load to all nodes on the free face."""
+    tStart, tEnd, period = 0.0, 6.0, 4.0
+    ops.timeSeries('Trig', 1, tStart, tEnd, period, '-factor', 1.0)
+    ops.pattern("Plain", 1, 1)
+    far_x_nodes = [
+        node for node in ops.getNodeTags()
+        if math.isclose(ops.nodeCoord(node, 1), BAR_LENGTH, abs_tol=1e-9)
+    ]
+    if not far_x_nodes:
+        raise ValueError("No nodes found on the far face (x = BAR_LENGTH)")
+    load_per_node = total_load / len(far_x_nodes)
+    for node in far_x_nodes:
+        ops.load(node, 0.0, 0.0, -load_per_node)
+
+
+# -----------------------------------------------------------------------------
+# Analysis Configuration
+# -----------------------------------------------------------------------------
+
+
+def configure_static_analysis(solver_setup: Callable[[], None], numberer: str, num_steps: int, tol: float, max_iter: int) -> None:
+    """Configure the analysis for a given solver."""
+    ops.constraints("Plain")
+    ops.numberer(numberer)
+    solver_setup()
+    ops.integrator("LoadControl", 1.0 / num_steps)
+    ops.test("NormUnbalance", tol, max_iter)
+    ops.algorithm("ModifiedNewton", "-FactorOnce")
+    ops.analysis("Static")
+
+
+# -----------------------------------------------------------------------------
+# Solver Setup Functions
+# -----------------------------------------------------------------------------
+
+
+def setup_bandspd() -> None:
+    """Setup BandSPD solver."""
+    ops.system("BandSPD")
+
+
+def setup_umfpack() -> None:
+    """Setup UmfPack solver."""
+    ops.system("UmfPack")
+
+
+def setup_cupy_cg() -> None:
+    """Setup CuPy CG solver."""
+    solver = CuPyCGSolver(rtol=1.0e-7, atol=1.0e-12, maxiter=None)
+    ops.system("PythonSparse", {"solver": solver, "scheme": "CSR"})
+
+
+# -----------------------------------------------------------------------------
+# Benchmark Data Structures
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class BenchmarkRow:
+    solver_name: str
+    mesh_factor: float
+    mesh_size: float
+    num_elements: int
+    num_nodes: int
+    num_equations: int
+    status: int
+    time_seconds: float
+    displacement_x: Optional[float] = None
+    displacement_y: Optional[float] = None
+    displacement_z: Optional[float] = None
+
+
+CSV_HEADER = (
+    "solver",
+    "mesh_factor",
+    "mesh_c",
+    "num_elements",
+    "num_nodes",
+    "num_equations",
+    "status",
+    "time_seconds",
+    "displacement_x",
+    "displacement_y",
+    "displacement_z",
+)
+
+
+# -----------------------------------------------------------------------------
+# Utility Functions
+# -----------------------------------------------------------------------------
+
+
+def counts_from_mesh_factor(factor: float) -> Tuple[float, Tuple[int, int, int]]:
+    """Return mesh size and brick counts for a given refinement factor."""
+    mesh_size = BAR_THICKNESS / factor
+
+    def count(dim: float) -> int:
+        return max(1, int(math.ceil(dim / mesh_size)))
+
+    return mesh_size, (count(BAR_LENGTH), count(BAR_THICKNESS), count(BAR_HEIGHT))
+
+
+# -----------------------------------------------------------------------------
+# Benchmark Execution
+# -----------------------------------------------------------------------------
+
+
+def run_benchmark(
+    solver_name: str,
+    solver_setup: Callable[[], None],
+    numberer: str,
+    mesh_factor: float,
+    mesh_size: float,
+    counts: Tuple[int, int, int],
+    num_steps: int = 5,
+    tol: float = 1.0e-7,
+    max_iter: int = 50,
+) -> BenchmarkRow:
+    """Run benchmark for a single solver and mesh configuration."""
+    nx, ny, nz = counts
+    build_solid_bar_model(nx, ny, nz)
+
+    # Calculate load
+    total_load = 1.25 * YIELD_STRESS * (BAR_THICKNESS * BAR_HEIGHT**2) / (6 * BAR_LENGTH)
+    apply_load_pattern(total_load)
+
+    # Static analysis
+    configure_static_analysis(solver_setup, numberer, num_steps, tol, max_iter)
+    start_time = time.perf_counter()
+    status = ops.analyze(num_steps)
+    time_seconds = time.perf_counter() - start_time
+
+    # Get system information
+    num_elements = len(ops.getEleTags())
+    num_nodes = len(ops.getNodeTags())
+    try:
+        neq = ops.systemSize()
+    except AttributeError:
+        neq = -1
+
+    # Get displacement at far corner
+    displacement = None
+    if status == 0:
+        for node in ops.getNodeTags():
+            x = ops.nodeCoord(node, 1)
+            y = ops.nodeCoord(node, 2)
+            z = ops.nodeCoord(node, 3)
+            if np.isclose(
+                [x, y, z],
+                [BAR_LENGTH, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0],
+                atol=1e-9,
+            ).all():
+                dx = ops.nodeDisp(node, 1)
+                dy = ops.nodeDisp(node, 2)
+                dz = ops.nodeDisp(node, 3)
+                displacement = (dx, dy, dz)
+                break
+
+    if displacement is not None:
+        dx, dy, dz = displacement
+    else:
+        dx = dy = dz = None
+
+    return BenchmarkRow(
+        solver_name=solver_name,
+        mesh_factor=mesh_factor,
+        mesh_size=mesh_size,
+        num_elements=num_elements,
+        num_nodes=num_nodes,
+        num_equations=neq,
+        status=status,
+        time_seconds=time_seconds,
+        displacement_x=dx,
+        displacement_y=dy,
+        displacement_z=dz,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Main Function
+# -----------------------------------------------------------------------------
+
+
+def main():
+    """Run benchmarks and output CSV."""
+    if len(sys.argv) < 2:
+        print(f"Usage: python {FILENAME} <output.csv>")
+        sys.exit(1)
+
+    # Handle output CSV path: if simple filename, store in script directory
+    output_arg = sys.argv[1]
+    if '/' not in output_arg and '\\' not in output_arg:
+        # Simple filename, store in script directory
+        output_csv = SCRIPT_DIR / output_arg
+    else:
+        # Path provided, use as-is
+        output_csv = Path(output_arg)
+    
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    # Solver configurations: (name, setup_function, numberer)
+    solvers = [
+        ("BandSPD", setup_bandspd, "RCM"),
+        ("UmfPack", setup_umfpack, "Plain"),
+        ("CuPyCG", setup_cupy_cg, "RCM"),
+    ]
+
+    # Known problematic solver/mesh factor combinations that cause segmentation faults or are too large
+    # Format: (solver_name, mesh_factor)
+    SKIP_COMBINATIONS = {
+        ("UmfPack", 14.0),
+        ("UmfPack", 16.0),
+        ("UmfPack", 18.0),
+        ("UmfPack", 20.0),
+        ("UmfPack", 22.0),
+        ("UmfPack", 24.0),
+        ("UmfPack", 26.0),
+        ("BandSPD", 20.0),
+        ("BandSPD", 22.0),
+        ("BandSPD", 24.0),
+        ("BandSPD", 26.0),
+    }
+
+    # Mesh refinement factors
+    mesh_factors = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0]
+
+    print("\n=== Python Sparse Solver Benchmark ===")
+    print(f"Comparing: {[s[0] for s in solvers]}")
+    print(f"Mesh factors: {mesh_factors}")
+    print(f"Results will be written to: {output_csv}\n")
+
+    with output_csv.open("w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(CSV_HEADER)
+
+        for mesh_factor in mesh_factors:
+            mesh_size, counts = counts_from_mesh_factor(mesh_factor)
+            mesh_info_printed = False
+
+            for solver_name, solver_setup, numberer in solvers:
+                # Skip known problematic combinations
+                if (solver_name, mesh_factor) in SKIP_COMBINATIONS:
+                    # Write skipped row
+                    writer.writerow((
+                        solver_name,
+                        mesh_factor,
+                        mesh_size,
+                        -1,  # num_elements
+                        -1,  # num_nodes
+                        -1,  # num_equations
+                        -999,  # status
+                        float("nan"),
+                        "",
+                        "",
+                        "",
+                    ))
+                    csvfile.flush()
+                    
+                    status_str = "⊘"
+                    # Print mesh info after first solver completes, then its status on one line
+                    if not mesh_info_printed:
+                        print(f"\nMesh factor {mesh_factor:.1f}: (skipped)")
+                        print(f"  Running {solver_name}... {status_str} (skipped - either known segfault or too large)")
+                        mesh_info_printed = True
+                    else:
+                        print(f"  Running {solver_name}... {status_str} (skipped - either known segfault or too large)")
+                    continue
+                
+                try:
+                    # For first solver, don't print "Running..." yet - we'll print it with mesh info
+                    if mesh_info_printed:
+                        print(f"  Running {solver_name}...", end=" ", flush=True)
+                    
+                    row = run_benchmark(
+                        solver_name=solver_name,
+                        solver_setup=solver_setup,
+                        numberer=numberer,
+                        mesh_factor=mesh_factor,
+                        mesh_size=mesh_size,
+                        counts=counts,
+                    )
+                    
+                    writer.writerow((
+                        row.solver_name,
+                        row.mesh_factor,
+                        row.mesh_size,
+                        row.num_elements,
+                        row.num_nodes,
+                        row.num_equations,
+                        row.status,
+                        row.time_seconds,
+                        row.displacement_x if row.displacement_x is not None else "",
+                        row.displacement_y if row.displacement_y is not None else "",
+                        row.displacement_z if row.displacement_z is not None else "",
+                    ))
+                    csvfile.flush()
+                    
+                    status_str = "✓" if row.status == 0 else "✗"
+                    # Print mesh info after first solver completes, then its status on one line
+                    if not mesh_info_printed:
+                        print(f"\nMesh factor {mesh_factor:.1f}: {row.num_elements} elements, {row.num_nodes} nodes, {row.num_equations} equations")
+                        print(f"  Running {solver_name}... {status_str} ({row.time_seconds:.3f}s)")
+                        mesh_info_printed = True
+                    else:
+                        print(f"{status_str} ({row.time_seconds:.3f}s)")
+                except Exception as e:
+                    print(f"✗ Error: {e}")
+                    # Write error row
+                    writer.writerow((
+                        solver_name,
+                        mesh_factor,
+                        mesh_size,
+                        -1,  # num_elements
+                        -1,  # num_nodes
+                        -1,  # num_equations
+                        -999,  # status
+                        float("nan"),
+                        "",
+                        "",
+                        "",
+                    ))
+                    csvfile.flush()
+
+    print(f"\n✓ Results written to {output_csv}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py
+++ b/EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py
@@ -377,27 +377,14 @@ def main():
         ("SciPyEigsh", run_scipy_eigsh),
     ]
 
-    # Known problematic solver/mesh factor combinations that cause segmentation faults or are too large
-    # Format: (solver_name, mesh_factor)
-    SKIP_COMBINATIONS = {
-        ("fullGenLapack", 4.0),
-        ("fullGenLapack", 6.0),
-        ("fullGenLapack", 8.0),
-        ("fullGenLapack", 10.0),
-        ("fullGenLapack", 12.0),
-        ("fullGenLapack", 14.0),
-        ("fullGenLapack", 16.0),
-        ("fullGenLapack", 18.0),
-        ("fullGenLapack", 20.0),
-        ("fullGenLapack", 22.0),
-        ("fullGenLapack", 24.0),
-        ("fullGenLapack", 26.0),
-        ("fullGenLapack", 28.0),
-        ("fullGenLapack", 30.0),
+    # Known problematic solver/mesh factor thresholds that cause segmentation faults or are too large
+    # Format: solver_name -> mesh_factor limit (skip if mesh_factor >= limit)
+    SKIP_LIMITS = {
+        "fullGenLapack": 4.0,
     }
 
     # Mesh refinement factors
-    mesh_factors = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0]
+    mesh_factors = [1.0, 2.0, 3.0, 4.0]
 
     print("\n=== Python Sparse Eigen Solver Benchmark ===")
     print(f"Comparing: {[s[0] for s in solvers]}")
@@ -413,8 +400,9 @@ def main():
             mesh_info_printed = False
 
             for solver_name, solver_run in solvers:
-                # Skip known problematic combinations
-                if (solver_name, mesh_factor) in SKIP_COMBINATIONS:
+                # Skip if mesh_factor exceeds the limit for this solver
+                limit = SKIP_LIMITS.get(solver_name, float('inf'))
+                if mesh_factor >= limit:
                     # Write skipped row
                     writer.writerow((
                         solver_name,

--- a/EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py
+++ b/EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py
@@ -1,0 +1,534 @@
+"""
+Simple benchmark comparing SciPy eigen solver with native OpenSees eigen solvers.
+
+Model geometry from Michael H. Scott's blog post:
+https://portwooddigital.com/2021/12/19/three-dimensional-meshing/
+
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as sp_linalg
+
+# Import OpenSeesPy
+SCRIPT_PATH = Path(__file__).resolve()
+FILENAME = SCRIPT_PATH.name
+SCRIPT_DIR = SCRIPT_PATH.parent
+REPO_ROOT = SCRIPT_PATH.parents[2]
+OPENSEESPY_BUILD = REPO_ROOT / "build"
+print(f"[{FILENAME}] Importing OpenSeesPy from: {OPENSEESPY_BUILD}")
+sys.path.append(str(OPENSEESPY_BUILD))
+import opensees as ops
+
+
+# -----------------------------------------------------------------------------
+# SciPy Eigen Solver Definition
+# -----------------------------------------------------------------------------
+
+
+class SciPyGeneralizedEigenSolver:
+    """SciPy-based generalized eigenvalue solver."""
+    
+    def __init__(self, maxiter=None, tol=0.0):
+        self.maxiter = maxiter
+        self.tol = tol
+        self._k_matrix = None  # Cache stiffness matrix
+        self._m_matrix = None  # Cache mass matrix
+    
+    def solve(self, **kwargs):
+        # Extract buffers from kwargs
+        index_ptr: memoryview = kwargs['index_ptr']  # int32, read-only
+        indices: memoryview = kwargs['indices']  # int32, read-only
+        k_values: memoryview = kwargs['k_values']  # float64, read-only
+        m_values: memoryview = kwargs['m_values']  # float64, read-only
+        eigenvalues: memoryview = kwargs['eigenvalues']  # float64, writable
+        eigenvectors: memoryview = kwargs['eigenvectors']  # float64, writable (flat buffer)
+        num_eqn: int = kwargs['num_eqn']
+        nnz: int = kwargs['nnz']
+        matrix_status: str = kwargs['matrix_status']
+        num_modes: int = kwargs['num_modes']
+        find_smallest: bool = kwargs['find_smallest']
+        
+        # Wrap memoryviews in NumPy arrays
+        indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
+        idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
+        k_data = np.frombuffer(k_values, dtype=np.float64, count=nnz)
+        m_data = np.frombuffer(m_values, dtype=np.float64, count=nnz)
+        
+        # Rebuild matrices if structure changed (assume CSR storage scheme)
+        if matrix_status == 'STRUCTURE_CHANGED' or self._k_matrix is None:
+            self._k_matrix = sp.csr_matrix((k_data, idx, indptr), shape=(num_eqn, num_eqn))
+            self._m_matrix = sp.csr_matrix((m_data, idx, indptr), shape=(num_eqn, num_eqn))
+        elif matrix_status == 'COEFFICIENTS_CHANGED':
+            # Update only the values
+            self._k_matrix.data[:] = k_data
+            self._m_matrix.data[:] = m_data
+        
+        # Solve generalized eigenvalue problem Kx = λMx
+        eigsh_kwargs = {
+            'k': num_modes,
+            'M': self._m_matrix,
+            'which': 'LM',
+        }
+        if find_smallest:
+            eigsh_kwargs['sigma'] = 0.0  # shift-invert method for smallest eigenvalues
+        if self.maxiter is not None:
+            eigsh_kwargs['maxiter'] = self.maxiter
+        if self.tol > 0.0:
+            eigsh_kwargs['tol'] = self.tol
+        
+        eigenvalues_result, eigenvectors_result = sp_linalg.eigsh(self._k_matrix, **eigsh_kwargs)
+        
+        # Write eigenvalues directly to the writable buffer
+        eigenvalues_buf = np.frombuffer(eigenvalues, dtype=np.float64, count=num_modes)
+        eigenvalues_buf[:] = eigenvalues_result[:num_modes]
+        
+        # Write eigenvectors directly to the flat buffer (mode-major layout)
+        # Buffer layout: eigenvectors[mode * num_eqn + eqn]
+        # Transpose and flatten for efficient single assignment (eigenvectors_result is (num_eqn, num_modes))
+        eigenvectors_buf = np.frombuffer(eigenvectors, dtype=np.float64, count=num_modes * num_eqn)
+        eigenvectors_buf[:] = eigenvectors_result.T.flatten()
+        
+        return None  # Success
+
+
+# -----------------------------------------------------------------------------
+# Model Geometry and Material Properties
+# -----------------------------------------------------------------------------
+
+BAR_LENGTH = 10.0  # inches
+BAR_HEIGHT = 2.0  # inches
+BAR_THICKNESS = 1.0  # inches
+
+ELASTIC_MODULUS = 29_000.0  # kip / in^2
+POISSON_RATIO = 0.3
+STEEL_DENSITY = 0.284e-3 / 386.4  # kip s^2 / in^4
+
+# -----------------------------------------------------------------------------
+# Model Building Functions
+# -----------------------------------------------------------------------------
+
+
+def build_solid_bar_model(nx: int, ny: int, nz: int) -> Optional[int]:
+    """Create a structured hexahedral mesh using block3D.
+    
+    Returns the node tag at the far corner (x=BAR_LENGTH, y=BAR_THICKNESS/2, z=BAR_HEIGHT/2)
+    for eigenvector reporting.
+    """
+    ops.wipe()
+    ops.model("basic", "-ndm", 3, "-ndf", 3)
+    ops.nDMaterial("ElasticIsotropic", 1, ELASTIC_MODULUS, POISSON_RATIO, STEEL_DENSITY)
+
+    eleType = "stdBrick"
+    eleArgs = 1
+    ops.block3D(
+        nx, ny, nz, 1, 1, eleType, eleArgs,
+        1, 0.0, -BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        2, BAR_LENGTH, -BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        3, BAR_LENGTH, BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        4, 0.0, BAR_THICKNESS / 2.0, -BAR_HEIGHT / 2.0,
+        5, 0.0, -BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        6, BAR_LENGTH, -BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        7, BAR_LENGTH, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+        8, 0.0, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0,
+    )
+
+    ops.fixX(0.0, 1, 1, 1)
+    
+    # Find the node at the far corner for eigenvector reporting
+    far_corner_node = None
+    for node in ops.getNodeTags():
+        x = ops.nodeCoord(node, 1)
+        y = ops.nodeCoord(node, 2)
+        z = ops.nodeCoord(node, 3)
+        if np.isclose(
+            [x, y, z],
+            [BAR_LENGTH, BAR_THICKNESS / 2.0, BAR_HEIGHT / 2.0],
+            atol=1e-9,
+        ).all():
+            far_corner_node = node
+            break
+    
+    return far_corner_node
+
+
+# -----------------------------------------------------------------------------
+# Solver Run Functions
+# -----------------------------------------------------------------------------
+
+
+def run_gen_band_arpack(num_modes: int) -> Optional[List[float]]:
+    """Run genBandArpack eigen solver."""
+    return ops.eigen("genBandArpack", num_modes)
+
+
+def run_full_gen_lapack(num_modes: int) -> Optional[List[float]]:
+    """Run fullGenLapack eigen solver."""
+    return ops.eigen("fullGenLapack", num_modes)
+
+
+def run_scipy_eigsh(num_modes: int) -> Optional[List[float]]:
+    """Run SciPy eigsh eigen solver."""
+    solver = SciPyGeneralizedEigenSolver(maxiter=None, tol=0.0)
+    return ops.eigen("PythonSparse", num_modes, {"solver": solver, "scheme": "CSR"})
+
+
+# -----------------------------------------------------------------------------
+# Benchmark Data Structures
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class BenchmarkRow:
+    solver_name: str
+    mesh_factor: float
+    mesh_size: float
+    num_elements: int
+    num_nodes: int
+    num_equations: int
+    status: int
+    time_seconds: float
+    eigenvalue_mode1: Optional[float] = None
+    eigenvalue_mode5: Optional[float] = None
+    eigenvec_mode1_x: Optional[float] = None
+    eigenvec_mode1_y: Optional[float] = None
+    eigenvec_mode1_z: Optional[float] = None
+    eigenvec_mode5_x: Optional[float] = None
+    eigenvec_mode5_y: Optional[float] = None
+    eigenvec_mode5_z: Optional[float] = None
+    eigenvalues_all: Optional[List[float]] = None  # First 5 eigenvalues for console output
+
+
+CSV_HEADER = (
+    "solver",
+    "mesh_factor",
+    "mesh_c",
+    "num_elements",
+    "num_nodes",
+    "num_equations",
+    "status",
+    "time_seconds",
+    "eigenvalue_mode1",
+    "eigenvalue_mode5",
+    "eigenvec_mode1_x",
+    "eigenvec_mode1_y",
+    "eigenvec_mode1_z",
+    "eigenvec_mode5_x",
+    "eigenvec_mode5_y",
+    "eigenvec_mode5_z",
+)
+
+
+# -----------------------------------------------------------------------------
+# Utility Functions
+# -----------------------------------------------------------------------------
+
+
+def counts_from_mesh_factor(factor: float) -> Tuple[float, Tuple[int, int, int]]:
+    """Return mesh size and brick counts for a given refinement factor."""
+    mesh_size = BAR_THICKNESS / factor
+
+    def count(dim: float) -> int:
+        return max(1, int(math.ceil(dim / mesh_size)))
+
+    return mesh_size, (count(BAR_LENGTH), count(BAR_THICKNESS), count(BAR_HEIGHT))
+
+
+# -----------------------------------------------------------------------------
+# Benchmark Execution
+# -----------------------------------------------------------------------------
+
+
+def run_benchmark(
+    solver_name: str,
+    solver_run: Callable[[int], Optional[List[float]]],
+    mesh_factor: float,
+    mesh_size: float,
+    counts: Tuple[int, int, int],
+    num_modes: int = 5,
+) -> BenchmarkRow:
+    """Run benchmark for a single eigen solver and mesh configuration."""
+    nx, ny, nz = counts
+    far_corner_node = build_solid_bar_model(nx, ny, nz)
+    
+    # Initialize to get system size
+    try:
+        ops.system("Diagonal")  # to obtain the number of equations
+        ops.analysis("Static", "-noWarnings")
+        ops.analyze(1)
+        neq = ops.systemSize()
+    except AttributeError:
+        neq = -1
+    
+    # Run eigen analysis
+    start_time = time.perf_counter()
+    eigenvalues = None
+    status = -1
+    
+    try:
+        eigenvalues = solver_run(num_modes)
+        status = 0 if eigenvalues is not None and len(eigenvalues) > 0 else -1
+    except Exception as e:
+        print(f"Error in eigen analysis: {e}", file=sys.stderr)
+        status = -1
+    
+    time_seconds = time.perf_counter() - start_time
+    
+    # Get system information
+    num_elements = len(ops.getEleTags())
+    num_nodes = len(ops.getNodeTags())
+    
+    # Extract eigenvalues for modes 1 and 5
+    eigenvalue_mode1 = None
+    eigenvalue_mode5 = None
+    eigenvalues_all = None
+    
+    if eigenvalues is not None and len(eigenvalues) >= 5:
+        eigenvalue_mode1 = eigenvalues[0]
+        eigenvalue_mode5 = eigenvalues[4]
+        eigenvalues_all = eigenvalues[:5]
+    elif eigenvalues is not None and len(eigenvalues) > 0:
+        eigenvalue_mode1 = eigenvalues[0]
+        eigenvalues_all = list(eigenvalues) + [None] * (5 - len(eigenvalues))
+    
+    # Extract eigenvectors for modes 1 and 5 at the far corner node
+    eigenvec_mode1 = None
+    eigenvec_mode5 = None
+    
+    if status == 0 and far_corner_node is not None:
+        try:
+            # Mode 1 (1-based indexing in OpenSees)
+            if eigenvalues is not None and len(eigenvalues) >= 1:
+                eigenvec_mode1 = ops.nodeEigenvector(far_corner_node, 1)
+            # Mode 5 (1-based indexing in OpenSees)
+            if eigenvalues is not None and len(eigenvalues) >= 5:
+                eigenvec_mode5 = ops.nodeEigenvector(far_corner_node, 5)
+        except Exception:
+            # If we can't get eigenvectors, mark as failed
+            status = -1
+    
+    if eigenvec_mode1 is not None:
+        eigenvec_mode1_x, eigenvec_mode1_y, eigenvec_mode1_z = eigenvec_mode1
+    else:
+        eigenvec_mode1_x = eigenvec_mode1_y = eigenvec_mode1_z = None
+    
+    if eigenvec_mode5 is not None:
+        eigenvec_mode5_x, eigenvec_mode5_y, eigenvec_mode5_z = eigenvec_mode5
+    else:
+        eigenvec_mode5_x = eigenvec_mode5_y = eigenvec_mode5_z = None
+
+    return BenchmarkRow(
+        solver_name=solver_name,
+        mesh_factor=mesh_factor,
+        mesh_size=mesh_size,
+        num_elements=num_elements,
+        num_nodes=num_nodes,
+        num_equations=neq,
+        status=status,
+        time_seconds=time_seconds,
+        eigenvalue_mode1=eigenvalue_mode1,
+        eigenvalue_mode5=eigenvalue_mode5,
+        eigenvec_mode1_x=eigenvec_mode1_x,
+        eigenvec_mode1_y=eigenvec_mode1_y,
+        eigenvec_mode1_z=eigenvec_mode1_z,
+        eigenvec_mode5_x=eigenvec_mode5_x,
+        eigenvec_mode5_y=eigenvec_mode5_y,
+        eigenvec_mode5_z=eigenvec_mode5_z,
+        eigenvalues_all=eigenvalues_all,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Main Function
+# -----------------------------------------------------------------------------
+
+
+def main():
+    """Run benchmarks and output CSV."""
+    if len(sys.argv) < 2:
+        print(f"Usage: python {FILENAME} <output.csv>")
+        sys.exit(1)
+
+    # Handle output CSV path: if simple filename, store in script directory
+    output_arg = sys.argv[1]
+    if '/' not in output_arg and '\\' not in output_arg:
+        # Simple filename, store in script directory
+        output_csv = SCRIPT_DIR / output_arg
+    else:
+        # Path provided, use as-is
+        output_csv = Path(output_arg)
+    
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    # Solver configurations: (name, run_function)
+    solvers = [
+        ("genBandArpack", run_gen_band_arpack),
+        ("fullGenLapack", run_full_gen_lapack),
+        ("SciPyEigsh", run_scipy_eigsh),
+    ]
+
+    # Known problematic solver/mesh factor combinations that cause segmentation faults or are too large
+    # Format: (solver_name, mesh_factor)
+    SKIP_COMBINATIONS = {
+        ("fullGenLapack", 4.0),
+        ("fullGenLapack", 6.0),
+        ("fullGenLapack", 8.0),
+        ("fullGenLapack", 10.0),
+        ("fullGenLapack", 12.0),
+        ("fullGenLapack", 14.0),
+        ("fullGenLapack", 16.0),
+        ("fullGenLapack", 18.0),
+        ("fullGenLapack", 20.0),
+        ("fullGenLapack", 22.0),
+        ("fullGenLapack", 24.0),
+        ("fullGenLapack", 26.0),
+        ("fullGenLapack", 28.0),
+        ("fullGenLapack", 30.0),
+    }
+
+    # Mesh refinement factors
+    mesh_factors = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0]
+
+    print("\n=== Python Sparse Eigen Solver Benchmark ===")
+    print(f"Comparing: {[s[0] for s in solvers]}")
+    print(f"Mesh factors: {mesh_factors}")
+    print(f"Results will be written to: {output_csv}\n")
+
+    with output_csv.open("w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(CSV_HEADER)
+
+        for mesh_factor in mesh_factors:
+            mesh_size, counts = counts_from_mesh_factor(mesh_factor)
+            mesh_info_printed = False
+
+            for solver_name, solver_run in solvers:
+                # Skip known problematic combinations
+                if (solver_name, mesh_factor) in SKIP_COMBINATIONS:
+                    # Write skipped row
+                    writer.writerow((
+                        solver_name,
+                        mesh_factor,
+                        mesh_size,
+                        -1,  # num_elements
+                        -1,  # num_nodes
+                        -1,  # num_equations
+                        -999,  # status
+                        float("nan"),
+                        "",  # eigenvalue_mode1
+                        "",  # eigenvalue_mode5
+                        "",  # eigenvec_mode1_x
+                        "",  # eigenvec_mode1_y
+                        "",  # eigenvec_mode1_z
+                        "",  # eigenvec_mode5_x
+                        "",  # eigenvec_mode5_y
+                        "",  # eigenvec_mode5_z
+                    ))
+                    csvfile.flush()
+                    
+                    status_str = "⊘"
+                    # Print mesh info after first solver completes, then its status on one line
+                    if not mesh_info_printed:
+                        print(f"\nMesh factor {mesh_factor:.1f}: (skipped)")
+                        print(f"  Running {solver_name}... {status_str} (skipped - either known segfault or too large)")
+                        mesh_info_printed = True
+                    else:
+                        print(f"  Running {solver_name}... {status_str} (skipped - either known segfault or too large)")
+                    continue
+                
+                try:
+                    # For first solver, don't print "Running..." yet - we'll print it with mesh info
+                    if mesh_info_printed:
+                        print(f"  Running {solver_name}...", end=" ", flush=True)
+                    
+                    row = run_benchmark(
+                        solver_name=solver_name,
+                        solver_run=solver_run,
+                        mesh_factor=mesh_factor,
+                        mesh_size=mesh_size,
+                        counts=counts,
+                    )
+                    
+                    writer.writerow((
+                        row.solver_name,
+                        row.mesh_factor,
+                        row.mesh_size,
+                        row.num_elements,
+                        row.num_nodes,
+                        row.num_equations,
+                        row.status,
+                        row.time_seconds,
+                        row.eigenvalue_mode1 if row.eigenvalue_mode1 is not None else "",
+                        row.eigenvalue_mode5 if row.eigenvalue_mode5 is not None else "",
+                        row.eigenvec_mode1_x if row.eigenvec_mode1_x is not None else "",
+                        row.eigenvec_mode1_y if row.eigenvec_mode1_y is not None else "",
+                        row.eigenvec_mode1_z if row.eigenvec_mode1_z is not None else "",
+                        row.eigenvec_mode5_x if row.eigenvec_mode5_x is not None else "",
+                        row.eigenvec_mode5_y if row.eigenvec_mode5_y is not None else "",
+                        row.eigenvec_mode5_z if row.eigenvec_mode5_z is not None else "",
+                    ))
+                    csvfile.flush()
+                    
+                    status_str = "✓" if row.status == 0 else "✗"
+                    # Print mesh info after first solver completes, then its status on one line
+                    if not mesh_info_printed:
+                        print(f"\nMesh factor {mesh_factor:.1f}: {row.num_elements} elements, {row.num_nodes} nodes, {row.num_equations} equations")
+                        # Format first 5 eigenvalues for display
+                        if row.eigenvalues_all:
+                            eig_str = ", ".join(
+                                f"{e:.6e}" if e is not None else "N/A"
+                                for e in row.eigenvalues_all
+                            )
+                        else:
+                            eig_str = "N/A"
+                        print(f"  Running {solver_name}... {status_str} ({row.time_seconds:.3f}s)  λ=[{eig_str}]")
+                        mesh_info_printed = True
+                    else:
+                        # Format first 5 eigenvalues for display
+                        if row.eigenvalues_all:
+                            eig_str = ", ".join(
+                                f"{e:.6e}" if e is not None else "N/A"
+                                for e in row.eigenvalues_all
+                            )
+                        else:
+                            eig_str = "N/A"
+                        print(f"{status_str} ({row.time_seconds:.3f}s)  λ=[{eig_str}]")
+                except Exception as e:
+                    print(f"✗ Error: {e}")
+                    # Write error row
+                    writer.writerow((
+                        solver_name,
+                        mesh_factor,
+                        mesh_size,
+                        -1,  # num_elements
+                        -1,  # num_nodes
+                        -1,  # num_equations
+                        -999,  # status
+                        float("nan"),
+                        "",  # eigenvalue_mode1
+                        "",  # eigenvalue_mode5
+                        "",  # eigenvec_mode1_x
+                        "",  # eigenvec_mode1_y
+                        "",  # eigenvec_mode1_z
+                        "",  # eigenvec_mode5_x
+                        "",  # eigenvec_mode5_y
+                        "",  # eigenvec_mode5_z
+                    ))
+                    csvfile.flush()
+
+    print(f"\n✓ Results written to {output_csv}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/EXAMPLES/SolverBenchmark/plot_timing.py
+++ b/EXAMPLES/SolverBenchmark/plot_timing.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Plot timing results from benchmark CSV file.
+Plots num_equations vs time_seconds for different solvers.
+"""
+
+import sys
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.ticker import EngFormatter
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python plot_timing.py <input.csv> <output.png>")
+        sys.exit(1)
+    
+    # Get script directory
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    input_csv_arg = sys.argv[1]
+    output_png_arg = sys.argv[2]
+    
+    # Resolve input CSV path
+    if os.path.isabs(input_csv_arg):
+        input_csv = input_csv_arg
+    else:
+        # Check in script directory
+        input_csv = os.path.join(script_dir, input_csv_arg)
+        if not os.path.exists(input_csv):
+            # If not found, try the path as-is (might be relative to current working directory)
+            input_csv = input_csv_arg
+    
+    if not os.path.exists(input_csv):
+        print(f"Error: Input file not found: {input_csv}")
+        sys.exit(1)
+    
+    # Get directory of input CSV file
+    csv_dir = os.path.dirname(os.path.abspath(input_csv))
+    
+    # Resolve output PNG path
+    if os.path.isabs(output_png_arg):
+        output_png = output_png_arg
+    elif os.path.dirname(output_png_arg):
+        # Has a directory component, treat as relative to current working directory
+        output_png = output_png_arg
+    else:
+        # Just a filename, store in same directory as input CSV
+        output_png = os.path.join(csv_dir, output_png_arg)
+    
+    # Read CSV
+    df = pd.read_csv(input_csv)
+    
+    # Filter out skipped runs (status == -999)
+    df = df[df['status'] != -999]
+    
+    # Filter out rows with invalid num_equations or time_seconds
+    df = df[(df['num_equations'] > 0) & (df['time_seconds'].notna())]
+    
+    # Get unique solvers
+    solvers = df['solver'].unique()
+    
+    # Create plot
+    plt.figure(figsize=(10, 6))
+    
+    # Plot each solver
+    for solver in sorted(solvers):
+        solver_data = df[df['solver'] == solver]
+        solver_data = solver_data.sort_values('num_equations')
+        plt.plot(solver_data['num_equations'], solver_data['time_seconds'], 
+                marker='o', label=solver, linewidth=2, markersize=6)
+    
+    # Set labels and title
+    plt.xlabel('Number of Equations', fontsize=12)
+    plt.ylabel('Time (seconds)', fontsize=12)
+    plt.title('Solver Performance: Number of Equations vs Time', fontsize=14)
+    plt.legend(fontsize=10)
+    plt.grid(True, alpha=0.3)
+    
+    # Apply engineering notation to x-axis
+    ax = plt.gca()
+    ax.xaxis.set_major_formatter(EngFormatter(unit=''))
+    
+    # Use log scale for better visualization if needed
+    # Uncomment the following lines if you want log scale:
+    # plt.xscale('log')
+    # plt.yscale('log')
+    
+    plt.tight_layout()
+    plt.savefig(output_png, dpi=300, bbox_inches='tight')
+    print(f"Plot saved to {os.path.abspath(output_png)}")
+
+if __name__ == '__main__':
+    main()
+

--- a/SRC/api/elementAPI.h
+++ b/SRC/api/elementAPI.h
@@ -210,6 +210,7 @@ extern "C" int         OPS_SetStringList(std::vector<const char*>& data);
 extern "C" int         OPS_SetStringLists(std::vector<std::vector<const char*>>& data);
 extern "C" int         OPS_SetStringDict(std::map<const char*, const char*>& data);
 extern "C" int         OPS_SetStringDictList(std::map<const char*, std::vector<const char*>>& data);
+extern "C" void*       OPS_GetVoidPtr();
 extern "C" int         OPS_GetStringCopy(char** cArray); // returns a new copy
 extern "C" matObj*     OPS_GetMaterial(int* matTag, int* matType);
 extern "C" eleObj*     OPS_GetElement(int* eleTag);
@@ -300,6 +301,7 @@ int    OPS_GetNodeVel(int* nodeTag, int* sizeData, double* data);
 int    OPS_GetNodeAcc(int* nodeTag, int* sizeData, double* data);
 int    OPS_GetNodeIncrDisp(int* nodeTag, int* sizeData, double* data);
 int    OPS_GetNodeIncrDeltaDisp(int* nodeTag, int* sizeData, double* data);
+void*  OPS_GetVoidPtr();
 
 AnalysisModel** OPS_GetAnalysisModel(void);
 EquiSolnAlgo** OPS_GetAlgorithm(void);

--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -52,6 +52,8 @@
 #define EigenSOE_TAGS_ArpackSOE 	5
 #define EigenSOE_TAGS_GeneralArpackSOE 	6
 #define EigenSOE_TAGS_SymmGeneralizedEigenSOE 	7
+#define EigenSOE_TAGS_SparsePythonCompressedEigenSOE 	8
+#define EigenSOE_TAGS_SparsePythonCOOEigenSOE 	9
 #define EigenSOLVER_TAGS_BandArpackSolver 	1
 #define EigenSOLVER_TAGS_SymArpackSolver 	2
 #define EigenSOLVER_TAGS_SymBandEigenSolver     3
@@ -59,6 +61,8 @@
 #define EigenSOLVER_TAGS_ArpackSolver  5
 #define EigenSOLVER_TAGS_GeneralArpackSolver  6
 #define EigenSOLVER_TAGS_SymmGeneralizedEigenSolver  7
+#define EigenSOLVER_TAGS_SparsePythonCompressedEigenSolver  8
+#define EigenSOLVER_TAGS_SparsePythonCOOEigenSolver  9
 
 #define EigenALGORITHM_TAGS_Frequency 1
 #define EigenALGORITHM_TAGS_Standard  2
@@ -1136,6 +1140,8 @@
 #define LinSOE_TAGS_PFEMCompressibleLinSOE 28
 #define LinSOE_TAGS_PFEMQuasiLinSOE 29
 #define LinSOE_TAGS_PFEMDiaLinSOE 30
+#define LinSOE_TAGS_SparsePythonCompressedLinSOE 100101
+#define LinSOE_TAGS_SparsePythonCOOLinSOE        100102
 #define LinSOE_TAGS_PARDISOGenLinSOE 99990
 
 
@@ -1172,6 +1178,8 @@
 #define SOLVER_TAGS_CuSP                                31
 #define SOLVER_TAGS_PFEMQuasiSolver                     32
 #define SOLVER_TAGS_PFEMDiaSolver                       33
+#define SOLVER_TAGS_SparsePythonCompressedLinSolver     100201
+#define SOLVER_TAGS_SparsePythonCOOLinSolver            100202
 
 #define RECORDER_TAGS_ElementRecorder		1
 #define RECORDER_TAGS_NodeRecorder		2

--- a/SRC/interpreter/DL_Interpreter.cpp
+++ b/SRC/interpreter/DL_Interpreter.cpp
@@ -90,6 +90,12 @@ DL_Interpreter::getString()
     return 0;
 }
 
+void*
+DL_Interpreter::getVoidPtr()
+{
+    return 0;
+}
+
 const char*
 DL_Interpreter::getStringFromAll(char* buffer, int len)
 {

--- a/SRC/interpreter/DL_Interpreter.h
+++ b/SRC/interpreter/DL_Interpreter.h
@@ -71,6 +71,7 @@ class DL_Interpreter
     virtual const char* getString();
     virtual const char* getStringFromAll(char* buffer, int len);
     virtual int getStringCopy(char **stringPtr);
+    virtual void* getVoidPtr();
     virtual int evalDoubleStringExpression(const char* theExpression, double& current_val);
     virtual void resetInput(int cArg);
 

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -157,7 +157,8 @@ public:
     void wipeAnalysis();
     void wipe();
     int eigen(int typeSolver, double shift,
-	      bool generalizedAlgo, bool findSmallest);
+	      bool generalizedAlgo, bool findSmallest,
+              EigenSOE *providedEigenSOE = nullptr);
 
 private:
 

--- a/SRC/interpreter/PythonAnalysisBuilder.h
+++ b/SRC/interpreter/PythonAnalysisBuilder.h
@@ -74,7 +74,7 @@ public:
     void newStaticAnalysis();
     void newTransientAnalysis();
     void newPFEMAnalysis(double,double,double);
-    void newEigenAnalysis(int typeSolver, double shift);
+    void newEigenAnalysis(int typeSolver, double shift, EigenSOE *providedEigenSOE = nullptr);
 
     StaticAnalysis* getStaticAnalysis() {return theStaticAnalysis;}
     DirectIntegrationAnalysis* getTransientAnalysis() {return theTransientAnalysis;}

--- a/SRC/interpreter/PythonModule.cpp
+++ b/SRC/interpreter/PythonModule.cpp
@@ -320,6 +320,18 @@ const char *PythonModule::getStringFromAll(char* buffer, int len) {
 #endif
 }
 
+void*
+PythonModule::getVoidPtr()
+{
+    if (wrapper.getCurrentArg() >= wrapper.getNumberArgs()) {
+        return nullptr;
+    }
+    PyObject *obj =
+        PyTuple_GetItem(wrapper.getCurrentArgv(), wrapper.getCurrentArg());
+    wrapper.incrCurrentArg();
+    return static_cast<void*>(obj);
+}
+
 int
 PythonModule::getStringCopy(char **stringPtr) {
     return -1;

--- a/SRC/interpreter/PythonModule.h
+++ b/SRC/interpreter/PythonModule.h
@@ -77,6 +77,7 @@ class PythonModule: public DL_Interpreter
     virtual const char* getString();
     virtual const char* getStringFromAll(char* buffer, int len);
     virtual int getStringCopy(char **stringPtr);
+    virtual void* getVoidPtr();
     virtual int evalDoubleStringExpression(const char* theExpression, double& current_val);
     virtual void resetInput(int cArg);
 

--- a/SRC/system_of_eqn/eigenSOE/CMakeLists.txt
+++ b/SRC/system_of_eqn/eigenSOE/CMakeLists.txt
@@ -42,3 +42,5 @@ target_sources(OPS_SysOfEqn
     SymArpackSolver.h
 )
 
+add_subdirectory(sparsePython)
+

--- a/SRC/system_of_eqn/eigenSOE/EigenSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/EigenSOE.h
@@ -53,10 +53,10 @@ class EigenSOE : public MovableObject
      virtual void zeroA(void) = 0;
      virtual void zeroM(void) = 0;
 
-    // methods to get the eigenvectors and eigenvalues
-    virtual const Vector &getEigenvector(int mode);
-    virtual double getEigenvalue(int mode);
-    
+     // methods to get the eigenvectors and eigenvalues
+     virtual const Vector &getEigenvector(int mode);
+     virtual double getEigenvalue(int mode);          
+     
   protected:
      virtual int setSolver(EigenSolver &newSolver);
      EigenSolver *getSolver(void);

--- a/SRC/system_of_eqn/eigenSOE/EigenSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/EigenSOE.h
@@ -53,10 +53,10 @@ class EigenSOE : public MovableObject
      virtual void zeroA(void) = 0;
      virtual void zeroM(void) = 0;
 
-     // methods to get the eigenvectors and eigenvalues
-     virtual const Vector &getEigenvector(int mode);
-     virtual double getEigenvalue(int mode);          
-     
+    // methods to get the eigenvectors and eigenvalues
+    virtual const Vector &getEigenvector(int mode);
+    virtual double getEigenvalue(int mode);
+    
   protected:
      virtual int setSolver(EigenSolver &newSolver);
      EigenSolver *getSolver(void);

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/CMakeLists.txt
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/CMakeLists.txt
@@ -1,0 +1,20 @@
+target_sources(OPS_SysOfEqn
+  PRIVATE
+    SparsePythonCompressedEigenSOE.cpp
+    SparsePythonCompressedEigenSolver.cpp
+    SparsePythonCOOEigenSOE.cpp
+    SparsePythonCOOEigenSolver.cpp
+    SparsePythonEigenCommon.cpp
+    SparsePythonEigenFactory.cpp
+  PUBLIC
+    SparsePythonCompressedEigenSOE.h
+    SparsePythonCompressedEigenSolver.h
+    SparsePythonCOOEigenSOE.h
+    SparsePythonCOOEigenSolver.h
+    SparsePythonEigenCommon.h
+    SparsePythonEigenFactory.h
+)
+
+find_package(Python3 COMPONENTS Development REQUIRED)
+target_link_libraries(OPS_SysOfEqn PRIVATE Python3::Python)
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/Makefile
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/Makefile
@@ -1,0 +1,25 @@
+include ../../../Makefile.def
+
+OBJS       = SparsePythonCompressedEigenSOE.o \
+	SparsePythonCompressedEigenSolver.o \
+	SparsePythonCOOEigenSOE.o \
+	SparsePythonCOOEigenSolver.o \
+	SparsePythonEigenCommon.o \
+	SparsePythonEigenFactory.o
+
+all:    $(OBJS)
+
+# Miscellaneous
+tidy:	
+	@$(RM) $(RMFLAGS) Makefile.bak *~ #*# core
+
+clean: tidy
+	@$(RM) $(RMFLAGS) $(OBJS) *.o
+
+spotless: clean
+	@$(RM) $(RMFLAGS)
+
+wipe: spotless
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSOE.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSOE.cpp
@@ -1,0 +1,253 @@
+#include "SparsePythonCOOEigenSOE.h"
+
+#include "SparsePythonCOOEigenSolver.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <Graph.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <OPS_Globals.h>
+#include <Vertex.h>
+#include <VertexIter.h>
+
+#include <algorithm>
+
+SparsePythonCOOEigenSOE::SparsePythonCOOEigenSOE(SparsePythonCOOEigenSolver &theSolver)
+    : EigenSOE(theSolver, EigenSOE_TAGS_SparsePythonCOOEigenSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED)
+{
+    theSolver.setEigenSOE(*this);
+}
+
+SparsePythonCOOEigenSOE::SparsePythonCOOEigenSOE()
+    : EigenSOE(EigenSOE_TAGS_SparsePythonCOOEigenSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED)
+{
+}
+
+SparsePythonCOOEigenSOE::~SparsePythonCOOEigenSOE() = default;
+
+int
+SparsePythonCOOEigenSOE::getNumEqn(void) const
+{
+    return static_cast<int>(rowOffsets.size() > 0 ? rowOffsets.size() - 1 : 0);
+}
+
+void
+SparsePythonCOOEigenSOE::buildCOOPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    if (size <= 0) {
+        rowIndices.clear();
+        colIndices.clear();
+        kValues.clear();
+        mValues.clear();
+        rowOffsets.assign(1u, 0);
+        return;
+    }
+
+    const std::size_t nnz = static_cast<std::size_t>(size) + 2 * theGraph.getNumEdge();
+
+    rowIndices.resize(nnz);
+    colIndices.resize(nnz);
+    kValues.assign(nnz, 0.0);
+    mValues.assign(nnz, 0.0);
+    rowOffsets.assign(static_cast<std::size_t>(size) + 1u, 0);
+
+    int last = 0;
+    rowOffsets[0] = 0;
+    for (int row = 0; row < size; ++row) {
+        Vertex *theVertex = theGraph.getVertexPtr(row);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCOOEigenSOE::buildCOOPattern - "
+                   << "vertex " << row << " not found in graph, size set to 0" << endln;
+            rowIndices.assign(0u, 0);
+            colIndices.assign(0u, 0);
+            kValues.clear();
+            mValues.clear();
+            rowOffsets.assign(1u, 0);
+            return;
+        }
+
+        const ID &theAdjacency = theVertex->getAdjacency();
+        ID columns(0, theAdjacency.Size() + 1);
+
+        columns.insert(theVertex->getTag());
+        for (int i = 0; i < theAdjacency.Size(); ++i) {
+            columns.insert(theAdjacency(i));
+        }
+
+        for (int i = 0; i < columns.Size(); ++i) {
+            rowIndices[static_cast<std::size_t>(last)] = row;
+            colIndices[static_cast<std::size_t>(last)] = columns(i);
+            ++last;
+        }
+
+        rowOffsets[static_cast<std::size_t>(row + 1)] = last;
+    }
+
+    if (static_cast<std::size_t>(last) < nnz) {
+        rowIndices.resize(static_cast<std::size_t>(last));
+        colIndices.resize(static_cast<std::size_t>(last));
+        kValues.resize(static_cast<std::size_t>(last), 0.0);
+        mValues.resize(static_cast<std::size_t>(last), 0.0);
+    }
+}
+
+int
+SparsePythonCOOEigenSOE::setSize(Graph &theGraph)
+{
+    buildCOOPattern(theGraph);
+
+    EigenSolver *theSolver = this->getSolver();
+    if (theSolver != nullptr) {
+        const int solverOK = theSolver->setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCOOEigenSOE::setSize - solver failed setSize()" << endln;
+            return solverOK;
+        }
+    }
+
+    matrixStatus = MatrixStatus::STRUCTURE_CHANGED;
+    return 0;
+}
+
+void
+SparsePythonCOOEigenSOE::updateMatrixStatus()
+{
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+int
+SparsePythonCOOEigenSOE::addA(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCOOEigenSOE::addA - Matrix and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+    if (size == 0 || rowOffsets.size() != static_cast<std::size_t>(size) + 1u) {
+        return 0;
+    }
+
+    for (int i = 0; i < idSize; ++i) {
+        const int row = id(i);
+        if (row < 0 || row >= size) {
+            continue;
+        }
+
+        const int start = rowOffsets[static_cast<std::size_t>(row)];
+        const int end = rowOffsets[static_cast<std::size_t>(row + 1)];
+
+        for (int j = 0; j < idSize; ++j) {
+            const int col = id(j);
+            if (col < 0 || col >= size) {
+                continue;
+            }
+
+            for (int k = start; k < end; ++k) {
+                if (colIndices[static_cast<std::size_t>(k)] == col) {
+                    kValues[static_cast<std::size_t>(k)] += fact * m(i, j);
+                    break;
+                }
+            }
+        }
+    }
+
+    updateMatrixStatus();
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSOE::addM(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCOOEigenSOE::addM - Matrix and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+    if (size == 0 || rowOffsets.size() != static_cast<std::size_t>(size) + 1u) {
+        return 0;
+    }
+
+    for (int i = 0; i < idSize; ++i) {
+        const int row = id(i);
+        if (row < 0 || row >= size) {
+            continue;
+        }
+
+        const int start = rowOffsets[static_cast<std::size_t>(row)];
+        const int end = rowOffsets[static_cast<std::size_t>(row + 1)];
+
+        for (int j = 0; j < idSize; ++j) {
+            const int col = id(j);
+            if (col < 0 || col >= size) {
+                continue;
+            }
+
+            for (int k = start; k < end; ++k) {
+                if (colIndices[static_cast<std::size_t>(k)] == col) {
+                    mValues[static_cast<std::size_t>(k)] += fact * m(i, j);
+                    break;
+                }
+            }
+        }
+    }
+
+    updateMatrixStatus();
+    return 0;
+}
+
+void
+SparsePythonCOOEigenSOE::zeroA(void)
+{
+    std::fill(kValues.begin(), kValues.end(), 0.0);
+    if (matrixStatus == MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+void
+SparsePythonCOOEigenSOE::zeroM(void)
+{
+    std::fill(mValues.begin(), mValues.end(), 0.0);
+    if (matrixStatus == MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+int
+SparsePythonCOOEigenSOE::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSOE::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSOE::setPythonSolver(SparsePythonCOOEigenSolver &newSolver)
+{
+    this->theSolver = &newSolver;
+    return 0;
+}
+
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSOE.h
@@ -1,0 +1,73 @@
+#ifndef SparsePythonCOOEigenSOE_h
+#define SparsePythonCOOEigenSOE_h
+
+#include "SparsePythonEigenCommon.h"
+
+#include <EigenSOE.h>
+
+#include <vector>
+
+class Channel;
+class FEM_ObjectBroker;
+class Graph;
+class ID;
+class Matrix;
+class SparsePythonCOOEigenSolver;
+
+class SparsePythonCOOEigenSOE : public EigenSOE
+{
+  public:
+    using MatrixStatus = SparsePythonEigenMatrixStatus;
+
+    explicit SparsePythonCOOEigenSOE(SparsePythonCOOEigenSolver &theSolver);
+    SparsePythonCOOEigenSOE();
+    ~SparsePythonCOOEigenSOE() override;
+
+    SparsePythonEigenStorageScheme getStorageScheme() const { return SparsePythonEigenStorageScheme::COO; }
+
+    int getNumEqn(void) const;
+    int setSize(Graph &theGraph) override;
+
+    int addA(const Matrix &, const ID &, double fact = 1.0) override;
+    int addM(const Matrix &, const ID &, double fact = 1.0) override;
+
+    void zeroA(void) override;
+    void zeroM(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setPythonSolver(SparsePythonCOOEigenSolver &newSolver);
+
+    MatrixStatus getMatrixStatus(void) const { return matrixStatus; }
+
+    const std::vector<int> &getRowIndices(void) const { return rowIndices; }
+    const std::vector<int> &getColIndices(void) const { return colIndices; }
+
+    std::vector<double> &getKValues(void) { return kValues; }
+    const std::vector<double> &getKValues(void) const { return kValues; }
+
+    std::vector<double> &getMValues(void) { return mValues; }
+    const std::vector<double> &getMValues(void) const { return mValues; }
+
+    std::size_t getNNZ(void) const { return kValues.size(); }
+
+  private:
+    void buildCOOPattern(Graph &theGraph);
+    void updateMatrixStatus();
+
+    std::vector<int> rowIndices;
+    std::vector<int> colIndices;
+    std::vector<int> rowOffsets;
+
+    std::vector<double> kValues;
+    std::vector<double> mValues;
+
+    MatrixStatus matrixStatus;
+
+    friend class SparsePythonCOOEigenSolver;
+};
+
+#endif /* SparsePythonCOOEigenSOE_h */
+
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSolver.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSolver.cpp
@@ -1,0 +1,355 @@
+#include "SparsePythonCOOEigenSolver.h"
+
+#include "SparsePythonCOOEigenSOE.h"
+#include "SparsePythonEigenCommon.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <OPS_Globals.h>
+#include <Vector.h>
+#include <elementAPI.h>
+#include <Python.h>
+
+namespace {
+
+struct PyObjectHolder {
+    PyObjectHolder() = default;
+    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
+    ~PyObjectHolder() { Py_XDECREF(ptr); }
+    PyObject *get() const { return ptr; }
+    PyObject *release() {
+        PyObject *tmp = ptr;
+        ptr = nullptr;
+        return tmp;
+    }
+    void reset(PyObject *obj = nullptr) {
+        if (ptr == obj) {
+            return;
+        }
+        Py_XDECREF(ptr);
+        ptr = obj;
+    }
+
+  private:
+    PyObject *ptr{nullptr};
+};
+
+} // namespace
+
+SparsePythonCOOEigenSolver::SparsePythonCOOEigenSolver()
+    : EigenSolver(EigenSOLVER_TAGS_SparsePythonCOOEigenSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName("solve"),
+      numComputedModes(0)
+{
+}
+
+SparsePythonCOOEigenSolver::SparsePythonCOOEigenSolver(PyObject *callable, const char *method)
+    : EigenSolver(EigenSOLVER_TAGS_SparsePythonCOOEigenSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName(method != nullptr ? method : "solve"),
+      numComputedModes(0)
+{
+    setPythonCallable(callable, methodName.c_str());
+}
+
+SparsePythonCOOEigenSolver::~SparsePythonCOOEigenSolver()
+{
+    if (solverObject != nullptr) {
+        if (Py_IsInitialized()) {
+            // Acquire GIL before decrementing reference count
+            // This is critical: Py_XDECREF must be called with GIL held
+            PyGILState_STATE gil_state = PyGILState_Ensure();
+            Py_XDECREF(solverObject);
+            PyGILState_Release(gil_state);
+        }
+        // If Python is not initialized, we cannot safely call Py_XDECREF
+        // The object will be cleaned up when Python interpreter shuts down
+        solverObject = nullptr;
+    }
+}
+
+int
+SparsePythonCOOEigenSolver::setEigenSOE(SparsePythonCOOEigenSOE &theEigenSOE)
+{
+    theSOE = &theEigenSOE;
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSolver::setPythonCallable(PyObject *callable, const char *method)
+{
+    if (method != nullptr) {
+        methodName = method;
+    }
+
+    if (callable == nullptr) {
+        Py_XDECREF(solverObject);
+        solverObject = nullptr;
+        return 0;
+    }
+
+    Py_XINCREF(callable);
+    Py_XDECREF(solverObject);
+    solverObject = callable;
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSolver::solve(int numModes, bool generalized, bool findSmallest)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::solve - no associated SOE\n";
+        return -1;
+    }
+    if (solverObject == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::solve - no Python callable bound\n";
+        return -2;
+    }
+    if (theSOE->getNumEqn() == 0) {
+        return 0;
+    }
+
+    return callPythonSolver(numModes, generalized, findSmallest);
+}
+
+int
+SparsePythonCOOEigenSolver::setSize(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::setSize - no associated SOE\n";
+        return -1;
+    }
+    return 0;
+}
+
+const Vector &
+SparsePythonCOOEigenSolver::getEigenvector(int mode)
+{
+    if (mode <= 0 || mode > numComputedModes) {
+        opserr << "SparsePythonCOOEigenSolver::getEigenvector - mode " << mode
+               << " out of range (1 - " << numComputedModes << ")\n";
+        static Vector dummy;
+        return dummy;
+    }
+    return eigenvectors[static_cast<std::size_t>(mode - 1)];
+}
+
+double
+SparsePythonCOOEigenSolver::getEigenvalue(int mode)
+{
+    if (mode <= 0 || mode > numComputedModes) {
+        opserr << "SparsePythonCOOEigenSolver::getEigenvalue - mode " << mode
+               << " out of range (1 - " << numComputedModes << ")\n";
+        return 0.0;
+    }
+    return eigenvalues[static_cast<std::size_t>(mode - 1)];
+}
+
+int
+SparsePythonCOOEigenSolver::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSolver::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOEigenSolver::callPythonSolver(int numModes, bool generalized, bool findSmallest)
+{
+    const std::vector<int> &rowIdx = theSOE->getRowIndices();
+    const std::vector<int> &colIdx = theSOE->getColIndices();
+    std::vector<double> &kValues = theSOE->getKValues();
+    std::vector<double> &mValues = theSOE->getMValues();
+
+    if (rowIdx.size() != colIdx.size() || rowIdx.size() != kValues.size() || rowIdx.size() != mValues.size()) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - inconsistent COO data\n";
+        return -3;
+    }
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObjectHolder method(PyObject_GetAttrString(solverObject, methodName.c_str()));
+    if (method.get() == nullptr || !PyCallable_Check(method.get())) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - attribute '"
+               << methodName.c_str() << "' not callable\n";
+        PyGILState_Release(gilState);
+        return -4;
+    }
+
+    const Py_ssize_t nnzBytes = static_cast<Py_ssize_t>(rowIdx.size() * sizeof(int));
+    const Py_ssize_t kValuesBytes = static_cast<Py_ssize_t>(kValues.size() * sizeof(double));
+    const Py_ssize_t mValuesBytes = static_cast<Py_ssize_t>(mValues.size() * sizeof(double));
+
+    PyObjectHolder pyRows(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(rowIdx.data())),
+        nnzBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyCols(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(colIdx.data())),
+        nnzBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyKValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(kValues.data()),
+        kValuesBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyMValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(mValues.data()),
+        mValuesBytes,
+        PyBUF_READ));
+
+    if (pyRows.get() == nullptr || pyCols.get() == nullptr ||
+        pyKValues.get() == nullptr || pyMValues.get() == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - failed to create memory views\n";
+        PyGILState_Release(gilState);
+        return -5;
+    }
+
+    PyObjectHolder matrixStatus(PyUnicode_FromString(theSOE->getMatrixStatus().to_str()));
+    PyObjectHolder storageScheme(PyUnicode_FromString(theSOE->getStorageScheme().to_str()));
+
+    PyObjectHolder kwargs(PyDict_New());
+    const char *rowIndicesKeyword = "row_indices";
+    const char *colIndicesKeyword = "col_indices";
+    const char *kValuesKeyword = "k_values";
+    const char *mValuesKeyword = "m_values";
+    const char *matrixStatusKeyword = "matrix_status";
+    const char *storageSchemeKeyword = "storage_scheme";
+    const char *numEqnKeyword = "num_eqn";
+    const char *nnzKeyword = "nnz";
+    const char *numModesKeyword = "num_modes";
+    const char *generalizedKeyword = "generalized";
+    const char *findSmallestKeyword = "find_smallest";
+
+    if (kwargs.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), rowIndicesKeyword, pyRows.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), colIndicesKeyword, pyCols.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), kValuesKeyword, pyKValues.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), mValuesKeyword, pyMValues.get()) != 0 ||
+        matrixStatus.get() == nullptr ||
+        storageScheme.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), matrixStatusKeyword, matrixStatus.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), storageSchemeKeyword, storageScheme.get()) != 0) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - failed to populate kwargs\n";
+        PyGILState_Release(gilState);
+        return -6;
+    }
+
+    PyObjectHolder numEqn(PyLong_FromLong(theSOE->getNumEqn()));
+    PyObjectHolder nnz(PyLong_FromSize_t(theSOE->getNNZ()));
+    PyObjectHolder pyNumModes(PyLong_FromLong(numModes));
+    PyObjectHolder pyGeneralized(PyBool_FromLong(generalized ? 1 : 0));
+    PyObjectHolder pyFindSmallest(PyBool_FromLong(findSmallest ? 1 : 0));
+
+    if (numEqn.get() == nullptr || nnz.get() == nullptr ||
+        pyNumModes.get() == nullptr || pyGeneralized.get() == nullptr || pyFindSmallest.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), numEqnKeyword, numEqn.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), nnzKeyword, nnz.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), numModesKeyword, pyNumModes.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), generalizedKeyword, pyGeneralized.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), findSmallestKeyword, pyFindSmallest.get()) != 0) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - failed to set metadata kwargs\n";
+        PyGILState_Release(gilState);
+        return -7;
+    }
+
+    PyObject *args = PyTuple_New(0);
+    if (args == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - failed to create args tuple\n";
+        PyGILState_Release(gilState);
+        return -8;
+    }
+    PyObjectHolder argsHolder(args);
+
+    PyObjectHolder result(PyObject_Call(method.get(), args, kwargs.get()));
+    PyGILState_Release(gilState);
+
+    if (result.get() == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - Python call failed\n";
+        PyErr_Print();
+        return -9;
+    }
+
+    if (!PyTuple_Check(result.get()) || PyTuple_Size(result.get()) != 2) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - result must be tuple (eigenvalues, eigenvectors)\n";
+        return -10;
+    }
+
+    PyObject *pyEigenvalues = PyTuple_GetItem(result.get(), 0);
+    PyObject *pyEigenvectors = PyTuple_GetItem(result.get(), 1);
+
+    if (pyEigenvalues == nullptr || pyEigenvectors == nullptr) {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - failed to extract result components\n";
+        return -11;
+    }
+
+    Py_ssize_t numEigen = 0;
+    if (PyList_Check(pyEigenvalues)) {
+        numEigen = PyList_Size(pyEigenvalues);
+        eigenvalues.resize(static_cast<std::size_t>(numEigen));
+        for (Py_ssize_t i = 0; i < numEigen; ++i) {
+            PyObject *item = PyList_GetItem(pyEigenvalues, i);
+            if (item == nullptr || !PyFloat_Check(item)) {
+                opserr << "SparsePythonCOOEigenSolver::callPythonSolver - invalid eigenvalue at index " << i << "\n";
+                return -12;
+            }
+            eigenvalues[static_cast<std::size_t>(i)] = PyFloat_AsDouble(item);
+        }
+    } else {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - eigenvalues must be a list\n";
+        return -13;
+    }
+
+    if (PyList_Check(pyEigenvectors)) {
+        Py_ssize_t numVecs = PyList_Size(pyEigenvectors);
+        if (numVecs != numEigen) {
+            opserr << "SparsePythonCOOEigenSolver::callPythonSolver - number of eigenvectors ("
+                   << numVecs << ") != number of eigenvalues (" << numEigen << ")\n";
+            return -14;
+        }
+        eigenvectors.clear();
+        eigenvectors.reserve(static_cast<std::size_t>(numVecs));
+        const int size = theSOE->getNumEqn();
+        for (Py_ssize_t i = 0; i < numVecs; ++i) {
+            PyObject *vec = PyList_GetItem(pyEigenvectors, i);
+            if (vec == nullptr || !PyList_Check(vec)) {
+                opserr << "SparsePythonCOOEigenSolver::callPythonSolver - invalid eigenvector at index " << i << "\n";
+                return -15;
+            }
+            Py_ssize_t vecSize = PyList_Size(vec);
+            if (vecSize != size) {
+                opserr << "SparsePythonCOOEigenSolver::callPythonSolver - eigenvector " << i
+                       << " size (" << vecSize << ") != system size (" << size << ")\n";
+                return -16;
+            }
+            Vector eigenvec(size);
+            for (Py_ssize_t j = 0; j < vecSize; ++j) {
+                PyObject *item = PyList_GetItem(vec, j);
+                if (item == nullptr || !PyFloat_Check(item)) {
+                    opserr << "SparsePythonCOOEigenSolver::callPythonSolver - invalid eigenvector element at ("
+                           << i << ", " << j << ")\n";
+                    return -17;
+                }
+                eigenvec(static_cast<int>(j)) = PyFloat_AsDouble(item);
+            }
+            eigenvectors.push_back(eigenvec);
+        }
+    } else {
+        opserr << "SparsePythonCOOEigenSolver::callPythonSolver - eigenvectors must be a list of lists\n";
+        return -18;
+    }
+
+    numComputedModes = static_cast<int>(numEigen);
+    return 0;
+}
+
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSolver.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCOOEigenSolver.h
@@ -1,0 +1,50 @@
+#ifndef SparsePythonCOOEigenSolver_h
+#define SparsePythonCOOEigenSolver_h
+
+#include <EigenSolver.h>
+#include <Vector.h>
+
+#include <string>
+#include <vector>
+
+class SparsePythonCOOEigenSOE;
+struct _object;
+typedef _object PyObject;
+
+class Channel;
+class FEM_ObjectBroker;
+
+class SparsePythonCOOEigenSolver : public EigenSolver
+{
+  public:
+    SparsePythonCOOEigenSolver();
+    explicit SparsePythonCOOEigenSolver(PyObject *callable, const char *methodName = "solve");
+    ~SparsePythonCOOEigenSolver() override;
+
+    int solve(int numModes, bool generalized, bool findSmallest = true) override;
+    int setSize(void) override;
+
+    const Vector &getEigenvector(int mode) override;
+    double getEigenvalue(int mode) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setEigenSOE(SparsePythonCOOEigenSOE &theSOE);
+    int setPythonCallable(PyObject *callable, const char *methodName = "solve");
+
+  private:
+    int callPythonSolver(int numModes, bool generalized, bool findSmallest);
+
+    SparsePythonCOOEigenSOE *theSOE;
+    PyObject *solverObject;
+    std::string methodName;
+
+    std::vector<double> eigenvalues;
+    std::vector<Vector> eigenvectors;
+    int numComputedModes;
+};
+
+#endif /* SparsePythonCOOEigenSolver_h */
+
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSOE.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSOE.cpp
@@ -1,0 +1,471 @@
+#include "SparsePythonCompressedEigenSOE.h"
+
+#include "SparsePythonCompressedEigenSolver.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <Graph.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <OPS_Globals.h>
+#include <Vertex.h>
+#include <VertexIter.h>
+
+#include <algorithm>
+#include <cmath>
+
+SparsePythonCompressedEigenSOE::SparsePythonCompressedEigenSOE(
+    SparsePythonCompressedEigenSolver &theSolver,
+    StorageScheme scheme)
+    : EigenSOE(theSolver, EigenSOE_TAGS_SparsePythonCompressedEigenSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED),
+      storageScheme(scheme)
+{
+    if (storageScheme == StorageScheme::COO) {
+        opserr << "WARNING: SparsePythonCompressedEigenSOE does not support COO; defaulting to CSR" << endln;
+        storageScheme = StorageScheme::CSR;
+    }
+    theSolver.setEigenSOE(*this);
+}
+
+SparsePythonCompressedEigenSOE::SparsePythonCompressedEigenSOE(StorageScheme scheme)
+    : EigenSOE(EigenSOE_TAGS_SparsePythonCompressedEigenSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED),
+      storageScheme(scheme)
+{
+    if (storageScheme == StorageScheme::COO) {
+        opserr << "WARNING: SparsePythonCompressedEigenSOE does not support COO; defaulting to CSR" << endln;
+        storageScheme = StorageScheme::CSR;
+    }
+}
+
+SparsePythonCompressedEigenSOE::~SparsePythonCompressedEigenSOE() = default;
+
+int
+SparsePythonCompressedEigenSOE::getNumEqn(void) const
+{
+    return static_cast<int>(indexPtr.size() > 0 ? indexPtr.size() - 1 : 0);
+}
+
+void
+SparsePythonCompressedEigenSOE::buildCSRPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    const std::size_t nnz = static_cast<std::size_t>(size) + 2 * theGraph.getNumEdge();
+
+    // Build shared sparsity pattern
+    indexPtr.assign(static_cast<std::size_t>(size) + 1u, 0);
+    indices.resize(nnz);
+    kValues.assign(nnz, 0.0);
+    mValues.assign(nnz, 0.0);
+
+    int last = 0;
+    indexPtr[0] = 0;
+    Vertex *theVertex = nullptr;
+    for (int row = 0; row < size; ++row) {
+        theVertex = theGraph.getVertexPtr(row);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCompressedEigenSOE::buildCSRPattern - "
+                   << "vertex " << row << " not found in graph, "
+                   << "size set to 0" << endln;
+            indexPtr.assign(1u, 0);
+            indices.clear();
+            kValues.clear();
+            mValues.clear();
+            return;
+        }
+
+        const ID &theAdjacency = theVertex->getAdjacency();
+        ID columns(0, theAdjacency.Size() + 1);
+
+        columns.insert(theVertex->getTag());
+        for (int i = 0; i < theAdjacency.Size(); ++i) {
+            columns.insert(theAdjacency(i));
+        }
+
+        for (int i = 0; i < columns.Size(); ++i) {
+            indices[static_cast<std::size_t>(last)] = columns(i);
+            last++;
+        }
+
+        indexPtr[static_cast<std::size_t>(row + 1)] = last;
+    }
+}
+
+void
+SparsePythonCompressedEigenSOE::buildCSCPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    const std::size_t nnz = static_cast<std::size_t>(size) + 2 * theGraph.getNumEdge();
+
+    // Build shared sparsity pattern
+    indexPtr.assign(static_cast<std::size_t>(size) + 1u, 0);
+    indices.resize(nnz);
+    kValues.assign(nnz, 0.0);
+    mValues.assign(nnz, 0.0);
+
+    int last = 0;
+    indexPtr[0] = 0;
+    Vertex *theVertex = nullptr;
+    for (int col = 0; col < size; ++col) {
+        theVertex = theGraph.getVertexPtr(col);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCompressedEigenSOE::buildCSCPattern - "
+                   << "vertex " << col << " not found in graph, "
+                   << "size set to 0" << endln;
+            indexPtr.assign(1u, 0);
+            indices.clear();
+            kValues.clear();
+            mValues.clear();
+            return;
+        }
+
+        const ID &theAdjacency = theVertex->getAdjacency();
+        ID rows(0, theAdjacency.Size() + 1);
+
+        rows.insert(theVertex->getTag());
+        for (int i = 0; i < theAdjacency.Size(); ++i) {
+            rows.insert(theAdjacency(i));
+        }
+
+        for (int i = 0; i < rows.Size(); ++i) {
+            indices[static_cast<std::size_t>(last)] = rows(i);
+            last++;
+        }
+
+        indexPtr[static_cast<std::size_t>(col + 1)] = last;
+    }
+}
+
+int
+SparsePythonCompressedEigenSOE::setSize(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    if (size < 0) {
+        opserr << "WARNING: SparsePythonCompressedEigenSOE::setSize - "
+               << "size of SOE < 0" << endln;
+        return -1;
+    }
+
+    if (storageScheme == StorageScheme::CSR) {
+        buildCSRPattern(theGraph);
+    } else if (storageScheme == StorageScheme::CSC) {
+        buildCSCPattern(theGraph);
+    } else {
+        opserr << "WARNING: SparsePythonCompressedEigenSOE::setSize - unknown storage scheme\n";
+        return -1;
+    }
+
+    EigenSolver *theSolver = this->getSolver();
+    if (theSolver != nullptr) {
+        const int solverOK = theSolver->setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCompressedEigenSOE::setSize -"
+                   << "solver failed setSize()" << endln;
+            return solverOK;
+        }
+    }
+
+    matrixStatus = MatrixStatus::STRUCTURE_CHANGED;
+
+    return 0;
+}
+
+SparsePythonCompressedEigenSOE::MatrixStatus
+SparsePythonCompressedEigenSOE::getMatrixStatus() const
+{
+    return matrixStatus;
+}
+
+void
+SparsePythonCompressedEigenSOE::updateMatrixStatus()
+{
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+int
+SparsePythonCompressedEigenSOE::addA(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCompressedEigenSOE::addA - Matrix and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+
+    if (storageScheme == StorageScheme::CSR) {
+        if (fact == 1.0) {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+    
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+    
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+    
+                    for (int k = start; k < end; ++k) {
+                        if (indices[static_cast<std::size_t>(k)] == col) {
+                            kValues[static_cast<std::size_t>(k)] += m(i, j);
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+
+                    for (int k = start; k < end; ++k) {
+                        if (indices[static_cast<std::size_t>(k)] == col) {
+                            kValues[static_cast<std::size_t>(k)] += fact * m(i, j);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    } else { // CSC
+        if (fact == 1.0) {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        kValues[offset] += m(i, j);
+                    }
+                }
+            }
+        } else {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        kValues[offset] += fact * m(i, j);
+                    }
+                }
+            }
+        }
+    }
+
+    updateMatrixStatus();
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSOE::addM(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCompressedEigenSOE::addM - Matrix and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+
+    if (storageScheme == StorageScheme::CSR) {
+        if (fact == 1.0) {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+    
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+    
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+    
+                    for (int k = start; k < end; ++k) {
+                        if (indices[static_cast<std::size_t>(k)] == col) {
+                            mValues[static_cast<std::size_t>(k)] += m(i, j);
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+
+                    for (int k = start; k < end; ++k) {
+                        if (indices[static_cast<std::size_t>(k)] == col) {
+                            mValues[static_cast<std::size_t>(k)] += fact * m(i, j);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    } else { // CSC
+        if (fact == 1.0) {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        mValues[offset] += m(i, j);
+                    }
+                }
+            }
+        } else {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        mValues[offset] += fact * m(i, j);
+                    }
+                }
+            }
+        }
+    }
+
+    updateMatrixStatus();
+    return 0;
+}
+
+void
+SparsePythonCompressedEigenSOE::zeroA(void)
+{
+    std::fill(kValues.begin(), kValues.end(), 0.0);
+    updateMatrixStatus();
+}
+
+void
+SparsePythonCompressedEigenSOE::zeroM(void)
+{
+    std::fill(mValues.begin(), mValues.end(), 0.0);
+    updateMatrixStatus();
+}
+
+int
+SparsePythonCompressedEigenSOE::setPythonSolver(SparsePythonCompressedEigenSolver &newSolver)
+{
+    return setSolver(newSolver);
+}
+
+int
+SparsePythonCompressedEigenSOE::sendSelf(int commitTag, Channel &theChannel)
+{
+    // Not implemented yet
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSOE::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
+{
+    // Not implemented yet
+    return 0;
+}
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSOE.h
@@ -1,0 +1,115 @@
+#ifndef SparsePythonCompressedEigenSOE_h
+#define SparsePythonCompressedEigenSOE_h
+
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: Gustavo A. Araujo R. (garaujor@stanford.edu, gaaraujor@gmail.com)
+// Created: 11/25
+//
+// Description: This file contains the class definition for
+// SparsePythonCompressedEigenSOE. The system stores both stiffness (K) and mass (M)
+// matrices in compressed sparse format (CSR or CSC) with shared sparsity pattern
+// and delegates the eigen solve to a Python callable provided to the associated
+// SparsePythonCompressedEigenSolver instance.
+
+#include <EigenSOE.h>
+#include <Vector.h>
+#include <vector>
+
+#include "SparsePythonEigenCommon.h"
+
+class Channel;
+class FEM_ObjectBroker;
+class Graph;
+class ID;
+class Matrix;
+class SparsePythonCompressedEigenSolver;
+
+class SparsePythonCompressedEigenSOE : public EigenSOE
+{
+  public:
+    using StorageScheme = SparsePythonEigenStorageScheme;
+    using MatrixStatus = SparsePythonEigenMatrixStatus;
+
+    SparsePythonCompressedEigenSOE(SparsePythonCompressedEigenSolver &theSolver,
+                                    StorageScheme scheme = StorageScheme::CSR);
+    explicit SparsePythonCompressedEigenSOE(StorageScheme scheme = StorageScheme::CSR);
+    ~SparsePythonCompressedEigenSOE() override;
+
+    StorageScheme getStorageScheme() const { return storageScheme; }
+
+    int getNumEqn(void) const;
+    int setSize(Graph &theGraph) override;
+
+    int addA(const Matrix &, const ID &, double fact = 1.0) override;
+    int addM(const Matrix &, const ID &, double fact = 1.0) override;
+
+    void zeroA(void) override;
+    void zeroM(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setPythonSolver(SparsePythonCompressedEigenSolver &newSolver);
+
+    MatrixStatus getMatrixStatus(void) const;
+
+    // Accessors for shared sparsity pattern
+    const std::vector<int> &getIndexPtr(void) const { return indexPtr; }
+    const std::vector<int> &getIndices(void) const { return indices; }
+
+    // Accessors for K matrix (stiffness) values
+    const std::vector<double> &getKValues(void) const { return kValues; }
+    std::vector<double> &getKValues(void) { return kValues; }
+
+    // Accessors for M matrix (mass) values
+    const std::vector<double> &getMValues(void) const { return mValues; }
+    std::vector<double> &getMValues(void) { return mValues; }
+
+    std::size_t getNNZ(void) const { return kValues.size(); }
+
+  protected:
+    void updateMatrixStatus();
+    void buildCSRPattern(Graph &theGraph);
+    void buildCSCPattern(Graph &theGraph);
+
+    std::vector<int> &accessIndexPtr() { return indexPtr; }
+    std::vector<int> &accessIndices() { return indices; }
+
+  private:
+    // Shared sparsity pattern (same for K and M)
+    std::vector<int> indexPtr;
+    std::vector<int> indices;
+
+    // K matrix (stiffness) values
+    std::vector<double> kValues;
+
+    // M matrix (mass) values
+    std::vector<double> mValues;
+
+    MatrixStatus matrixStatus;
+    StorageScheme storageScheme;
+
+    friend class SparsePythonCompressedEigenSolver;
+};
+
+#endif /* SparsePythonCompressedEigenSOE_h */
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSolver.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSolver.cpp
@@ -1,0 +1,380 @@
+#include "SparsePythonCompressedEigenSolver.h"
+
+#include "SparsePythonCompressedEigenSOE.h"
+#include "SparsePythonEigenCommon.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <OPS_Globals.h>
+#include <Vector.h>
+#include <cstring>
+#include <elementAPI.h>
+#include <Python.h>
+
+namespace {
+
+// RAII helper that manages reference counting for transient PyObject* instances.
+struct PyObjectHolder {
+    PyObjectHolder() = default;
+    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
+    ~PyObjectHolder() { Py_XDECREF(ptr); }
+    PyObject *get() const { return ptr; }
+    PyObject *release() {
+        PyObject *tmp = ptr;
+        ptr = nullptr;
+        return tmp;
+    }
+    void reset(PyObject *obj = nullptr) {
+        if (ptr == obj) {
+            return;
+        }
+        Py_XDECREF(ptr);
+        ptr = obj;
+    }
+  private:
+    PyObject *ptr{nullptr};
+};
+
+} // namespace
+
+SparsePythonCompressedEigenSolver::SparsePythonCompressedEigenSolver()
+    : EigenSolver(EigenSOLVER_TAGS_SparsePythonCompressedEigenSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName("solve"),
+      numComputedModes(0)
+{
+}
+
+SparsePythonCompressedEigenSolver::SparsePythonCompressedEigenSolver(PyObject *callable,
+                                                   const char *method)
+    : EigenSolver(EigenSOLVER_TAGS_SparsePythonCompressedEigenSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName(method != nullptr ? method : "solve"),
+      numComputedModes(0)
+{
+    setPythonCallable(callable, methodName.c_str());
+}
+
+SparsePythonCompressedEigenSolver::~SparsePythonCompressedEigenSolver()
+{
+    if (solverObject != nullptr) {
+        if (Py_IsInitialized()) {
+            // Acquire GIL before decrementing reference count
+            // This is critical: Py_XDECREF must be called with GIL held
+            PyGILState_STATE gil_state = PyGILState_Ensure();
+            Py_XDECREF(solverObject);
+            PyGILState_Release(gil_state);
+        }
+        // If Python is not initialized, we cannot safely call Py_XDECREF
+        // The object will be cleaned up when Python interpreter shuts down
+        solverObject = nullptr;
+    }
+}
+
+int
+SparsePythonCompressedEigenSolver::setEigenSOE(SparsePythonCompressedEigenSOE &theEigenSOE)
+{
+    theSOE = &theEigenSOE;
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSolver::setPythonCallable(PyObject *callable, const char *method)
+{
+    if (method != nullptr) {
+        methodName = method;
+    }
+
+    if (callable == nullptr) {
+        Py_XDECREF(solverObject);
+        solverObject = nullptr;
+        return 0;
+    }
+
+    Py_XINCREF(callable);
+    Py_XDECREF(solverObject);
+    solverObject = callable;
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSolver::solve(int numModes, bool generalized, bool findSmallest)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::solve - no associated SOE\n";
+        return -1;
+    }
+    if (solverObject == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::solve - no Python callable bound\n";
+        return -2;
+    }
+    if (theSOE->getNumEqn() == 0) {
+        return 0;
+    }
+
+    return callPythonSolver(numModes, generalized, findSmallest);
+}
+
+int
+SparsePythonCompressedEigenSolver::setSize(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::setSize - no associated SOE\n";
+        return -1;
+    }
+    return 0;
+}
+
+const Vector &
+SparsePythonCompressedEigenSolver::getEigenvector(int mode)
+{
+    // mode is 1-indexed (matches ArpackSolver and analysis code)
+    if (mode <= 0 || mode > numComputedModes) {
+        opserr << "SparsePythonCompressedEigenSolver::getEigenvector - mode " << mode
+               << " out of range (1 - " << numComputedModes << ")\n";
+        static Vector dummy;
+        return dummy;
+    }
+    return eigenvectorWrappers[static_cast<std::size_t>(mode - 1)];
+}
+
+double
+SparsePythonCompressedEigenSolver::getEigenvalue(int mode)
+{
+    // mode is 1-indexed (matches ArpackSolver and analysis code)
+    if (mode <= 0 || mode > numComputedModes) {
+        opserr << "SparsePythonCompressedEigenSolver::getEigenvalue - mode " << mode
+               << " out of range (1 - " << numComputedModes << ")\n";
+        return 0.0;
+    }
+    return eigenvaluesBuffer[static_cast<std::size_t>(mode - 1)];
+}
+
+int
+SparsePythonCompressedEigenSolver::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSolver::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedEigenSolver::callPythonSolver(int numModes, bool generalized, bool findSmallest)
+{
+    // Pull the SOE storage (shared sparsity pattern, separate values for K and M)
+    const std::vector<int> &indexPtr = theSOE->getIndexPtr();
+    const std::vector<int> &indices = theSOE->getIndices();
+    std::vector<double> &kValues = theSOE->getKValues();
+    std::vector<double> &mValues = theSOE->getMValues();
+
+    if (indexPtr.size() < 2) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - invalid sparse structure\n";
+        return -3;
+    }
+
+    // Ensure we hold the GIL while touching Python APIs.
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    // Lookup the bound solve method; bail if missing or not callable.
+    PyObjectHolder method(PyObject_GetAttrString(solverObject, methodName.c_str()));
+    if (method.get() == nullptr || !PyCallable_Check(method.get())) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - attribute '"
+               << methodName.c_str() << "' not callable\n";
+        PyGILState_Release(gilState);
+        return -4;
+    }
+
+    // Build memoryviews for shared sparsity pattern
+    const Py_ssize_t ptrBytes = static_cast<Py_ssize_t>(indexPtr.size() * sizeof(int));
+    const Py_ssize_t indBytes = static_cast<Py_ssize_t>(indices.size() * sizeof(int));
+
+    PyObjectHolder pyPtr(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(indexPtr.data())),
+        ptrBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyInd(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(indices.data())),
+        indBytes,
+        PyBUF_READ));
+
+    // Build memoryviews for K and M values
+    const Py_ssize_t kValuesBytes = static_cast<Py_ssize_t>(kValues.size() * sizeof(double));
+    const Py_ssize_t mValuesBytes = static_cast<Py_ssize_t>(mValues.size() * sizeof(double));
+
+    PyObjectHolder pyKValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(kValues.data()),
+        kValuesBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyMValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(mValues.data()),
+        mValuesBytes,
+        PyBUF_READ));
+
+    if (pyPtr.get() == nullptr || pyInd.get() == nullptr || 
+        pyKValues.get() == nullptr || pyMValues.get() == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - failed to create memory views\n";
+        PyGILState_Release(gilState);
+        return -5;
+    }
+
+    // Pre-allocate buffers for zero-copy transfer from Python
+    const int numEqn = theSOE->getNumEqn();
+    eigenvaluesBuffer.resize(static_cast<std::size_t>(numModes));
+    eigenvectorsBuffer.resize(static_cast<std::size_t>(numModes) * static_cast<std::size_t>(numEqn));
+
+    // Create writable memoryviews for eigenvalues and eigenvectors buffers
+    const Py_ssize_t eigenvaluesBytes = static_cast<Py_ssize_t>(eigenvaluesBuffer.size() * sizeof(double));
+    const Py_ssize_t eigenvectorsBytes = static_cast<Py_ssize_t>(eigenvectorsBuffer.size() * sizeof(double));
+
+    PyObjectHolder pyEigenvaluesBuffer(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(eigenvaluesBuffer.data()),
+        eigenvaluesBytes,
+        PyBUF_WRITE));
+
+    PyObjectHolder pyEigenvectorsBuffer(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(eigenvectorsBuffer.data()),
+        eigenvectorsBytes,
+        PyBUF_WRITE));
+
+    if (pyEigenvaluesBuffer.get() == nullptr || pyEigenvectorsBuffer.get() == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - failed to create writable memoryviews for results\n";
+        PyGILState_Release(gilState);
+        return -5;
+    }
+
+    // Scalar metadata
+    PyObjectHolder matrixStatus(
+        PyUnicode_FromString(theSOE->getMatrixStatus().to_str()));
+    PyObjectHolder storageScheme(
+        PyUnicode_FromString(theSOE->getStorageScheme().to_str()));
+
+    PyObjectHolder kwargs(PyDict_New());
+    const char *indexPtrKeyword = "index_ptr";
+    const char *indicesKeyword = "indices";
+    const char *kValuesKeyword = "k_values";
+    const char *mValuesKeyword = "m_values";
+    const char *matrixStatusKeyword = "matrix_status";
+    const char *storageSchemeKeyword = "storage_scheme";
+    const char *numEqnKeyword = "num_eqn";
+    const char *nnzKeyword = "nnz";
+    const char *numModesKeyword = "num_modes";
+    const char *generalizedKeyword = "generalized";
+    const char *findSmallestKeyword = "find_smallest";
+    const char *eigenvaluesKeyword = "eigenvalues";
+    const char *eigenvectorsKeyword = "eigenvectors";
+
+    if (kwargs.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), indexPtrKeyword, pyPtr.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), indicesKeyword, pyInd.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), kValuesKeyword, pyKValues.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), mValuesKeyword, pyMValues.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), eigenvaluesKeyword, pyEigenvaluesBuffer.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), eigenvectorsKeyword, pyEigenvectorsBuffer.get()) != 0 ||
+        matrixStatus.get() == nullptr ||
+        storageScheme.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), matrixStatusKeyword, matrixStatus.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), storageSchemeKeyword, storageScheme.get()) != 0) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - failed to populate kwargs\n";
+        PyGILState_Release(gilState);
+        return -6;
+    }
+
+    // Add additional metadata
+    PyObjectHolder numEqnObj(PyLong_FromLong(numEqn));
+    PyObjectHolder nnz(PyLong_FromSize_t(theSOE->getNNZ()));
+    PyObjectHolder pyNumModes(PyLong_FromLong(numModes));
+    PyObjectHolder pyGeneralized(PyBool_FromLong(generalized ? 1 : 0));
+    PyObjectHolder pyFindSmallest(PyBool_FromLong(findSmallest ? 1 : 0));
+
+    if (numEqnObj.get() == nullptr || nnz.get() == nullptr ||
+        pyNumModes.get() == nullptr || pyGeneralized.get() == nullptr || pyFindSmallest.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), numEqnKeyword, numEqnObj.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), nnzKeyword, nnz.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), numModesKeyword, pyNumModes.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), generalizedKeyword, pyGeneralized.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), findSmallestKeyword, pyFindSmallest.get()) != 0) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - failed to set metadata kwargs\n";
+        PyGILState_Release(gilState);
+        return -7;
+    }
+
+    // Call Python solver - it should write directly to the writable buffers
+    PyObject *args = PyTuple_New(0);
+    if (args == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - failed to create args tuple\n";
+        PyGILState_Release(gilState);
+        return -8;
+    }
+    PyObjectHolder argsHolder(args);
+
+    PyObjectHolder result(PyObject_Call(method.get(), args, kwargs.get()));
+
+    if (result.get() == nullptr) {
+        opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - Python call failed\n";
+        PyErr_Print();
+        PyGILState_Release(gilState);
+        return -9;
+    }
+
+    // Check return value - Python should write directly to buffers and return None or status code
+    int status = 0;
+    if (result.get() != Py_None) {
+        if (PyLong_Check(result.get())) {
+            status = static_cast<int>(PyLong_AsLong(result.get()));
+            if (status < 0) {
+                PyGILState_Release(gilState);
+                return status;
+            }
+        } else {
+            opserr << "SparsePythonCompressedEigenSolver::callPythonSolver - solver returned unexpected type (expected None or integer status)\n";
+            PyGILState_Release(gilState);
+            return -10;
+        }
+    }
+
+    // Create Vector wrappers for eigenvectors pointing to the flat buffer
+    // Buffer layout: eigenvectorsBuffer[mode * numEqn + eqn] (mode-major, row-major)
+    eigenvectorWrappers.clear();
+    eigenvectorWrappers.reserve(static_cast<std::size_t>(numModes));
+    for (int mode = 0; mode < numModes; ++mode) {
+        double *modeData = eigenvectorsBuffer.data() + mode * numEqn;
+        eigenvectorWrappers.emplace_back(Vector(modeData, numEqn));
+    }
+
+    // Release GIL before returning - all Python API calls are complete
+    // PyObjectHolder destructors will be called when function returns, but
+    // they need the GIL, so we manually clean them up now while we have the GIL
+    result.reset(nullptr);  // This will Py_XDECREF while GIL is held
+    argsHolder.reset(nullptr);
+    method.reset(nullptr);
+    // Note: Other PyObjectHolder objects (pyPtr, pyInd, pyKValues, pyMValues, etc.)
+    // are incorporated into kwargs, and kwargs itself will be cleaned up below.
+    // We need to clean up all PyObjectHolder objects before releasing GIL.
+    matrixStatus.reset(nullptr);
+    storageScheme.reset(nullptr);
+    numEqnObj.reset(nullptr);
+    nnz.reset(nullptr);
+    pyNumModes.reset(nullptr);
+    pyGeneralized.reset(nullptr);
+    pyFindSmallest.reset(nullptr);
+    pyPtr.reset(nullptr);
+    pyInd.reset(nullptr);
+    pyKValues.reset(nullptr);
+    pyMValues.reset(nullptr);
+    pyEigenvaluesBuffer.reset(nullptr);
+    pyEigenvectorsBuffer.reset(nullptr);
+    kwargs.reset(nullptr);
+    PyGILState_Release(gilState);
+
+    numComputedModes = numModes;
+    return status;
+}
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSolver.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonCompressedEigenSolver.h
@@ -1,0 +1,83 @@
+#ifndef SparsePythonCompressedEigenSolver_h
+#define SparsePythonCompressedEigenSolver_h
+
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: Gustavo A. Araujo R. (garaujor@stanford.edu, gaaraujor@gmail.com)
+// Created: 11/25
+//
+// Description: This file contains the class definition for
+// SparsePythonCompressedEigenSolver. The solver delegates the eigen solve to a Python
+// callable that operates directly on the sparse buffers owned by
+// SparsePythonCompressedEigenSOE.
+
+#include "SparsePythonCompressedEigenSOE.h"
+#include "SparsePythonEigenCommon.h"
+
+#include <EigenSolver.h>
+#include <Vector.h>
+#include <string>
+
+struct _object;
+typedef _object PyObject;
+
+class Channel;
+class FEM_ObjectBroker;
+class SparsePythonCompressedEigenSolver : public EigenSolver
+{
+  public:
+    SparsePythonCompressedEigenSolver();
+    explicit SparsePythonCompressedEigenSolver(PyObject *callable,
+                                                const char *methodName = "solve");
+    ~SparsePythonCompressedEigenSolver() override;
+
+    int solve(int numModes, bool generalized, bool findSmallest = true) override;
+    int setSize(void) override;
+
+    virtual const Vector &getEigenvector(int mode) override;
+    virtual double getEigenvalue(int mode) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setEigenSOE(SparsePythonCompressedEigenSOE &theSOE);
+    int setPythonCallable(PyObject *callable, const char *methodName = "solve");
+
+    PyObject *getPythonCallable() const { return solverObject; }
+    const std::string &getMethodName() const { return methodName; }
+
+  private:
+    int callPythonSolver(int numModes, bool generalized, bool findSmallest);
+
+    SparsePythonCompressedEigenSOE *theSOE;
+    PyObject *solverObject;
+    std::string methodName;
+
+    // Storage for eigenvalues and eigenvectors
+    // Flat buffers for zero-copy transfer from Python
+    std::vector<double> eigenvaluesBuffer;      // Flat buffer for eigenvalues
+    std::vector<double> eigenvectorsBuffer;     // Flat buffer: numModes * numEqn (row-major: mode-major)
+    std::vector<Vector> eigenvectorWrappers;    // Vector wrappers pointing to slices of eigenvectorsBuffer
+    int numComputedModes;
+};
+
+#endif /* SparsePythonCompressedEigenSolver_h */
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenCommon.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenCommon.cpp
@@ -1,0 +1,38 @@
+#include "SparsePythonEigenCommon.h"
+
+// Define static const members for SparsePythonEigenStorageScheme
+const SparsePythonEigenStorageScheme SparsePythonEigenStorageScheme::CSR(SparsePythonEigenStorageScheme::Value::CSR);
+const SparsePythonEigenStorageScheme SparsePythonEigenStorageScheme::CSC(SparsePythonEigenStorageScheme::Value::CSC);
+const SparsePythonEigenStorageScheme SparsePythonEigenStorageScheme::COO(SparsePythonEigenStorageScheme::Value::COO);
+
+const char* SparsePythonEigenStorageScheme::to_str() const {
+    switch (value_) {
+        case Value::CSR:
+            return "CSR";
+        case Value::CSC:
+            return "CSC";
+        case Value::COO:
+            return "COO";
+        default:
+            return "CSR";  // fallback
+    }
+}
+
+// Define static const members for SparsePythonEigenMatrixStatus
+const SparsePythonEigenMatrixStatus SparsePythonEigenMatrixStatus::UNCHANGED(SparsePythonEigenMatrixStatus::Value::UNCHANGED);
+const SparsePythonEigenMatrixStatus SparsePythonEigenMatrixStatus::COEFFICIENTS_CHANGED(SparsePythonEigenMatrixStatus::Value::COEFFICIENTS_CHANGED);
+const SparsePythonEigenMatrixStatus SparsePythonEigenMatrixStatus::STRUCTURE_CHANGED(SparsePythonEigenMatrixStatus::Value::STRUCTURE_CHANGED);
+
+const char* SparsePythonEigenMatrixStatus::to_str() const {
+    switch (value_) {
+        case Value::UNCHANGED:
+            return "UNCHANGED";
+        case Value::COEFFICIENTS_CHANGED:
+            return "COEFFICIENTS_CHANGED";
+        case Value::STRUCTURE_CHANGED:
+            return "STRUCTURE_CHANGED";
+        default:
+            return "UNCHANGED";  // fallback
+    }
+}
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenCommon.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenCommon.h
@@ -1,0 +1,85 @@
+#ifndef SparsePythonEigenCommon_h
+#define SparsePythonEigenCommon_h
+
+/**
+ * Storage scheme class: acts like an enum with string conversion.
+ */
+class SparsePythonEigenStorageScheme {
+private:
+    enum class Value : int {
+        CSR = 0,
+        CSC = 1,
+        COO = 2
+    };
+    Value value_;
+
+public:
+    // Static const members for easy access (defined in .cpp)
+    static const SparsePythonEigenStorageScheme CSR;
+    static const SparsePythonEigenStorageScheme CSC;
+    static const SparsePythonEigenStorageScheme COO;
+
+    // Constructors
+    SparsePythonEigenStorageScheme() : value_(Value::CSR) {}
+    explicit SparsePythonEigenStorageScheme(Value v) : value_(v) {}
+    SparsePythonEigenStorageScheme(int v) : value_(static_cast<Value>(v)) {}
+
+    // Implicit conversion operators for comparisons and assignments
+    operator Value() const { return value_; }
+    operator int() const { return static_cast<int>(value_); }
+
+    // Comparison operators
+    bool operator==(const SparsePythonEigenStorageScheme& other) const {
+        return value_ == other.value_;
+    }
+    bool operator!=(const SparsePythonEigenStorageScheme& other) const {
+        return value_ != other.value_;
+    }
+
+    // String conversion for Python
+    const char* to_str() const;
+};
+
+/**
+ * Matrix status class: tracks changes for potential factorization reuse.
+ * Useful for shift-and-invert methods (e.g., ARPACK mode 3) that factorize
+ * (K - sigma*M) and can reuse symbolic factorization if only coefficients change.
+ */
+class SparsePythonEigenMatrixStatus {
+private:
+    enum class Value : int {
+        UNCHANGED = 0,
+        COEFFICIENTS_CHANGED = 1,
+        STRUCTURE_CHANGED = 2
+    };
+    Value value_;
+
+public:
+    // Static const members for easy access (defined in .cpp)
+    static const SparsePythonEigenMatrixStatus UNCHANGED;
+    static const SparsePythonEigenMatrixStatus COEFFICIENTS_CHANGED;
+    static const SparsePythonEigenMatrixStatus STRUCTURE_CHANGED;
+
+    // Constructors
+    SparsePythonEigenMatrixStatus() : value_(Value::UNCHANGED) {}
+    explicit SparsePythonEigenMatrixStatus(Value v) : value_(v) {}
+    SparsePythonEigenMatrixStatus(int v) : value_(static_cast<Value>(v)) {}
+
+    // Implicit conversion operators for comparisons and assignments
+    operator Value() const { return value_; }
+    operator int() const { return static_cast<int>(value_); }
+
+    // Comparison operators
+    bool operator==(const SparsePythonEigenMatrixStatus& other) const {
+        return value_ == other.value_;
+    }
+    bool operator!=(const SparsePythonEigenMatrixStatus& other) const {
+        return value_ != other.value_;
+    }
+
+    // String conversion for Python
+    const char* to_str() const;
+};
+
+#endif /* SparsePythonEigenCommon_h */
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.cpp
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.cpp
@@ -1,0 +1,134 @@
+#include "SparsePythonEigenFactory.h"
+
+#include "SparsePythonCompressedEigenSOE.h"
+#include "SparsePythonCompressedEigenSolver.h"
+#include "SparsePythonCOOEigenSOE.h"
+#include "SparsePythonCOOEigenSolver.h"
+#include "SparsePythonEigenCommon.h"
+
+#include <OPS_Globals.h>
+#include <elementAPI.h>
+
+#include <Python.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <string>
+
+namespace {
+
+bool
+IsSparsePythonEigenType(const char *type)
+{
+    return strcmp(type, "PythonSparse") == 0 ||
+           strcmp(type, "PythonCompressedSparseEigen") == 0;
+}
+
+std::string
+ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+bool
+ParseSchemeToken(const char *token, SparsePythonEigenStorageScheme &scheme)
+{
+    if (token == nullptr) {
+        return false;
+    }
+    std::string normalized = ToLower(token);
+    if (normalized == "csr" || normalized == "row") {
+        scheme = SparsePythonEigenStorageScheme::CSR;
+        return true;
+    }
+    if (normalized == "csc" || normalized == "column" || normalized == "col") {
+        scheme = SparsePythonEigenStorageScheme::CSC;
+        return true;
+    }
+    if (normalized == "coo") {
+        scheme = SparsePythonEigenStorageScheme::COO;
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+void *
+OPS_SparsePythonEigenSolver()
+{
+    const char *expectedSyntax = "eigen 'PythonSparse' numModes {'solver': SolverObject, 'scheme': 'CSR'|'CSC'|'COO'}";
+
+    // Note: This function is called AFTER numModes has been read in PythonAnalysisBuilder.cpp
+    // So we don't need to reset or read the type string again - just get the dict argument
+
+    if (!Py_IsInitialized()) {
+        Py_Initialize();
+    }
+
+    // Get the dictionary argument (should be the next argument after numModes)
+    void *dictPtr = OPS_GetVoidPtr();
+    if (dictPtr == nullptr) {
+        opserr << "WARNING: eigen PythonSparse - requires a dictionary argument as third parameter" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    PyObject *dict = static_cast<PyObject *>(dictPtr);
+    if (!PyDict_Check(dict)) {
+        opserr << "WARNING: eigen PythonSparse - third argument must be a dictionary" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    // Extract 'solver' (required)
+    PyObject *solverObj = PyDict_GetItemString(dict, "solver");
+    if (solverObj == nullptr) {
+        opserr << "WARNING: eigen PythonSparse - dictionary must contain 'solver' key" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    // Extract 'scheme' (optional, defaults to CSR)
+    SparsePythonEigenStorageScheme scheme = SparsePythonEigenStorageScheme::CSR;
+    PyObject *schemeObj = PyDict_GetItemString(dict, "scheme");
+    if (schemeObj != nullptr) {
+        if (!PyUnicode_Check(schemeObj)) {
+            opserr << "WARNING: eigen PythonSparse - 'scheme' must be a string" << endln;
+            return nullptr;
+        }
+        const char *schemeStr = PyUnicode_AsUTF8(schemeObj);
+        if (schemeStr == nullptr || !ParseSchemeToken(schemeStr, scheme)) {
+            opserr << "WARNING: eigen PythonSparse - unknown storage scheme '"
+                   << (schemeStr != nullptr ? schemeStr : "null") << "' (expected CSR, CSC, or COO)" << endln;
+            return nullptr;
+        }
+    }
+
+    if (scheme == SparsePythonEigenStorageScheme::COO) {
+        SparsePythonCOOEigenSolver *solver = new SparsePythonCOOEigenSolver();
+        if (solver->setPythonCallable(solverObj, "solve") != 0) {
+            opserr << "WARNING: eigen PythonSparse - failed to set Python callable" << endln;
+            delete solver;
+            return nullptr;
+        }
+        SparsePythonCOOEigenSOE *soe = new SparsePythonCOOEigenSOE(*solver);
+        return static_cast<void *>(soe);
+    }
+
+    SparsePythonCompressedEigenSolver *solver = new SparsePythonCompressedEigenSolver();
+    if (solver->setPythonCallable(solverObj, "solve") != 0) {
+        opserr << "WARNING: eigen PythonSparse - failed to set Python callable" << endln;
+        delete solver;
+        return nullptr;
+    }
+
+    SparsePythonCompressedEigenSOE *soe = new SparsePythonCompressedEigenSOE(*solver, scheme);
+    return static_cast<void *>(soe);
+}
+
+

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.h
@@ -1,8 +1,6 @@
 #ifndef SparsePythonEigenFactory_h
 #define SparsePythonEigenFactory_h
 
-#include "SparsePythonEigenCommon.h"
-
 /**
  * Parse the `eigen PythonSparse` command and construct the corresponding EigenSOE.
  *

--- a/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.h
+++ b/SRC/system_of_eqn/eigenSOE/sparsePython/SparsePythonEigenFactory.h
@@ -1,0 +1,28 @@
+#ifndef SparsePythonEigenFactory_h
+#define SparsePythonEigenFactory_h
+
+#include "SparsePythonEigenCommon.h"
+
+/**
+ * Parse the `eigen PythonSparse` command and construct the corresponding EigenSOE.
+ *
+ * Expected syntax:
+ *   `eigen PythonSparse numModes {'solver': SolverObject, 'scheme': 'CSR'|'CSC'|'COO'}`
+ *
+ * The supplied Python object must expose a `solve` method. When invoked the
+ * solver receives memoryviews pointing directly to the EigenSOE storage:
+ *   - Shared sparsity pattern: `index_ptr` (int32) and `indices` (int32) arrays
+ *   - Separate value arrays: `k_values` (float64) for stiffness, `m_values` (float64) for mass
+ *   - Metadata: `num_eqn`, `nnz`, `matrix_status`, `storage_scheme`, `num_modes`, `generalized`, `find_smallest`
+ *
+ * The solver must return a tuple (eigenvalues, eigenvectors) where:
+ *   - eigenvalues: list of floats
+ *   - eigenvectors: list of lists (each inner list is an eigenvector)
+ *
+ * The returned pointer owns a Python-backed `EigenSOE` instance and should be
+ * treated as an `EigenSOE*` by the caller.
+ */
+void *OPS_SparsePythonEigenSolver();
+
+#endif /* SparsePythonEigenFactory_h */
+

--- a/SRC/system_of_eqn/linearSOE/CMakeLists.txt
+++ b/SRC/system_of_eqn/linearSOE/CMakeLists.txt
@@ -25,6 +25,7 @@ add_subdirectory(fullGEN)
 add_subdirectory(sparseGEN)
 add_subdirectory(sparseSYM)
 add_subdirectory(umfGEN)
+add_subdirectory(sparsePython)
 
 add_subdirectory(profileSPD)
 #add_subdirectory(cg)

--- a/SRC/system_of_eqn/linearSOE/Makefile
+++ b/SRC/system_of_eqn/linearSOE/Makefile
@@ -17,6 +17,7 @@ all:         $(OBJS)
 	@$(CD) $(FE)/system_of_eqn/linearSOE/petsc; $(MAKE);
 	@$(CD) $(FE)/system_of_eqn/linearSOE/mumps; $(MAKE);
 	@$(CD) $(FE)/system_of_eqn/linearSOE/itpack; $(MAKE);
+	@$(CD) $(FE)/system_of_eqn/linearSOE/sparsePython; $(MAKE);
 
 
 
@@ -40,6 +41,7 @@ spotless: clean
 	@$(CD) $(FE)/system_of_eqn/linearSOE/petsc; $(MAKE) wipe;
 	@$(CD) $(FE)/system_of_eqn/linearSOE/mumps; $(MAKE) wipe;
 	@$(CD) $(FE)/system_of_eqn/linearSOE/itpack; $(MAKE) wipe;
+	@$(CD) $(FE)/system_of_eqn/linearSOE/sparsePython; $(MAKE) wipe;
 
 wipe: spotless
 

--- a/SRC/system_of_eqn/linearSOE/sparsePython/CMakeLists.txt
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/CMakeLists.txt
@@ -1,0 +1,20 @@
+target_sources(OPS_SysOfEqn
+  PRIVATE
+    SparsePythonCompressedLinSOE.cpp
+    SparsePythonCompressedLinSolver.cpp
+    SparsePythonCOOLinSOE.cpp
+    SparsePythonCOOLinSolver.cpp
+    SparsePythonFactory.cpp
+    SparsePythonCommon.cpp
+  PUBLIC
+    SparsePythonCompressedLinSOE.h
+    SparsePythonCompressedLinSolver.h
+    SparsePythonCOOLinSOE.h
+    SparsePythonCOOLinSolver.h
+    SparsePythonCommon.h
+    SparsePythonFactory.h
+)
+
+find_package(Python3 COMPONENTS Development REQUIRED)
+target_link_libraries(OPS_SysOfEqn PRIVATE Python3::Python)
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/Makefile
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/Makefile
@@ -1,0 +1,22 @@
+include ../../../../Makefile.def
+
+OBJS       = SparsePythonCompressedLinSOE.o SparsePythonCompressedLinSolver.o \
+             SparsePythonCOOLinSOE.o SparsePythonCOOLinSolver.o \
+             SparsePythonFactory.o
+
+all:         $(OBJS)
+
+# Miscellaneous
+tidy:
+	@$(RM) $(RMFLAGS) Makefile.bak *~ #*# core
+
+clean: tidy
+	@$(RM) $(RMFLAGS) $(OBJS) *.o
+
+spotless: clean
+	@$(RM) $(RMFLAGS)
+
+wipe: spotless
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSOE.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSOE.cpp
@@ -1,0 +1,355 @@
+#include "SparsePythonCOOLinSOE.h"
+
+#include "SparsePythonCOOLinSolver.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <Graph.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <OPS_Globals.h>
+#include <Vertex.h>
+#include <VertexIter.h>
+
+#include <algorithm>
+#include <cmath>
+
+SparsePythonCOOLinSOE::SparsePythonCOOLinSOE(SparsePythonCOOLinSolver &theSolver)
+    : LinearSOE(theSolver, LinSOE_TAGS_SparsePythonCOOLinSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED)
+{
+    theSolver.setLinearSOE(*this);
+    updateVectorViews();
+}
+
+SparsePythonCOOLinSOE::SparsePythonCOOLinSOE()
+    : LinearSOE(LinSOE_TAGS_SparsePythonCOOLinSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED)
+{
+    updateVectorViews();
+}
+
+SparsePythonCOOLinSOE::~SparsePythonCOOLinSOE() = default;
+
+int
+SparsePythonCOOLinSOE::getNumEqn(void) const
+{
+    return static_cast<int>(sol.size());
+}
+
+void
+SparsePythonCOOLinSOE::buildCOOPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    if (size < 0) {
+        opserr << "WARNING: SparsePythonCOOLinSOE::buildCOOPattern - invalid graph size" << endln;
+        rowIndices.clear();
+        colIndices.clear();
+        values.clear();
+        rhs.clear();
+        sol.clear();
+        rowOffsets.clear();
+        updateVectorViews();
+        return;
+    }
+
+    rhs.assign(static_cast<std::size_t>(size), 0.0);
+    sol.assign(static_cast<std::size_t>(size), 0.0);
+
+    const std::size_t nnz =
+        static_cast<std::size_t>(size) + 2u * static_cast<std::size_t>(theGraph.getNumEdge());
+
+    rowOffsets.assign(static_cast<std::size_t>(size) + 1u, 0);
+    rowIndices.resize(nnz);
+    colIndices.resize(nnz);
+    values.assign(nnz, 0.0);
+
+    std::size_t last = 0;
+    rowOffsets[0] = 0;
+
+    Vertex *theVertex = nullptr;
+    for (int row = 0; row < size; ++row) {
+        theVertex = theGraph.getVertexPtr(row);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCOOLinSOE::buildCOOPattern - vertex "
+                   << row << " not found; resetting system" << endln;
+            rowOffsets.assign(1u, 0);
+            rowIndices.clear();
+            colIndices.clear();
+            values.clear();
+            rhs.clear();
+            sol.clear();
+            updateVectorViews();
+            return;
+        }
+
+        const ID &adjacency = theVertex->getAdjacency();
+        ID columns(0, adjacency.Size() + 1);
+
+        columns.insert(theVertex->getTag());
+        for (int i = 0; i < adjacency.Size(); ++i) {
+            columns.insert(adjacency(i));
+        }
+
+        for (int i = 0; i < columns.Size(); ++i) {
+            rowIndices[last] = row;
+            colIndices[last] = columns(i);
+            ++last;
+        }
+
+        rowOffsets[static_cast<std::size_t>(row + 1)] = static_cast<int>(last);
+    }
+
+    if (last < nnz) {
+        rowIndices.resize(last);
+        colIndices.resize(last);
+        values.resize(last);
+    }
+}
+
+int
+SparsePythonCOOLinSOE::setSize(Graph &theGraph)
+{
+    buildCOOPattern(theGraph);
+    updateVectorViews();
+
+    LinearSOESolver *theSolver = this->getSolver();
+    if (theSolver != nullptr) {
+        const int solverOK = theSolver->setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCOOLinSOE::setSize - solver failed setSize()" << endln;
+            return solverOK;
+        }
+    }
+
+    matrixStatus = MatrixStatus::STRUCTURE_CHANGED;
+    return 0;
+}
+
+int
+SparsePythonCOOLinSOE::addA(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCOOLinSOE::addA - Matrix and ID not of similar sizes" << endln;
+        return -1;
+    }
+
+    const int size = getNumEqn();
+    if (size == 0 || rowOffsets.size() != static_cast<std::size_t>(size) + 1u) {
+        return 0;
+    }
+
+    if (fact == 1.0) {
+        for (int i = 0; i < idSize; ++i) {
+            const int row = id(i);
+            if (row < 0 || row >= size) {
+                continue;
+            }
+
+            const int start = rowOffsets[static_cast<std::size_t>(row)];
+            const int end = rowOffsets[static_cast<std::size_t>(row + 1)];
+
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                for (int k = start; k < end; ++k) {
+                    if (colIndices[static_cast<std::size_t>(k)] == col) {
+                        values[static_cast<std::size_t>(k)] += m(i, j);
+                        break;
+                    }
+                }
+            }
+        }
+    } else {
+        for (int i = 0; i < idSize; ++i) {
+            const int row = id(i);
+            if (row < 0 || row >= size) {
+                continue;
+            }
+
+            const int start = rowOffsets[static_cast<std::size_t>(row)];
+            const int end = rowOffsets[static_cast<std::size_t>(row + 1)];
+
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                for (int k = start; k < end; ++k) {
+                    if (colIndices[static_cast<std::size_t>(k)] == col) {
+                        values[static_cast<std::size_t>(k)] += fact * m(i, j);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+
+    return 0;
+}
+
+int
+SparsePythonCOOLinSOE::addB(const Vector &v, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != v.Size()) {
+        opserr << "SparsePythonCOOLinSOE::addB - Vector and ID not of similar sizes" << endln;
+        return -1;
+    }
+
+    for (int i = 0; i < idSize; ++i) {
+        const int pos = id(i);
+        if (pos < 0 || pos >= getNumEqn()) {
+            continue;
+        }
+        rhs[static_cast<std::size_t>(pos)] += fact * v(i);
+    }
+    return 0;
+}
+
+int
+SparsePythonCOOLinSOE::setB(const Vector &v, double fact)
+{
+    if (fact == 0.0) {
+        std::fill(rhs.begin(), rhs.end(), 0.0);
+        bVector.Zero();
+        return 0;
+    }
+
+    if (v.Size() != getNumEqn()) {
+        opserr << "SparsePythonCOOLinSOE::setB - incompatible sizes "
+               << getNumEqn() << " and " << v.Size() << endln;
+        return -1;
+    }
+
+    for (int i = 0; i < getNumEqn(); ++i) {
+        rhs[static_cast<std::size_t>(i)] = fact * v(i);
+    }
+    return 0;
+}
+
+void
+SparsePythonCOOLinSOE::zeroA(void)
+{
+    std::fill(values.begin(), values.end(), 0.0);
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+void
+SparsePythonCOOLinSOE::zeroB(void)
+{
+    std::fill(rhs.begin(), rhs.end(), 0.0);
+}
+
+const Vector &
+SparsePythonCOOLinSOE::getX(void)
+{
+    return xVector;
+}
+
+const Vector &
+SparsePythonCOOLinSOE::getB(void)
+{
+    return bVector;
+}
+
+double
+SparsePythonCOOLinSOE::normRHS(void)
+{
+    double norm = 0.0;
+    for (double value : rhs) {
+        norm += value * value;
+    }
+    return std::sqrt(norm);
+}
+
+void
+SparsePythonCOOLinSOE::setX(int loc, double value)
+{
+    if (loc >= 0 && loc < getNumEqn()) {
+        sol[static_cast<std::size_t>(loc)] = value;
+    }
+}
+
+void
+SparsePythonCOOLinSOE::setX(const Vector &X)
+{
+    if (X.Size() != getNumEqn()) {
+        return;
+    }
+    for (int i = 0; i < getNumEqn(); ++i) {
+        sol[static_cast<std::size_t>(i)] = X(i);
+    }
+}
+
+int
+SparsePythonCOOLinSOE::solve(void)
+{
+    int status = this->LinearSOE::solve();
+    if (status < 0) {
+        return status;
+    }
+    matrixStatus = MatrixStatus::UNCHANGED;
+    return status;
+}
+
+int
+SparsePythonCOOLinSOE::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOLinSOE::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOLinSOE::setPythonSolver(SparsePythonCOOLinSolver &newSolver)
+{
+    newSolver.setLinearSOE(*this);
+    if (getNumEqn() != 0) {
+        const int solverOK = newSolver.setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCOOLinSOE::setPythonSolver - solver failed setSize()" << endln;
+            return -1;
+        }
+    }
+    return this->LinearSOE::setSolver(newSolver);
+}
+
+void
+SparsePythonCOOLinSOE::updateVectorViews()
+{
+    if (sol.empty()) {
+        xVector.resize(0);
+    } else {
+        xVector.setData(sol.data(), static_cast<int>(sol.size()));
+    }
+
+    if (rhs.empty()) {
+        bVector.resize(0);
+    } else {
+        bVector.setData(rhs.data(), static_cast<int>(rhs.size()));
+    }
+}

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSOE.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSOE.h
@@ -1,0 +1,85 @@
+#ifndef SparsePythonCOOLinSOE_h
+#define SparsePythonCOOLinSOE_h
+
+#include "SparsePythonCommon.h"
+
+#include <LinearSOE.h>
+#include <Vector.h>
+
+#include <vector>
+
+class Channel;
+class FEM_ObjectBroker;
+class Graph;
+class ID;
+class Matrix;
+class SparsePythonCOOLinSolver;
+
+class SparsePythonCOOLinSOE : public LinearSOE
+{
+  public:
+    using MatrixStatus = SparsePythonMatrixStatus;
+
+    explicit SparsePythonCOOLinSOE(SparsePythonCOOLinSolver &theSolver);
+    SparsePythonCOOLinSOE();
+    ~SparsePythonCOOLinSOE() override;
+
+    SparsePythonStorageScheme getStorageScheme() const { return SparsePythonStorageScheme::COO; }
+
+    int getNumEqn(void) const override;
+    int setSize(Graph &theGraph) override;
+
+    int addA(const Matrix &, const ID &, double fact = 1.0) override;
+    int addB(const Vector &, const ID &, double fact = 1.0) override;
+    int setB(const Vector &, double fact = 1.0) override;
+
+    void zeroA(void) override;
+    void zeroB(void) override;
+
+    const Vector &getX(void) override;
+    const Vector &getB(void) override;
+    double normRHS(void) override;
+
+    void setX(int loc, double value) override;
+    void setX(const Vector &X) override;
+    int solve(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setPythonSolver(SparsePythonCOOLinSolver &newSolver);
+
+    MatrixStatus getMatrixStatus(void) const { return matrixStatus; }
+
+    const std::vector<int> &getRowIndices(void) const { return rowIndices; }
+    const std::vector<int> &getColIndices(void) const { return colIndices; }
+    std::vector<double> &getValues(void) { return values; }
+    const std::vector<double> &getValues(void) const { return values; }
+    std::vector<double> &getRHS(void) { return rhs; }
+    const std::vector<double> &getRHS(void) const { return rhs; }
+    std::vector<double> &getSolution(void) { return sol; }
+    const std::vector<double> &getSolution(void) const { return sol; }
+
+    std::size_t getNNZ(void) const { return values.size(); }
+
+  private:
+    void updateVectorViews();
+    void buildCOOPattern(Graph &theGraph);
+
+    std::vector<int> rowIndices;
+    std::vector<int> colIndices;
+    std::vector<double> values;
+    std::vector<double> rhs;
+    std::vector<double> sol;
+
+    std::vector<int> rowOffsets;
+
+    Vector xVector;
+    Vector bVector;
+
+    MatrixStatus matrixStatus;
+
+    friend class SparsePythonCOOLinSolver;
+};
+
+#endif /* SparsePythonCOOLinSOE_h */

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSolver.cpp
@@ -1,0 +1,275 @@
+#include "SparsePythonCOOLinSolver.h"
+#include "SparsePythonCommon.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <OPS_Globals.h>
+#include <elementAPI.h>
+
+#include <Python.h>
+
+#include <cstring>
+
+namespace {
+
+struct PyObjectHolder {
+    PyObjectHolder() = default;
+    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
+    ~PyObjectHolder() { Py_XDECREF(ptr); }
+    PyObject *get() const { return ptr; }
+    PyObject *release() {
+        PyObject *tmp = ptr;
+        ptr = nullptr;
+        return tmp;
+    }
+    void reset(PyObject *obj = nullptr) {
+        if (ptr == obj) {
+            return;
+        }
+        Py_XDECREF(ptr);
+        ptr = obj;
+    }
+
+  private:
+    PyObject *ptr{nullptr};
+};
+
+} // namespace
+
+SparsePythonCOOLinSolver::SparsePythonCOOLinSolver()
+    : LinearSOESolver(SOLVER_TAGS_SparsePythonCOOLinSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName("solve")
+{
+}
+
+SparsePythonCOOLinSolver::SparsePythonCOOLinSolver(PyObject *callable, const char *method)
+    : LinearSOESolver(SOLVER_TAGS_SparsePythonCOOLinSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName(method != nullptr ? method : "solve")
+{
+    setPythonCallable(callable, methodName.c_str());
+}
+
+SparsePythonCOOLinSolver::~SparsePythonCOOLinSolver()
+{
+    if (solverObject != nullptr) {
+        if (Py_IsInitialized()) {
+            // Acquire GIL before decrementing reference count
+            // This is critical: Py_XDECREF must be called with GIL held
+            PyGILState_STATE gil_state = PyGILState_Ensure();
+            Py_XDECREF(solverObject);
+            PyGILState_Release(gil_state);
+        }
+        // If Python is not initialized, we cannot safely call Py_XDECREF
+        // The object will be cleaned up when Python interpreter shuts down
+        solverObject = nullptr;
+    }
+}
+
+int
+SparsePythonCOOLinSolver::setLinearSOE(SparsePythonCOOLinSOE &theLinearSOE)
+{
+    theSOE = &theLinearSOE;
+    return 0;
+}
+
+int
+SparsePythonCOOLinSolver::setPythonCallable(PyObject *callable, const char *method)
+{
+    if (method != nullptr) {
+        methodName = method;
+    }
+
+    if (callable == nullptr) {
+        Py_XDECREF(solverObject);
+        solverObject = nullptr;
+        return 0;
+    }
+
+    Py_XINCREF(callable);
+    Py_XDECREF(solverObject);
+    solverObject = callable;
+    return 0;
+}
+
+int
+SparsePythonCOOLinSolver::solve(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::solve - no associated SOE" << endln;
+        return -1;
+    }
+    if (solverObject == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::solve - no Python callable bound" << endln;
+        return -2;
+    }
+    if (theSOE->getNumEqn() == 0) {
+        return 0;
+    }
+
+    return callPythonSolver();
+}
+
+int
+SparsePythonCOOLinSolver::setSize(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::setSize - no associated SOE" << endln;
+        return -1;
+    }
+    return 0;
+}
+
+int
+SparsePythonCOOLinSolver::callPythonSolver()
+{
+    const std::vector<int> &rowIdx = theSOE->getRowIndices();
+    const std::vector<int> &colIdx = theSOE->getColIndices();
+    std::vector<double> &values = theSOE->getValues();
+    std::vector<double> &rhs = theSOE->getRHS();
+    std::vector<double> &sol = theSOE->getSolution();
+
+    if (rowIdx.size() != colIdx.size() || rowIdx.size() != values.size()) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - inconsistent COO storage" << endln;
+        return -3;
+    }
+
+    if (rowIdx.empty()) {
+        return 0;
+    }
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    PyObjectHolder method(PyObject_GetAttrString(solverObject, methodName.c_str()));
+    if (method.get() == nullptr || !PyCallable_Check(method.get())) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - attribute '"
+               << methodName.c_str() << "' not callable" << endln;
+        PyGILState_Release(gilState);
+        return -4;
+    }
+
+    const Py_ssize_t nnz = static_cast<Py_ssize_t>(rowIdx.size());
+    const Py_ssize_t rowBytes = nnz * sizeof(int);
+    const Py_ssize_t colBytes = nnz * sizeof(int);
+    const Py_ssize_t valuesBytes = nnz * sizeof(double);
+    const Py_ssize_t rhsBytes = static_cast<Py_ssize_t>(rhs.size() * sizeof(double));
+    const Py_ssize_t solBytes = static_cast<Py_ssize_t>(sol.size() * sizeof(double));
+
+    PyObjectHolder pyRow(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(rowIdx.data())),
+        rowBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyCol(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(colIdx.data())),
+        colBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(values.data()),
+        valuesBytes,
+        writableFlags.values ? PyBUF_WRITE : PyBUF_READ));
+
+    PyObjectHolder pyRhs(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(rhs.data()),
+        rhsBytes,
+        writableFlags.rhs ? PyBUF_WRITE : PyBUF_READ));
+
+    PyObjectHolder pySol(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(sol.data()),
+        solBytes,
+        PyBUF_WRITE));
+
+    if (pyRow.get() == nullptr || pyCol.get() == nullptr ||
+        pyValues.get() == nullptr || pyRhs.get() == nullptr || pySol.get() == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - failed to create memory views" << endln;
+        PyGILState_Release(gilState);
+        return -5;
+    }
+
+    // Scalar metadata handed to the Python solver (as all-caps strings).
+    PyObjectHolder matrixStatus(
+        PyUnicode_FromString(theSOE->getMatrixStatus().to_str()));
+    PyObjectHolder storageScheme(
+        PyUnicode_FromString(SparsePythonStorageScheme::COO.to_str()));
+
+    PyObjectHolder kwargs(PyDict_New());
+    const char *rowKeyword = "row";
+    const char *colKeyword = "col";
+    const char *valuesKeyword = "values";
+    const char *rhsKeyword = "rhs";
+    const char *xKeyword = "x";
+    const char *matrixStatusKeyword = "matrix_status";
+    const char *storageSchemeKeyword = "storage_scheme";
+    const char *numEqnKeyword = "num_eqn";
+    const char *nnzKeyword = "nnz";
+
+    if (kwargs.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), rowKeyword, pyRow.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), colKeyword, pyCol.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), valuesKeyword, pyValues.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), rhsKeyword, pyRhs.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), xKeyword, pySol.get()) != 0 ||
+        matrixStatus.get() == nullptr ||
+        storageScheme.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), matrixStatusKeyword, matrixStatus.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), storageSchemeKeyword, storageScheme.get()) != 0) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - failed to populate kwargs" << endln;
+        PyGILState_Release(gilState);
+        return -6;
+    }
+
+    PyObjectHolder numEqn(PyLong_FromLong(theSOE->getNumEqn()));
+    PyObjectHolder nnzValue(PyLong_FromSize_t(theSOE->getNNZ()));
+
+    if (numEqn.get() == nullptr || nnzValue.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), numEqnKeyword, numEqn.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), nnzKeyword, nnzValue.get()) != 0) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - failed to set metadata kwargs" << endln;
+        PyGILState_Release(gilState);
+        return -7;
+    }
+
+    PyObject *args = PyTuple_New(0);
+    if (args == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - failed to create args tuple" << endln;
+        PyGILState_Release(gilState);
+        return -8;
+    }
+    PyObjectHolder argsHolder(args);
+
+    PyObjectHolder result(PyObject_Call(method.get(), argsHolder.get(), kwargs.get()));
+    if (result.get() == nullptr) {
+        opserr << "SparsePythonCOOLinSolver::callPythonSolver - Python callable raised an exception" << endln;
+        PyErr_Print();
+        PyGILState_Release(gilState);
+        return -9;
+    }
+
+    int status = 0;
+    if (result.get() != Py_None) {
+        if (PyLong_Check(result.get())) {
+            status = static_cast<int>(PyLong_AsLong(result.get()));
+        } else if (PyFloat_Check(result.get())) {
+            status = static_cast<int>(PyFloat_AsDouble(result.get()));
+        }
+    }
+
+    PyGILState_Release(gilState);
+    return status;
+}
+
+int
+SparsePythonCOOLinSolver::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCOOLinSolver::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSolver.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCOOLinSolver.h
@@ -1,0 +1,46 @@
+#ifndef SparsePythonCOOLinSolver_h
+#define SparsePythonCOOLinSolver_h
+
+#include "SparsePythonCOOLinSOE.h"
+#include "SparsePythonCommon.h"
+
+#include <LinearSOESolver.h>
+#include <string>
+
+struct _object;
+typedef _object PyObject;
+
+class Channel;
+class FEM_ObjectBroker;
+
+class SparsePythonCOOLinSolver : public LinearSOESolver
+{
+  public:
+    SparsePythonCOOLinSolver();
+    explicit SparsePythonCOOLinSolver(PyObject *callable, const char *methodName = "solve");
+    ~SparsePythonCOOLinSolver() override;
+
+    int solve(void) override;
+    int setSize(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setLinearSOE(SparsePythonCOOLinSOE &theSOE);
+    int setPythonCallable(PyObject *callable, const char *methodName = "solve");
+    void setWritableFlags(const SparsePythonWritableFlags &flags) { writableFlags = flags; }
+
+    PyObject *getPythonCallable() const { return solverObject; }
+    const std::string &getMethodName() const { return methodName; }
+    const SparsePythonWritableFlags &getWritableFlags() const { return writableFlags; }
+
+  private:
+    int callPythonSolver();
+
+    SparsePythonCOOLinSOE *theSOE;
+    PyObject *solverObject;
+    std::string methodName;
+    SparsePythonWritableFlags writableFlags;
+};
+
+#endif /* SparsePythonCOOLinSolver_h */

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.cpp
@@ -1,0 +1,38 @@
+#include "SparsePythonCommon.h"
+
+// Define static const members for SparsePythonStorageScheme
+const SparsePythonStorageScheme SparsePythonStorageScheme::CSR(SparsePythonStorageScheme::Value::CSR);
+const SparsePythonStorageScheme SparsePythonStorageScheme::CSC(SparsePythonStorageScheme::Value::CSC);
+const SparsePythonStorageScheme SparsePythonStorageScheme::COO(SparsePythonStorageScheme::Value::COO);
+
+const char* SparsePythonStorageScheme::to_str() const {
+    switch (value_) {
+        case Value::CSR:
+            return "CSR";
+        case Value::CSC:
+            return "CSC";
+        case Value::COO:
+            return "COO";
+        default:
+            return "CSR";  // fallback
+    }
+}
+
+// Define static const members for SparsePythonMatrixStatus
+const SparsePythonMatrixStatus SparsePythonMatrixStatus::UNCHANGED(SparsePythonMatrixStatus::Value::UNCHANGED);
+const SparsePythonMatrixStatus SparsePythonMatrixStatus::COEFFICIENTS_CHANGED(SparsePythonMatrixStatus::Value::COEFFICIENTS_CHANGED);
+const SparsePythonMatrixStatus SparsePythonMatrixStatus::STRUCTURE_CHANGED(SparsePythonMatrixStatus::Value::STRUCTURE_CHANGED);
+
+const char* SparsePythonMatrixStatus::to_str() const {
+    switch (value_) {
+        case Value::UNCHANGED:
+            return "UNCHANGED";
+        case Value::COEFFICIENTS_CHANGED:
+            return "COEFFICIENTS_CHANGED";
+        case Value::STRUCTURE_CHANGED:
+            return "STRUCTURE_CHANGED";
+        default:
+            return "UNCHANGED";  // fallback
+    }
+}
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.h
@@ -1,0 +1,97 @@
+#ifndef SparsePythonCommon_h
+#define SparsePythonCommon_h
+
+/**
+ * Storage scheme class: acts like an enum with string conversion.
+ */
+class SparsePythonStorageScheme {
+private:
+    enum class Value : int {
+        CSR = 0,
+        CSC = 1,
+        COO = 2
+    };
+    Value value_;
+
+public:
+    // Static const members for easy access (defined in .cpp)
+    static const SparsePythonStorageScheme CSR;
+    static const SparsePythonStorageScheme CSC;
+    static const SparsePythonStorageScheme COO;
+
+    // Constructors
+    SparsePythonStorageScheme() : value_(Value::CSR) {}
+    explicit SparsePythonStorageScheme(Value v) : value_(v) {}
+    SparsePythonStorageScheme(int v) : value_(static_cast<Value>(v)) {}
+
+    // Implicit conversion operators for comparisons and assignments
+    operator Value() const { return value_; }
+    operator int() const { return static_cast<int>(value_); }
+
+    // Comparison operators
+    bool operator==(const SparsePythonStorageScheme& other) const {
+        return value_ == other.value_;
+    }
+    bool operator!=(const SparsePythonStorageScheme& other) const {
+        return value_ != other.value_;
+    }
+
+    // String conversion for Python
+    const char* to_str() const;
+};
+
+/**
+ * Matrix status class: acts like an enum with string conversion.
+ */
+class SparsePythonMatrixStatus {
+private:
+    enum class Value : int {
+        UNCHANGED = 0,
+        COEFFICIENTS_CHANGED = 1,
+        STRUCTURE_CHANGED = 2
+    };
+    Value value_;
+
+public:
+    // Static const members for easy access (defined in .cpp)
+    static const SparsePythonMatrixStatus UNCHANGED;
+    static const SparsePythonMatrixStatus COEFFICIENTS_CHANGED;
+    static const SparsePythonMatrixStatus STRUCTURE_CHANGED;
+
+    // Constructors
+    SparsePythonMatrixStatus() : value_(Value::UNCHANGED) {}
+    explicit SparsePythonMatrixStatus(Value v) : value_(v) {}
+    SparsePythonMatrixStatus(int v) : value_(static_cast<Value>(v)) {}
+
+    // Implicit conversion operators for comparisons and assignments
+    operator Value() const { return value_; }
+    operator int() const { return static_cast<int>(value_); }
+
+    // Comparison operators
+    bool operator==(const SparsePythonMatrixStatus& other) const {
+        return value_ == other.value_;
+    }
+    bool operator!=(const SparsePythonMatrixStatus& other) const {
+        return value_ != other.value_;
+    }
+
+    // String conversion for Python
+    const char* to_str() const;
+};
+
+/**
+ * Flags controlling which buffers are exported as writable to Python solvers.
+ * By default, all buffers except 'x' (solution) are read-only for safety.
+ * Advanced users can enable writable buffers for in-place modifications.
+ */
+struct SparsePythonWritableFlags {
+    bool values = false;  // Matrix coefficients (values array)
+    bool rhs = false;     // Right-hand side vector
+    // Note: index_ptr, indices, row, col are always read-only (structural)
+    // Note: x (solution) is always writable (output buffer)
+
+    SparsePythonWritableFlags() = default;
+    SparsePythonWritableFlags(bool v, bool r) : values(v), rhs(r) {}
+};
+
+#endif /* SparsePythonCommon_h */

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCommon.h
@@ -1,6 +1,8 @@
 #ifndef SparsePythonCommon_h
 #define SparsePythonCommon_h
 
+#include <Python.h>
+
 /**
  * Storage scheme class: acts like an enum with string conversion.
  */
@@ -92,6 +94,40 @@ struct SparsePythonWritableFlags {
 
     SparsePythonWritableFlags() = default;
     SparsePythonWritableFlags(bool v, bool r) : values(v), rhs(r) {}
+};
+
+/**
+ * RAII helper that manages reference counting for transient PyObject* instances.
+ * Acquires the GIL before calling Py_XDECREF to ensure thread safety.
+ */
+struct PyObjectHolder {
+    PyObjectHolder() = default;
+    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
+    ~PyObjectHolder() {
+        // Acquire GIL before calling Py_XDECREF to ensure thread safety
+        // Note: We don't set ptr to nullptr here because the object is being destroyed
+        if (ptr != nullptr && Py_IsInitialized()) {
+            PyGILState_STATE gilState = PyGILState_Ensure();
+            Py_XDECREF(ptr);
+            PyGILState_Release(gilState);
+        }
+    }
+    PyObject *get() const { return ptr; }
+    PyObject *release() {
+        PyObject *tmp = ptr;
+        ptr = nullptr;
+        return tmp;
+    }
+    void reset(PyObject *obj = nullptr) {
+        if (ptr == obj) {
+            return;
+        }
+        // reset() should only be called while GIL is held
+        Py_XDECREF(ptr);
+        ptr = obj;
+    }
+  private:
+    PyObject *ptr{nullptr};
 };
 
 #endif /* SparsePythonCommon_h */

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSOE.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSOE.cpp
@@ -1,0 +1,504 @@
+#include "SparsePythonCompressedLinSOE.h"
+
+#include "SparsePythonCompressedLinSolver.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <Graph.h>
+#include <ID.h>
+#include <Matrix.h>
+#include <OPS_Globals.h>
+#include <Vertex.h>
+#include <VertexIter.h>
+
+#include <algorithm>
+#include <cmath>
+
+SparsePythonCompressedLinSOE::SparsePythonCompressedLinSOE(
+    SparsePythonCompressedLinSolver &theSolver,
+    StorageScheme scheme)
+    : LinearSOE(theSolver, LinSOE_TAGS_SparsePythonCompressedLinSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED),
+      storageScheme(scheme)
+{
+    if (storageScheme == StorageScheme::COO) {
+        opserr << "WARNING: SparsePythonCompressedLinSOE does not support COO; defaulting to CSR" << endln;
+        storageScheme = StorageScheme::CSR;
+    }
+    theSolver.setLinearSOE(*this);
+    updateVectorViews();
+}
+
+SparsePythonCompressedLinSOE::SparsePythonCompressedLinSOE(StorageScheme scheme)
+    : LinearSOE(LinSOE_TAGS_SparsePythonCompressedLinSOE),
+      matrixStatus(MatrixStatus::STRUCTURE_CHANGED),
+      storageScheme(scheme)
+{
+    if (storageScheme == StorageScheme::COO) {
+        opserr << "WARNING: SparsePythonCompressedLinSOE does not support COO; defaulting to CSR" << endln;
+        storageScheme = StorageScheme::CSR;
+    }
+    updateVectorViews();
+}
+
+SparsePythonCompressedLinSOE::~SparsePythonCompressedLinSOE() = default;
+
+int
+SparsePythonCompressedLinSOE::getNumEqn(void) const
+{
+    return static_cast<int>(sol.size());
+}
+
+void
+SparsePythonCompressedLinSOE::buildCSRPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    const std::size_t nnz = static_cast<std::size_t>(size) + 2 * theGraph.getNumEdge();
+
+    indexPtr.assign(static_cast<std::size_t>(size) + 1u, 0);
+    indices.resize(nnz);
+    values.assign(nnz, 0.0);
+    rhs.assign(static_cast<std::size_t>(size), 0.0);
+    sol.assign(static_cast<std::size_t>(size), 0.0);
+
+    int last = 0;
+    indexPtr[0] = 0;
+    Vertex *theVertex = nullptr;
+    for (int row = 0; row < size; ++row) {
+        theVertex = theGraph.getVertexPtr(row);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCompressedLinSOE::buildCSRPattern - "
+                   << "vertex " << row << " not found in graph, "
+                   << "size set to 0" << endln;
+            indexPtr.assign(1u, 0);
+            indices.clear();
+            values.clear();
+            rhs.clear();
+            sol.clear();
+            updateVectorViews();
+            return;
+        }
+
+        const ID &theAdjacency = theVertex->getAdjacency();
+        ID columns(0, theAdjacency.Size() + 1);
+
+        columns.insert(theVertex->getTag());
+        for (int i = 0; i < theAdjacency.Size(); ++i) {
+            columns.insert(theAdjacency(i));
+        }
+
+        for (int i = 0; i < columns.Size(); ++i) {
+            indices[static_cast<std::size_t>(last++)] = columns(i);
+        }
+
+        indexPtr[static_cast<std::size_t>(row + 1)] = last;
+    }
+}
+
+void
+SparsePythonCompressedLinSOE::buildCSCPattern(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    const std::size_t nnz = static_cast<std::size_t>(size) + 2 * theGraph.getNumEdge();
+
+    indexPtr.assign(static_cast<std::size_t>(size) + 1u, 0);
+    indices.resize(nnz);
+    values.assign(nnz, 0.0);
+    rhs.assign(static_cast<std::size_t>(size), 0.0);
+    sol.assign(static_cast<std::size_t>(size), 0.0);
+
+    int last = 0;
+    indexPtr[0] = 0;
+    Vertex *theVertex = nullptr;
+    for (int col = 0; col < size; ++col) {
+        theVertex = theGraph.getVertexPtr(col);
+        if (theVertex == nullptr) {
+            opserr << "WARNING: SparsePythonCompressedLinSOE::buildCSCPattern - "
+                   << "vertex " << col << " not found in graph, "
+                   << "size set to 0" << endln;
+            indexPtr.assign(1u, 0);
+            indices.clear();
+            values.clear();
+            rhs.clear();
+            sol.clear();
+            updateVectorViews();
+            return;
+        }
+
+        const ID &theAdjacency = theVertex->getAdjacency();
+        ID rows(0, theAdjacency.Size() + 1);
+
+        rows.insert(theVertex->getTag());
+        for (int i = 0; i < theAdjacency.Size(); ++i) {
+            rows.insert(theAdjacency(i));
+        }
+
+        for (int i = 0; i < rows.Size(); ++i) {
+            indices[static_cast<std::size_t>(last++)] = rows(i);
+        }
+
+        indexPtr[static_cast<std::size_t>(col + 1)] = last;
+    }
+}
+
+int
+SparsePythonCompressedLinSOE::setSize(Graph &theGraph)
+{
+    const int size = theGraph.getNumVertex();
+    if (size < 0) {
+        opserr << "WARNING: SparsePythonCompressedLinSOE::setSize - "
+               << "size of SOE < 0" << endln;
+        return -1;
+    }
+
+    if (storageScheme == StorageScheme::CSR) {
+        buildCSRPattern(theGraph);
+    } else if (storageScheme == StorageScheme::CSC) {
+        buildCSCPattern(theGraph);
+    } else {
+        opserr << "WARNING: SparsePythonCompressedLinSOE::setSize - unknown storage scheme\n";
+        return -1;
+    }
+
+    updateVectorViews();
+
+    LinearSOESolver *theSolver = this->getSolver();
+    if (theSolver != nullptr) {
+        const int solverOK = theSolver->setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCompressedLinSOE::setSize -"
+                   << "solver failed setSize()" << endln;
+            return solverOK;
+        }
+    }
+
+    matrixStatus = MatrixStatus::STRUCTURE_CHANGED;
+
+    return 0;
+}
+
+SparsePythonCompressedLinSOE::MatrixStatus
+SparsePythonCompressedLinSOE::getMatrixStatus() const
+{
+    return matrixStatus;
+}
+
+int
+SparsePythonCompressedLinSOE::addA(const Matrix &m, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != m.noRows() || idSize != m.noCols()) {
+        opserr << "SparsePythonCompressedLinSOE::addA - Matrix and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+
+    if (storageScheme == StorageScheme::CSR) {
+        if (fact == 1.0) {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+    
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+    
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+    
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+    
+                    auto it = std::lower_bound(beginIt, endIt, col);
+                    if (it != endIt && *it == col) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        values[offset] += m(i, j);
+                    }
+                }
+            }
+        } else {
+            for (int i = 0; i < idSize; ++i) {
+                const int row = id(i);
+                if (row < 0 || row >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(row)];
+                const int end = indexPtr[static_cast<std::size_t>(row + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int j = 0; j < idSize; ++j) {
+                    const int col = id(j);
+                    if (col < 0 || col >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, col);
+                    if (it != endIt && *it == col) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        values[offset] += fact * m(i, j);
+                    }
+                }
+            }
+        }
+    } else { // CSC
+        if (fact == 1.0) {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        values[offset] += m(i, j);
+                    }
+                }
+            }
+        } else {
+            for (int j = 0; j < idSize; ++j) {
+                const int col = id(j);
+                if (col < 0 || col >= size) {
+                    continue;
+                }
+
+                const int start = indexPtr[static_cast<std::size_t>(col)];
+                const int end = indexPtr[static_cast<std::size_t>(col + 1)];
+
+                auto beginIt = indices.begin() + start;
+                auto endIt = indices.begin() + end;
+
+                for (int i = 0; i < idSize; ++i) {
+                    const int row = id(i);
+                    if (row < 0 || row >= size) {
+                        continue;
+                    }
+
+                    auto it = std::lower_bound(beginIt, endIt, row);
+                    if (it != endIt && *it == row) {
+                        const std::size_t offset = static_cast<std::size_t>(it - indices.begin());
+                        values[offset] += fact * m(i, j);
+                    }
+                }
+            }
+        }
+    }
+
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSOE::addB(const Vector &v, const ID &id, double fact)
+{
+    if (fact == 0.0) {
+        return 0;
+    }
+
+    const int idSize = id.Size();
+    if (idSize != v.Size()) {
+        opserr << "SparsePythonCompressedLinSOE::addB - Vector and ID not of similar sizes\n";
+        return -1;
+    }
+
+    const int size = getNumEqn();
+
+    if (fact == 1.0) {
+        for (int i = 0; i < idSize; ++i) {
+            const int pos = id(i);
+            if (pos < 0 || pos >= size) {
+                continue;
+            }
+            rhs[static_cast<std::size_t>(pos)] += v(i);
+        }
+    } else if (fact == -1.0) {
+        for (int i = 0; i < idSize; ++i) {
+            const int pos = id(i);
+            if (pos < 0 || pos >= size) {
+                continue;
+            }
+            rhs[static_cast<std::size_t>(pos)] -= v(i);
+        }
+    } else {
+        for (int i = 0; i < idSize; ++i) {
+            const int pos = id(i);
+            if (pos < 0 || pos >= size) {
+                continue;
+            }
+            rhs[static_cast<std::size_t>(pos)] += v(i) * fact;
+        }
+    }
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSOE::setB(const Vector &v, double fact)
+{
+    if (fact == 0.0) {
+        std::fill(rhs.begin(), rhs.end(), 0.0);
+        bVector.Zero();
+        return 0;
+    }
+
+    if (v.Size() != getNumEqn()) {
+        opserr << "SparsePythonCompressedLinSOE::setB - incompatible sizes "
+               << getNumEqn() << " and " << v.Size() << endln;
+        return -1;
+    }
+
+    const int size = getNumEqn();
+    if (fact == 1.0) {
+        for (int i = 0; i < size; ++i) {
+            rhs[static_cast<std::size_t>(i)] = v(i);
+        }
+    } else if (fact == -1.0) {
+        for (int i = 0; i < size; ++i) {
+            rhs[static_cast<std::size_t>(i)] = -v(i);
+        }
+    } else {
+        for (int i = 0; i < size; ++i) {
+            rhs[static_cast<std::size_t>(i)] = v(i) * fact;
+        }
+    }
+    return 0;
+}
+
+void
+SparsePythonCompressedLinSOE::zeroA(void)
+{
+    std::fill(values.begin(), values.end(), 0.0);
+    if (matrixStatus != MatrixStatus::STRUCTURE_CHANGED) {
+        matrixStatus = MatrixStatus::COEFFICIENTS_CHANGED;
+    }
+}
+
+void
+SparsePythonCompressedLinSOE::zeroB(void)
+{
+    std::fill(rhs.begin(), rhs.end(), 0.0);
+}
+
+const Vector &
+SparsePythonCompressedLinSOE::getX(void)
+{
+    return xVector;
+}
+
+const Vector &
+SparsePythonCompressedLinSOE::getB(void)
+{
+    return bVector;
+}
+
+double
+SparsePythonCompressedLinSOE::normRHS(void)
+{
+    double norm = 0.0;
+    for (double value : rhs) {
+        norm += value * value;
+    }
+    return std::sqrt(norm);
+}
+
+void
+SparsePythonCompressedLinSOE::setX(int loc, double value)
+{
+    if (loc >= 0 && loc < getNumEqn()) {
+        sol[static_cast<std::size_t>(loc)] = value;
+    }
+}
+
+void
+SparsePythonCompressedLinSOE::setX(const Vector &X)
+{
+    if (X.Size() != getNumEqn()) {
+        return;
+    }
+
+    const int size = getNumEqn();
+    for (int i = 0; i < size; ++i) {
+        sol[static_cast<std::size_t>(i)] = X(i);
+    }
+}
+
+int
+SparsePythonCompressedLinSOE::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSOE::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSOE::setPythonSolver(SparsePythonCompressedLinSolver &newSolver)
+{
+    newSolver.setLinearSOE(*this);
+    if (getNumEqn() != 0) {
+        const int solverOK = newSolver.setSize();
+        if (solverOK < 0) {
+            opserr << "WARNING: SparsePythonCompressedLinSOE::setPythonSolver - "
+                   << "the new solver could not setSize(), keeping the old solver\n";
+            return -1;
+        }
+    }
+    return this->LinearSOE::setSolver(newSolver);
+}
+
+void
+SparsePythonCompressedLinSOE::updateVectorViews()
+{
+    if (sol.empty()) {
+        xVector.resize(0);
+    } else {
+        xVector.setData(sol.data(), static_cast<int>(sol.size()));
+    }
+
+    if (rhs.empty()) {
+        bVector.resize(0);
+    } else {
+        bVector.setData(rhs.data(), static_cast<int>(rhs.size()));
+    }
+}
+
+int
+SparsePythonCompressedLinSOE::solve(void)
+{
+    int status = this->LinearSOE::solve();
+    if (status < 0) {
+        return status;
+    }
+    matrixStatus = MatrixStatus::UNCHANGED;
+    return status;
+}
+
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSOE.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSOE.h
@@ -1,0 +1,125 @@
+#ifndef SparsePythonCompressedLinSOE_h
+#define SparsePythonCompressedLinSOE_h
+
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: Gustavo A. Araujo R. (garaujor@stanford.edu, gaaraujor@gmail.com)
+// Created: 11/25
+//
+// Description: This file contains the class definition for
+// SparsePythonCompressedLinSOE. The system stores a general sparse matrix in
+// either Compressed Sparse Row (CSR) or Compressed Sparse Column (CSC) layout
+// and delegates the linear solve to a Python callable provided to the
+// associated SparsePythonCompressedLinSolver instance.
+
+#include <LinearSOE.h>
+#include <Vector.h>
+#include <vector>
+
+#include "SparsePythonCommon.h"
+
+class Channel;
+class FEM_ObjectBroker;
+class Graph;
+class ID;
+class Matrix;
+class SparsePythonCompressedLinSolver;
+
+class SparsePythonCompressedLinSOE : public LinearSOE
+{
+  public:
+    using StorageScheme = SparsePythonStorageScheme;
+
+    using MatrixStatus = SparsePythonMatrixStatus;
+
+    SparsePythonCompressedLinSOE(SparsePythonCompressedLinSolver &theSolver,
+                                 StorageScheme scheme = StorageScheme::CSR);
+    explicit SparsePythonCompressedLinSOE(StorageScheme scheme = StorageScheme::CSR);
+    ~SparsePythonCompressedLinSOE() override;
+
+    StorageScheme getStorageScheme() const { return storageScheme; }
+
+    int getNumEqn(void) const override;
+    int setSize(Graph &theGraph) override;
+
+    int addA(const Matrix &, const ID &, double fact = 1.0) override;
+    int addB(const Vector &, const ID &, double fact = 1.0) override;
+    int setB(const Vector &, double fact = 1.0) override;
+
+    void zeroA(void) override;
+    void zeroB(void) override;
+
+    const Vector &getX(void) override;
+    const Vector &getB(void) override;
+    double normRHS(void) override;
+
+    void setX(int loc, double value) override;
+    void setX(const Vector &X) override;
+    int solve(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setPythonSolver(SparsePythonCompressedLinSolver &newSolver);
+
+    MatrixStatus getMatrixStatus(void) const;
+
+    const std::vector<int> &getIndexPtr(void) const { return indexPtr; }
+    const std::vector<int> &getIndices(void) const { return indices; }
+    const std::vector<double> &getValues(void) const { return values; }
+    std::vector<double> &getValues(void) { return values; }
+    std::vector<double> &getRHS(void) { return rhs; }
+    std::vector<double> &getSolution(void) { return sol; }
+    const std::vector<double> &getRHS(void) const { return rhs; }
+    const std::vector<double> &getSolution(void) const { return sol; }
+
+    std::size_t getNNZ(void) const { return values.size(); }
+
+  protected:
+    void updateVectorViews();
+    void buildCSRPattern(Graph &theGraph);
+    void buildCSCPattern(Graph &theGraph);
+
+    std::vector<int> &accessIndexPtr() { return indexPtr; }
+    std::vector<int> &accessIndices() { return indices; }
+
+    const std::vector<int> &getRowPtr() const { return indexPtr; } // compatibility alias
+    const std::vector<int> &getColInd() const { return indices; }  // compatibility alias
+
+  private:
+    std::vector<int> indexPtr;
+    std::vector<int> indices;
+    std::vector<double> values;
+    std::vector<double> rhs;
+    std::vector<double> sol;
+
+    Vector xVector;
+    Vector bVector;
+
+    MatrixStatus matrixStatus;
+    StorageScheme storageScheme;
+
+    friend class SparsePythonCompressedLinSolver;
+};
+
+#endif /* SparsePythonCompressedLinSOE_h */
+
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.cpp
@@ -1,0 +1,282 @@
+#include "SparsePythonCompressedLinSolver.h"
+
+#include "SparsePythonCompressedLinSOE.h"
+#include "SparsePythonCommon.h"
+
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+#include <OPS_Globals.h>
+#include <cstring>
+#include <elementAPI.h>
+#include <Python.h>
+
+
+namespace {
+
+// RAII helper that manages reference counting for transient PyObject* instances.
+struct PyObjectHolder {
+    PyObjectHolder() = default;
+    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
+    ~PyObjectHolder() { Py_XDECREF(ptr); }
+    PyObject *get() const { return ptr; }
+    PyObject *release() {
+        PyObject *tmp = ptr;
+        ptr = nullptr;
+        return tmp;
+    }
+    void reset(PyObject *obj = nullptr) {
+        if (ptr == obj) {
+            return;
+        }
+        Py_XDECREF(ptr);
+        ptr = obj;
+    }
+  private:
+    PyObject *ptr{nullptr};
+};
+
+} // namespace
+
+SparsePythonCompressedLinSolver::SparsePythonCompressedLinSolver()
+    : LinearSOESolver(SOLVER_TAGS_SparsePythonCompressedLinSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName("solve")
+{
+}
+
+SparsePythonCompressedLinSolver::SparsePythonCompressedLinSolver(PyObject *callable,
+                                                                 const char *method)
+    : LinearSOESolver(SOLVER_TAGS_SparsePythonCompressedLinSolver),
+      theSOE(nullptr),
+      solverObject(nullptr),
+      methodName(method != nullptr ? method : "solve")
+{
+    setPythonCallable(callable, methodName.c_str());
+}
+
+SparsePythonCompressedLinSolver::~SparsePythonCompressedLinSolver()
+{
+    if (solverObject != nullptr) {
+        if (Py_IsInitialized()) {
+            // Acquire GIL before decrementing reference count
+            // This is critical: Py_XDECREF must be called with GIL held
+            PyGILState_STATE gil_state = PyGILState_Ensure();
+            Py_XDECREF(solverObject);
+            PyGILState_Release(gil_state);
+        }
+        // If Python is not initialized, we cannot safely call Py_XDECREF
+        // The object will be cleaned up when Python interpreter shuts down
+        solverObject = nullptr;
+    }
+}
+
+int
+SparsePythonCompressedLinSolver::setLinearSOE(SparsePythonCompressedLinSOE &theLinearSOE)
+{
+    theSOE = &theLinearSOE;
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSolver::setPythonCallable(PyObject *callable, const char *method)
+{
+    if (method != nullptr) {
+        methodName = method;
+    }
+
+    if (callable == nullptr) {
+        Py_XDECREF(solverObject);
+        solverObject = nullptr;
+        return 0;
+    }
+
+    Py_XINCREF(callable);
+    Py_XDECREF(solverObject);
+    solverObject = callable;
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSolver::solve(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::solve - no associated SOE\n";
+        return -1;
+    }
+    if (solverObject == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::solve - no Python callable bound\n";
+        return -2;
+    }
+    if (theSOE->getNumEqn() == 0) {
+        return 0;
+    }
+
+    return callPythonSolver();
+}
+
+int
+SparsePythonCompressedLinSolver::setSize(void)
+{
+    if (theSOE == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::setSize - no associated SOE\n";
+        return -1;
+    }
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSolver::sendSelf(int, Channel &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSolver::recvSelf(int, Channel &, FEM_ObjectBroker &)
+{
+    return 0;
+}
+
+int
+SparsePythonCompressedLinSolver::callPythonSolver()
+{
+    // Pull the SOE storage; indexPtr/indices are immutable views, values/rhs/sol are writable.
+    const std::vector<int> &indexPtr = theSOE->getIndexPtr();
+    const std::vector<int> &indices = theSOE->getIndices();
+    std::vector<double> &values = theSOE->getValues();
+    std::vector<double> &rhs = theSOE->getRHS();
+    std::vector<double> &sol = theSOE->getSolution();
+
+    
+    if (indexPtr.size() < 2) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - invalid sparse structure\n";
+        return -3;
+    }
+
+    // Ensure we hold the GIL while touching Python APIs.
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    // Lookup the bound solve method; bail if missing or not callable.
+    PyObjectHolder method(PyObject_GetAttrString(solverObject, methodName.c_str()));
+    if (method.get() == nullptr || !PyCallable_Check(method.get())) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - attribute '"
+               << methodName.c_str() << "' not callable\n";
+        PyGILState_Release(gilState);
+        return -4;
+    }
+
+    // Build memoryviews that hand the raw SOE buffers to Python without copying.
+    const Py_ssize_t ptrBytes = static_cast<Py_ssize_t>(indexPtr.size() * sizeof(int));
+    const Py_ssize_t indBytes = static_cast<Py_ssize_t>(indices.size() * sizeof(int));
+    const Py_ssize_t valuesBytes = static_cast<Py_ssize_t>(values.size() * sizeof(double));
+    const Py_ssize_t rhsBytes = static_cast<Py_ssize_t>(rhs.size() * sizeof(double));
+    const Py_ssize_t solBytes = static_cast<Py_ssize_t>(sol.size() * sizeof(double));
+
+    PyObjectHolder pyPtr(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(indexPtr.data())),
+        ptrBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyInd(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(const_cast<int *>(indices.data())),
+        indBytes,
+        PyBUF_READ));
+
+    PyObjectHolder pyValues(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(values.data()),
+        valuesBytes,
+        writableFlags.values ? PyBUF_WRITE : PyBUF_READ));
+
+    PyObjectHolder pyRhs(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(rhs.data()),
+        rhsBytes,
+        writableFlags.rhs ? PyBUF_WRITE : PyBUF_READ));
+
+    PyObjectHolder pySol(PyMemoryView_FromMemory(
+        reinterpret_cast<char *>(sol.data()),
+        solBytes,
+        PyBUF_WRITE));
+
+    if (pyPtr.get() == nullptr || pyInd.get() == nullptr ||
+        pyValues.get() == nullptr || pyRhs.get() == nullptr || pySol.get() == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - failed to create memory views\n";
+        PyGILState_Release(gilState);
+        return -5;
+    }
+
+    // Scalar metadata handed to the Python solver (as all-caps strings).
+    PyObjectHolder matrixStatus(
+        PyUnicode_FromString(theSOE->getMatrixStatus().to_str()));
+    PyObjectHolder storageScheme(
+        PyUnicode_FromString(theSOE->getStorageScheme().to_str()));
+
+    PyObjectHolder kwargs(PyDict_New());
+    const char *ptrKeyword = "index_ptr";
+    const char *indicesKeyword = "indices";
+    const char *valuesKeyword = "values";
+    const char *rhsKeyword = "rhs";
+    const char *xKeyword = "x";
+    const char *matrixStatusKeyword = "matrix_status";
+    const char *storageSchemeKeyword = "storage_scheme";
+    const char *numEqnKeyword = "num_eqn";
+    const char *nnzKeyword = "nnz";
+
+    if (kwargs.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), ptrKeyword, pyPtr.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), indicesKeyword, pyInd.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), valuesKeyword, pyValues.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), rhsKeyword, pyRhs.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), xKeyword, pySol.get()) != 0 ||
+        matrixStatus.get() == nullptr ||
+        storageScheme.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), matrixStatusKeyword, matrixStatus.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), storageSchemeKeyword, storageScheme.get()) != 0) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - failed to populate kwargs\n";
+        PyGILState_Release(gilState);
+        return -6;
+    }
+
+    // Add additional metadata expected by the solver (num equations, number of nonzeros).
+    PyObjectHolder numEqn(PyLong_FromLong(theSOE->getNumEqn()));
+    PyObjectHolder nnz(PyLong_FromSize_t(theSOE->getNNZ()));
+
+    if (numEqn.get() == nullptr || nnz.get() == nullptr ||
+        PyDict_SetItemString(kwargs.get(), numEqnKeyword, numEqn.get()) != 0 ||
+        PyDict_SetItemString(kwargs.get(), nnzKeyword, nnz.get()) != 0) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - failed to set metadata kwargs\n";
+        PyGILState_Release(gilState);
+        return -7;
+    }
+
+    // The Python callable expects no positional args; we pass everything via kwargs.
+    PyObject *args = PyTuple_New(0);
+    if (args == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - failed to create args tuple\n";
+        PyGILState_Release(gilState);
+        return -8;
+    }
+    PyObjectHolder argsHolder(args);
+
+    PyObjectHolder result(PyObject_Call(method.get(), argsHolder.get(), kwargs.get()));
+    if (result.get() == nullptr) {
+        opserr << "SparsePythonCompressedLinSolver::callPythonSolver - Python callable raised an exception\n";
+        PyErr_Print();
+        PyGILState_Release(gilState);
+        return -9;
+    }
+
+    // Interpret the return value: None -> success, numeric -> explicit status code.
+    int status = 0;
+    if (result.get() != Py_None) {
+        if (PyLong_Check(result.get())) {
+            status = static_cast<int>(PyLong_AsLong(result.get()));
+        } else if (PyFloat_Check(result.get())) {
+            status = static_cast<int>(PyFloat_AsDouble(result.get()));
+        } else {
+            status = 0;
+        }
+    }
+
+    PyGILState_Release(gilState);
+    return status;
+}

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.cpp
@@ -1,7 +1,6 @@
 #include "SparsePythonCompressedLinSolver.h"
 
 #include "SparsePythonCompressedLinSOE.h"
-#include "SparsePythonCommon.h"
 
 #include <Channel.h>
 #include <FEM_ObjectBroker.h>
@@ -9,33 +8,7 @@
 #include <cstring>
 #include <elementAPI.h>
 #include <Python.h>
-
-
-namespace {
-
-// RAII helper that manages reference counting for transient PyObject* instances.
-struct PyObjectHolder {
-    PyObjectHolder() = default;
-    explicit PyObjectHolder(PyObject *obj) : ptr(obj) {}
-    ~PyObjectHolder() { Py_XDECREF(ptr); }
-    PyObject *get() const { return ptr; }
-    PyObject *release() {
-        PyObject *tmp = ptr;
-        ptr = nullptr;
-        return tmp;
-    }
-    void reset(PyObject *obj = nullptr) {
-        if (ptr == obj) {
-            return;
-        }
-        Py_XDECREF(ptr);
-        ptr = obj;
-    }
-  private:
-    PyObject *ptr{nullptr};
-};
-
-} // namespace
+#include "SparsePythonCommon.h"
 
 SparsePythonCompressedLinSolver::SparsePythonCompressedLinSolver()
     : LinearSOESolver(SOLVER_TAGS_SparsePythonCompressedLinSolver),
@@ -57,17 +30,15 @@ SparsePythonCompressedLinSolver::SparsePythonCompressedLinSolver(PyObject *calla
 
 SparsePythonCompressedLinSolver::~SparsePythonCompressedLinSolver()
 {
-    if (solverObject != nullptr) {
-        if (Py_IsInitialized()) {
-            // Acquire GIL before decrementing reference count
-            // This is critical: Py_XDECREF must be called with GIL held
-            PyGILState_STATE gil_state = PyGILState_Ensure();
-            Py_XDECREF(solverObject);
-            PyGILState_Release(gil_state);
-        }
-        // If Python is not initialized, we cannot safely call Py_XDECREF
-        // The object will be cleaned up when Python interpreter shuts down
-        solverObject = nullptr;
+    // NOTE: This is generally unsafe to call Python C-API from destructors,
+    // as destructors may run after Py_Finalize(). This will be addressed later.
+    // For now, we assume the user will call ops.wipe() at the end of their script
+    // to ensure resources are released before exiting Python, making it safe to
+    // decrement refcounts in destructors.
+    if (solverObject != nullptr && Py_IsInitialized()) {
+        PyGILState_STATE gilState = PyGILState_Ensure();
+        Py_XDECREF(solverObject);
+        PyGILState_Release(gilState);
     }
 }
 
@@ -85,17 +56,24 @@ SparsePythonCompressedLinSolver::setPythonCallable(PyObject *callable, const cha
         methodName = method;
     }
 
+    // Acquire GIL before any Python API calls
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
     if (callable == nullptr) {
         Py_XDECREF(solverObject);
         solverObject = nullptr;
+        PyGILState_Release(gilState);
         return 0;
     }
 
     Py_XINCREF(callable);
     Py_XDECREF(solverObject);
     solverObject = callable;
+
+    PyGILState_Release(gilState);
     return 0;
 }
+
 
 int
 SparsePythonCompressedLinSolver::solve(void)
@@ -257,6 +235,9 @@ SparsePythonCompressedLinSolver::callPythonSolver()
     }
     PyObjectHolder argsHolder(args);
 
+    // PyObject_Call must be made with GIL held. CuPy/NumPy will release the GIL
+    // internally during their native GPU/CPU computations, so we don't need to
+    // do anything special here.
     PyObjectHolder result(PyObject_Call(method.get(), argsHolder.get(), kwargs.get()));
     if (result.get() == nullptr) {
         opserr << "SparsePythonCompressedLinSolver::callPythonSolver - Python callable raised an exception\n";

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonCompressedLinSolver.h
@@ -1,0 +1,73 @@
+#ifndef SparsePythonCompressedLinSolver_h
+#define SparsePythonCompressedLinSolver_h
+
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+**                                                                    **
+**                                                                    **
+** (C) Copyright 1999, The Regents of the University of California    **
+** All Rights Reserved.                                               **
+**                                                                    **
+** Commercial use of this program without express permission of the   **
+** University of California, Berkeley, is strictly prohibited.  See   **
+** file 'COPYRIGHT'  in main directory for information on usage and   **
+** redistribution,  and for a DISCLAIMER OF ALL WARRANTIES.           **
+**                                                                    **
+** Developed by:                                                      **
+**   Frank McKenna (fmckenna@ce.berkeley.edu)                         **
+**   Gregory L. Fenves (fenves@ce.berkeley.edu)                       **
+**   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
+**                                                                    **
+** ****************************************************************** */
+
+// Written: Gustavo A. Araujo R. (garaujor@stanford.edu, gaaraujor@gmail.com)
+// Created: 11/25
+//
+// Description: This file contains the class definition for
+// SparsePythonCompressedLinSolver. The solver delegates the factorization /
+// back-substitution to a Python callable that operates directly on the sparse
+// buffers owned by SparsePythonCompressedLinSOE.
+
+#include "SparsePythonCompressedLinSOE.h"
+#include "SparsePythonCommon.h"
+
+#include <LinearSOESolver.h>
+#include <string>
+
+struct _object;
+typedef _object PyObject;
+
+class Channel;
+class FEM_ObjectBroker;
+class SparsePythonCompressedLinSolver : public LinearSOESolver
+{
+  public:
+    SparsePythonCompressedLinSolver();
+    explicit SparsePythonCompressedLinSolver(PyObject *callable,
+                                             const char *methodName = "solve");
+    ~SparsePythonCompressedLinSolver() override;
+
+    int solve(void) override;
+    int setSize(void) override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) override;
+
+    int setLinearSOE(SparsePythonCompressedLinSOE &theSOE);
+    int setPythonCallable(PyObject *callable, const char *methodName = "solve");
+    void setWritableFlags(const SparsePythonWritableFlags &flags) { writableFlags = flags; }
+
+    PyObject *getPythonCallable() const { return solverObject; }
+    const std::string &getMethodName() const { return methodName; }
+    const SparsePythonWritableFlags &getWritableFlags() const { return writableFlags; }
+
+  private:
+    int callPythonSolver();
+
+    SparsePythonCompressedLinSOE *theSOE;
+    PyObject *solverObject;
+    std::string methodName;
+    SparsePythonWritableFlags writableFlags;
+};
+#endif /* SparsePythonCompressedLinSolver_h */

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.cpp
@@ -1,0 +1,331 @@
+#include "SparsePythonFactory.h"
+
+#include "SparsePythonCOOLinSOE.h"
+#include "SparsePythonCOOLinSolver.h"
+#include "SparsePythonCompressedLinSOE.h"
+#include "SparsePythonCompressedLinSolver.h"
+#include "SparsePythonCommon.h"
+
+#include <OPS_Globals.h>
+#include <elementAPI.h>
+
+#include <Python.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+namespace {
+
+bool
+IsSparsePythonType(const char *type)
+{
+    return strcmp(type, "PythonSparse") == 0;
+}
+
+std::string
+ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+bool
+ParseSchemeToken(const char *token, SparsePythonStorageScheme &scheme)
+{
+    if (token == nullptr) {
+        return false;
+    }
+    std::string normalized = ToLower(token);
+    if (normalized == "csr" || normalized == "row") {
+        scheme = SparsePythonStorageScheme::CSR;
+        return true;
+    }
+    if (normalized == "csc" || normalized == "column" || normalized == "col") {
+        scheme = SparsePythonStorageScheme::CSC;
+        return true;
+    }
+    if (normalized == "coo" || normalized == "coordinate") {
+        scheme = SparsePythonStorageScheme::COO;
+        return true;
+    }
+    return false;
+}
+
+// Parse a single writable flag token and update flags
+// Returns true if the token was recognized, false otherwise
+bool
+ParseSingleWritableFlag(const char *token, SparsePythonWritableFlags &flags, bool &hasAll, bool &hasNone)
+{
+    if (token == nullptr) {
+        return false;
+    }
+    std::string normalized = ToLower(token);
+    // Trim whitespace
+    normalized.erase(0, normalized.find_first_not_of(" \t"));
+    normalized.erase(normalized.find_last_not_of(" \t") + 1);
+    
+    if (normalized == "values" || normalized == "value" || normalized == "data") {
+        flags.values = true;
+        return true;
+    } else if (normalized == "rhs" || normalized == "b" || normalized == "right-hand-side") {
+        flags.rhs = true;
+        return true;
+    } else if (normalized == "all" || normalized == "true" || normalized == "1") {
+        flags.values = true;
+        flags.rhs = true;
+        hasAll = true;
+        return true;
+    } else if (normalized == "none" || normalized == "false" || normalized == "0") {
+        flags.values = false;
+        flags.rhs = false;
+        hasNone = true;
+        return true;
+    }
+    
+    return false;
+}
+
+bool
+ParseWritableFlags(const char *token, SparsePythonWritableFlags &flags)
+{
+    if (token == nullptr) {
+        return false;
+    }
+    std::string normalized = ToLower(token);
+    
+    flags = SparsePythonWritableFlags(false, false);
+    bool hasAll = false;
+    bool hasNone = false;
+    
+    // Parse comma-separated list
+    std::istringstream iss(normalized);
+    std::string item;
+    bool valid = false;
+    
+    while (std::getline(iss, item, ',')) {
+        if (item.empty()) {
+            // Skip empty items from multiple commas
+            continue;
+        }
+        
+        if (!ParseSingleWritableFlag(item.c_str(), flags, hasAll, hasNone)) {
+            // Unknown token
+            return false;
+        }
+        
+        valid = true;
+        
+        // Early exit for complete flags
+        if (hasAll || hasNone) {
+            break;
+        }
+    }
+    
+    return valid;
+}
+
+PyObject *
+EnsureCallable(PyObject *solverObject, const char *solveMethod)
+{
+    if (!PyObject_HasAttrString(solverObject, solveMethod)) {
+        opserr << "WARNING: system PythonSparse - solver object missing method '" << solveMethod << "'" << endln;
+        return nullptr;
+    }
+    PyObject *callable = PyObject_GetAttrString(solverObject, solveMethod);
+    if (callable == nullptr || !PyCallable_Check(callable)) {
+        opserr << "WARNING: system PythonSparse - attribute '" << solveMethod << "' not callable" << endln;
+        Py_XDECREF(callable);
+        return nullptr;
+    }
+    return callable; // new reference; caller responsible for DECREF
+}
+
+void *
+CreateCompressedSOE(PyObject *solverObject, SparsePythonStorageScheme scheme,
+                    const SparsePythonWritableFlags &writableFlags)
+{
+    if (scheme == SparsePythonStorageScheme::COO) {
+        opserr << "WARNING: system PythonSparse - COO scheme is not compatible with compressed storage" << endln;
+        return nullptr;
+    }
+
+    PyObject *callable = EnsureCallable(solverObject, "solve");
+    if (callable == nullptr) {
+        return nullptr;
+    }
+    Py_DECREF(callable);
+
+    auto *solver = new SparsePythonCompressedLinSolver();
+    solver->setPythonCallable(solverObject, "solve");
+    solver->setWritableFlags(writableFlags);
+
+    auto *soe = new SparsePythonCompressedLinSOE(*solver, scheme);
+    return soe;
+}
+
+void *
+CreateCOOSOE(PyObject *solverObject, const SparsePythonWritableFlags &writableFlags)
+{
+    PyObject *callable = EnsureCallable(solverObject, "solve");
+    if (callable == nullptr) {
+        return nullptr;
+    }
+    Py_DECREF(callable);
+
+    auto *solver = new SparsePythonCOOLinSolver();
+    solver->setPythonCallable(solverObject, "solve");
+    solver->setWritableFlags(writableFlags);
+
+    auto *soe = new SparsePythonCOOLinSOE(*solver);
+    return soe;
+}
+
+} // namespace
+
+void *
+OPS_SparsePythonSolver()
+{
+    const char *expectedSyntax = "system 'PythonSparse' {'solver': SolverObject, 'scheme': 'CSR'|'CSC'|'COO', 'writable': 'values'|'rhs'|'values,rhs'|'all'|'none'}";
+
+    OPS_ResetCurrentInputArg(-1);
+
+    const char *type = OPS_GetString();
+    if (type == nullptr || !IsSparsePythonType(type)) {
+        opserr << "WARNING: system " << (type != nullptr ? type : "PythonSparse")
+               << " - unexpected type" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    if (!Py_IsInitialized()) {
+        Py_Initialize();
+    }
+
+    // Get the dictionary argument
+    void *dictPtr = OPS_GetVoidPtr();
+    if (dictPtr == nullptr) {
+        opserr << "WARNING: system " << type << " - requires a dictionary argument" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    PyObject *dict = static_cast<PyObject *>(dictPtr);
+    if (!PyDict_Check(dict)) {
+        opserr << "WARNING: system " << type << " - second argument must be a dictionary" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    // Extract 'solver' (required)
+    PyObject *solverObj = PyDict_GetItemString(dict, "solver");
+    if (solverObj == nullptr) {
+        opserr << "WARNING: system " << type << " - dictionary must contain 'solver' key" << endln;
+        opserr << "Expected syntax: " << expectedSyntax << endln;
+        return nullptr;
+    }
+
+    // Extract 'scheme' (optional, defaults to CSR)
+    SparsePythonStorageScheme scheme = SparsePythonStorageScheme::CSR;
+    PyObject *schemeObj = PyDict_GetItemString(dict, "scheme");
+    if (schemeObj != nullptr) {
+        if (!PyUnicode_Check(schemeObj)) {
+            opserr << "WARNING: system " << type << " - 'scheme' must be a string" << endln;
+            return nullptr;
+        }
+        const char *schemeStr = PyUnicode_AsUTF8(schemeObj);
+        if (schemeStr == nullptr || !ParseSchemeToken(schemeStr, scheme)) {
+            opserr << "WARNING: system " << type << " - unknown storage scheme '"
+                   << (schemeStr != nullptr ? schemeStr : "null") << "' (expected CSR, CSC, or COO)" << endln;
+            return nullptr;
+        }
+    }
+
+    // Extract 'writable' (optional, defaults to read-only)
+    // Can be None, a string ('values', 'rhs', 'values,rhs', 'all', 'none'), or a list (['values', 'rhs'])
+    SparsePythonWritableFlags writableFlags;  // Default: all read-only
+    PyObject *writableObj = PyDict_GetItemString(dict, "writable");
+    if (writableObj != nullptr) {
+        if (writableObj == Py_None) {
+            // None means 'none' (all read-only), which is already the default
+            // No need to do anything, writableFlags is already false/false
+        } else if (PyUnicode_Check(writableObj)) {
+            // String format: 'values,rhs', 'all', 'none', etc.
+            const char *writableStr = PyUnicode_AsUTF8(writableObj);
+            if (writableStr == nullptr || !ParseWritableFlags(writableStr, writableFlags)) {
+                opserr << "WARNING: system " << type << " - invalid writable flags '"
+                       << (writableStr != nullptr ? writableStr : "null") << "'" << endln;
+                opserr << "Expected: 'values', 'rhs', 'values,rhs', 'all', or 'none'" << endln;
+                return nullptr;
+            }
+        } else if (PyList_Check(writableObj) || PyTuple_Check(writableObj)) {
+            // List/tuple format: ['values', 'rhs']
+            PyObject *seq = PySequence_Fast(writableObj, "writable must be a sequence");
+            if (seq == nullptr) {
+                return nullptr;
+            }
+            
+            Py_ssize_t len = PySequence_Fast_GET_SIZE(seq);
+            writableFlags = SparsePythonWritableFlags(false, false);
+            bool valid = false;
+            bool hasAll = false;
+            bool hasNone = false;
+            
+            for (Py_ssize_t i = 0; i < len; i++) {
+                PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+                if (!PyUnicode_Check(item)) {
+                    opserr << "WARNING: system " << type << " - 'writable' list items must be strings" << endln;
+                    Py_DECREF(seq);
+                    return nullptr;
+                }
+                
+                const char *itemStr = PyUnicode_AsUTF8(item);
+                if (itemStr == nullptr) {
+                    Py_DECREF(seq);
+                    return nullptr;
+                }
+                
+                if (!ParseSingleWritableFlag(itemStr, writableFlags, hasAll, hasNone)) {
+                    opserr << "WARNING: system " << type << " - unknown writable flag '"
+                           << itemStr << "' in list" << endln;
+                    opserr << "Expected: 'values', 'rhs', 'all', or 'none'" << endln;
+                    Py_DECREF(seq);
+                    return nullptr;
+                }
+                
+                valid = true;
+                
+                // Early exit for complete flags
+                if (hasAll || hasNone) {
+                    break;
+                }
+            }
+            
+            Py_DECREF(seq);
+            if (!valid) {
+                opserr << "WARNING: system " << type << " - 'writable' list must contain at least one valid flag" << endln;
+                return nullptr;
+            }
+        } else {
+            opserr << "WARNING: system " << type << " - 'writable' must be a string or a list/tuple" << endln;
+            return nullptr;
+        }
+    }
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+
+    void *result = nullptr;
+    if (scheme == SparsePythonStorageScheme::COO) {
+        result = CreateCOOSOE(solverObj, writableFlags);
+    } else {
+        result = CreateCompressedSOE(solverObj, scheme, writableFlags);
+    }
+
+    PyGILState_Release(gilState);
+    return result;
+}
+

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.h
@@ -1,8 +1,6 @@
 #ifndef SparsePythonFactory_h
 #define SparsePythonFactory_h
 
-#include "SparsePythonCommon.h"
-
 /**
  * Parse the `system PythonSparse` command and construct the corresponding SOE.
  *

--- a/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.h
+++ b/SRC/system_of_eqn/linearSOE/sparsePython/SparsePythonFactory.h
@@ -1,0 +1,29 @@
+#ifndef SparsePythonFactory_h
+#define SparsePythonFactory_h
+
+#include "SparsePythonCommon.h"
+
+/**
+ * Parse the `system PythonSparse` command and construct the corresponding SOE.
+ *
+ * Expected syntax:
+ *   `system 'PythonSparse' {'solver': SolverObject, 'scheme': 'CSR'|'CSC'|'COO', 'writable': 'values'|'rhs'|'values,rhs'|'all'|'none'}`
+ *
+ * The supplied Python object must expose a `solve` method. When invoked the
+ * solver receives memoryviews pointing directly to the SOE storage:
+ *   - CSR/CSC schemes share the `index_ptr` (int32) and `indices` (int32) arrays
+ *   - COO exposes `row` and `col` (int32) arrays instead
+ *   - All schemes provide `values`, `rhs`, `x` (float64) along with metadata
+ *     (`num_eqn`, `nnz`, `matrix_status`, `storage_scheme`).
+ *
+ * The callable must operate in place on these buffers and return either `None`
+ * for success or an integer status/error code. DO NOT rebind the keywords;
+ * wrap the memoryviews with NumPy/JAX/CuPy arrays so updates propagate directly
+ * to the underlying C++ storage.
+ *
+ * The returned pointer owns a Python-backed `LinearSOE` instance and should be
+ * treated as a `LinearSOE*` by the caller.
+ */
+void *OPS_SparsePythonSolver();
+
+#endif /* SparsePythonFactory_h */


### PR DESCRIPTION
## Overview

This PR adds a `PythonSparse` solver interface that lets OpenSees delegate linear system solves ($\mathbf{A}\mathbf{x} = \mathbf{b}$) and generalized eigenvalue problems ($\mathbf{K}\phi = \lambda \mathbf{M}\phi$) to user-defined Python objects. Sparse matrix buffers (CSR/CSC/COO) are exposed to Python via zero-copy memoryviews, enabling efficient integration with SciPy, CuPy, nvmath, or custom solvers without writing C++ wrappers or recompiling OpenSees. This lowers the barrier for experimenting with external CPU/GPU solvers and accelerators.

---

## Summary of Changes

### New Solver Types
- **`system PythonSparse`** — linear system solver for $\mathbf{A}\mathbf{x} = \mathbf{b}$
- **`eigen PythonSparse`** — generalized eigenvalue solver for $\mathbf{K}\phi = \lambda \mathbf{M}\phi$

### Main Features
- Zero-copy access to sparse buffers (`index_ptr`, `indices`, `values`, etc.)  
- Supports **CSR**, **CSC**, and **COO** formats  
- Writable buffers for in-place solution updates where appropriate  
- Matrix status flags to cache factorizations/preconditioners:
  - `UNCHANGED`
  - `COEFFICIENTS_CHANGED`
  - `STRUCTURE_CHANGED`
- Dictionary-based API for extensible solver configuration (no CLI-style parsing, easy to add options over time)

### Examples
A couple of examples benchmarking the `PythonSparse` interface against native OpenSees solvers are available in the `EXAMPLES/SolverBenchmark` directory:
- Linear system solve example: `EXAMPLES/SolverBenchmark/benchmark_python_sparse.py`
- Generalized eigenvalue problem example: `EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py`

---

## Motivation

Adding new sparse solvers traditionally requires writing C++ wrappers, linking external libraries, and recompiling OpenSees. This workflow is slow and hard to maintain across OS, hardware, and compiler versions.

The `PythonSparse` interface avoids this entirely by handing matrix data to Python, where users can:

- Use SciPy, CuPy, nvmath, or custom solvers
- Swap solvers just by changing a Python object
- Access GPU acceleration without modifying C++
- Prototype new algorithms quickly
- Minimize dependency and compilation issues

This makes solver development and experimentation much easier.

---

## Usage Examples

### Linear Solve Example (CuPy CG)

```python

# Define a custom solver class
class CuPyCGSolver:
    def __init__(self, rtol=1e-5, atol=1e-12, maxiter=None):
        self.rtol = rtol
        self.atol = atol
        self.maxiter = maxiter
        self.A = None

    def solve(self, **kwargs):
        index_ptr = kwargs['index_ptr']
        indices = kwargs['indices']
        values = kwargs['values']
        rhs = kwargs['rhs']
        x = kwargs['x']
        num_eqn = kwargs['num_eqn']
        nnz = kwargs['nnz']
        matrix_status = kwargs['matrix_status']

        import numpy as np
        import cupy as cp
        import cupyx.scipy.sparse.linalg

        indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
        idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
        vals = np.frombuffer(values, dtype=np.float64, count=nnz)

        if matrix_status == 'STRUCTURE_CHANGED' or self.A is None:
            self.A = cp.sparse.csr_matrix(
                (cp.asarray(vals), cp.asarray(idx), cp.asarray(indptr)),
                shape=(num_eqn, num_eqn)
            )
        elif matrix_status == 'COEFFICIENTS_CHANGED':
            self.A.data[:] = cp.asarray(vals)

        rhs_gpu = cp.asarray(np.frombuffer(rhs, dtype=np.float64, count=num_eqn))
        x_gpu, info = cupyx.scipy.sparse.linalg.cg(
            self.A, rhs_gpu, tol=self.rtol, atol=self.atol, maxiter=self.maxiter
        )

        np.frombuffer(x, dtype=np.float64, count=num_eqn)[:] = cp.asnumpy(x_gpu)
        return -int(info)

# Use the solver in OpenSees
solver = CuPyCGSolver(rtol=1e-8, atol=1e-12, maxiter=1000)
ops.system('PythonSparse', {'solver': solver, 'scheme': 'CSR'})
```

### Generalized Eigenproblem Example (SciPy)

```python
# Define a custom solver class
class SciPyGeneralizedEigenSolver:
    def __init__(self, maxiter=None, tol=0.0):
        self.maxiter = maxiter
        self.tol = tol
        self._k_matrix = None
        self._m_matrix = None

    def solve(self, **kwargs):
        index_ptr = kwargs['index_ptr']
        indices = kwargs['indices']
        k_values = kwargs['k_values']
        m_values = kwargs['m_values']
        eigenvalues = kwargs['eigenvalues']
        eigenvectors = kwargs['eigenvectors']
        num_eqn = kwargs['num_eqn']
        nnz = kwargs['nnz']
        matrix_status = kwargs['matrix_status']
        num_modes = kwargs['num_modes']
        find_smallest = kwargs['find_smallest']

        import numpy as np
        import scipy.sparse as sp
        import scipy.sparse.linalg as sp_linalg

        indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
        idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
        k_data = np.frombuffer(k_values, dtype=np.float64, count=nnz)
        m_data = np.frombuffer(m_values, dtype=np.float64, count=nnz)

        if matrix_status == 'STRUCTURE_CHANGED' or self._k_matrix is None:
            self._k_matrix = sp.csr_matrix((k_data, idx, indptr), shape=(num_eqn, num_eqn))
            self._m_matrix = sp.csr_matrix((m_data, idx, indptr), shape=(num_eqn, num_eqn))
        elif matrix_status == 'COEFFICIENTS_CHANGED':
            self._k_matrix.data[:] = k_data
            self._m_matrix.data[:] = m_data

        eigsh_kwargs = {
            'k': num_modes,
            'M': self._m_matrix,
            'which': 'LM',
        }
        if find_smallest:
            eigsh_kwargs['sigma'] = 0.0
        if self.maxiter is not None:
            eigsh_kwargs['maxiter'] = self.maxiter
        if self.tol > 0.0:
            eigsh_kwargs['tol'] = self.tol

        eigvals, eigvecs = sp_linalg.eigsh(self._k_matrix, **eigsh_kwargs)

        np.frombuffer(eigenvalues, dtype=np.float64, count=num_modes)[:] = eigvals[:num_modes]
        np.frombuffer(eigenvectors, dtype=np.float64, count=num_modes * num_eqn)[:] = eigvecs.T.flatten()

        return None

# Use the solver in OpenSees
solver = SciPyGeneralizedEigenSolver()
ops.eigen('PythonSparse', 10, {'solver': solver, 'scheme': 'CSR'})
```
