### PR TITLE
Expose section response type information via sectionResponseType

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -311,6 +311,7 @@ int OPS_sectionStiffness();
 int OPS_sectionFlexibility();
 int OPS_sectionLocation();
 int OPS_sectionWeight();
+int OPS_sectionResponseType();
 int OPS_sectionTag();
 int OPS_sectionDisplacement();
 int OPS_cbdiDisplacement();

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -1792,6 +1792,18 @@ static PyObject *Py_ops_sectionWeight(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject *Py_ops_sectionResponseType(PyObject *self, PyObject *args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_sectionResponseType() < 0) {
+	opserr<<(void*)0;
+	return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_sectionTag(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -3117,6 +3129,7 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("sectionLocation", &Py_ops_sectionLocation);
     addCommand("sectionWeight", &Py_ops_sectionWeight);
     addCommand("sectionTag", &Py_ops_sectionTag);
+    addCommand("sectionResponseType", &Py_ops_sectionResponseType);
     addCommand("sectionDisplacement", &Py_ops_sectionDisplacement);
     addCommand("cbdiDisplacement", &Py_ops_cbdiDisplacement);        
     addCommand("basicDeformation", &Py_ops_basicDeformation);

--- a/SRC/interpreter/TclWrapper.cpp
+++ b/SRC/interpreter/TclWrapper.cpp
@@ -981,6 +981,14 @@ static int Tcl_ops_sectionWeight(ClientData clientData, Tcl_Interp *interp, int 
     return TCL_OK;
 }
 
+static int Tcl_ops_sectionResponseType(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv) {
+    wrapper->resetCommandLine(argc, 1, argv);
+
+    if (OPS_sectionResponseType() < 0) return TCL_ERROR;
+
+    return TCL_OK;
+}
+
 static int Tcl_ops_basicDeformation(ClientData clientData, Tcl_Interp *interp, int argc,   TCL_Char **argv) {
     wrapper->resetCommandLine(argc, 1, argv);
 


### PR DESCRIPTION
Dear OpenSees developers,

In OpenSees, **the number and ordering of section response components are not fixed and may vary across section types** . However, users currently have no direct way to identify what each returned section response component represents.

This PR adds a new command, **sectionResponseType**, to expose the section response type codes corresponding to a given element section. This enables users to reliably interpret section response outputs regardless of section implementation.

The new command supports querying either a specific response component or the full list of response types for a section, and is available through the interpreter interfaces.

**Interfaces and Example (Python)**

The following example illustrates how the new functionality can be used from a high-level interface.

```python
# eleResponse(eleTag, "section", secNum, "code")
ops.eleResponse(1, "section", 1, "code")
# returns
[2.0, 1.0]

# sectionResponseType(eleTag, secNum, <dof>)
ops.sectionResponseType(1, 3)
# returns
['P', 'MZ']
```

These outputs indicate the response type identifiers associated with each section response component, enabling consistent post-processing even when section response ordering differs across implementations.

This change is additive and does not modify existing behavior.

The following is the test file.
[test - sectionResponseType.py.py](https://github.com/user-attachments/files/24143391/test.-.sectionResponseType.py.py)
