### PR TITLE
Use MPI_Comm_c2f for MUMPS Fortran communicator

### DIFF
--- a/SRC/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
@@ -94,7 +94,7 @@ MumpsParallelSolver::initializeMumps()
     //    id.comm_fortran=-987654;
     id.comm_fortran = 0;
 #else
-    id.comm_fortran = MPI_COMM_WORLD;
+    id.comm_fortran = MPI_Comm_c2f(MPI_COMM_WORLD);
 #endif
     
     id.ICNTL(5) = 0; id.ICNTL(18) = 3;

--- a/SRC/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
@@ -68,7 +68,7 @@ MumpsSolver::MumpsSolver(int ICNTL7, int ICNTL14)
   //  id.comm_fortran=-987654;
   id.comm_fortran=0;
 #else
-  id.comm_fortran=MPI_COMM_WORLD;
+  id.comm_fortran=MPI_Comm_c2f(MPI_COMM_WORLD);
 #endif
 
   id.ICNTL(14) = ICNTL14;


### PR DESCRIPTION
Explicitly converts the C MPI comm to its fortran counterpart. Needed in latest OpenMPI implementation, but backwards compatible. 