### PR TITLE
Fix R degradation in `SteelMPF` when strain history starts at zero

### DIFF
--- a/SRC/material/uniaxial/SteelMPF.cpp
+++ b/SRC/material/uniaxial/SteelMPF.cpp
@@ -415,15 +415,19 @@ void SteelMPF::determineTrialState(double def)
 	// Determine initial loading condition
 	if (incold == 0) {
 
+		static const double strainTol = 1.0e-14;
+
 		Rptwoprev = R0;
 		Rntwoprev = R0;
 		outp = 1;
 		outn = 1;
 
-		if (e < 0.0) {
+		if (e < -strainTol) {
 			inc = -1;
-		} else {
+		} else if (e > strainTol) {
 			inc = 1;
+		} else {
+			inc = 0;
 		}
 
 		erp=0.0;
@@ -449,44 +453,50 @@ void SteelMPF::determineTrialState(double def)
 		e0ntwoprev=e0n;
 		sig0ntwoprev=sig0n;
 
-		if (e==0.0) {
-			nloop=0;
-		} else {
-			nloop=1;
-		}
-
 		Rp = R0;
 		Rn = R0;
 
-		if (inc==1) {
+		if (inc == 0) {
 
-			e0p=eyieldp;
-			sig0p=sigyieldp;
-			e0ptwoprev=e0p;
-			sig0ptwoprev=sig0p;
-
-			double estp=(e-erp)/(e0p-erp);
-			double sigstp=bp*estp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*estp; 
-			double sig=sigrp+sigstp*(sig0p-sigrp);
-			double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
-
-			F = sig;
-			stif = Et;
+			F = 0.0;
+			stif = E0;
+			nloop = 0;
 
 		} else {
 
-			e0n=-eyieldn;
-			sig0n=-sigyieldn;
-			e0ntwoprev=e0n;
-			sig0ntwoprev=sig0n;
+			nloop = 1;
 
-			double estn=(e-ern)/(e0n-ern);
-			double sigstn=bn*estn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*estn;
-			double sig=sigrn+sigstn*(sig0n-sigrn);
-			double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+			if (inc==1) {
 
-			F = sig;
-			stif = Et;
+				e0p=eyieldp;
+				sig0p=sigyieldp;
+				e0ptwoprev=e0p;
+				sig0ptwoprev=sig0p;
+
+				double estp=(e-erp)/(e0p-erp);
+				double sigstp=bp*estp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*estp; 
+				double sig=sigrp+sigstp*(sig0p-sigrp);
+				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
+
+				F = sig;
+				stif = Et;
+
+			} else {
+
+				e0n=-eyieldn;
+				sig0n=-sigyieldn;
+				e0ntwoprev=e0n;
+				sig0ntwoprev=sig0n;
+
+				double estn=(e-ern)/(e0n-ern);
+				double sigstn=bn*estn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*estn;
+				double sig=sigrn+sigstn*(sig0n-sigrn);
+				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+
+				F = sig;
+				stif = Et;
+
+			}
 
 		}
 

--- a/SRC/material/uniaxial/SteelMPF.cpp
+++ b/SRC/material/uniaxial/SteelMPF.cpp
@@ -684,7 +684,7 @@ void SteelMPF::determineTrialState(double def)
 			}
 		}
 
-		if (incold == -1) {
+		else if (incold == -1) {
 
 			if (e > eold) {
 

--- a/SRC/material/uniaxial/SteelMPF.cpp
+++ b/SRC/material/uniaxial/SteelMPF.cpp
@@ -320,50 +320,9 @@ SteelMPF::~SteelMPF ()
 
 int SteelMPF::setTrialStrain(double strain, double strainRate)
 {
-	// Reset history variables to last converged state
-	inc = incold;
-
-	Rptwoprev = Rptwoprevold;
-	Rntwoprev = Rntwoprevold;
-
-	outp = outpold;
-	outn = outnold;
-
-	erp = erpold;
-	sigrp = sigrpold;
-
-	ern = ernold;
-	sigrn = sigrnold;
-
-	erpmaxmax = erpmaxmaxold;
-	ernmaxmax = ernmaxmaxold;
-
-	e0p = e0pold;
-	sig0p = sig0pold;
-
-	e0n = e0nold;
-	sig0n = sig0nold;
-
-	erntwoprev = erntwoprevold;
-	sigrntwoprev = sigrntwoprevold;
-	e0ntwoprev = e0ntwoprevold;
-	sig0ntwoprev = sig0ntwoprevold;
-
-	erptwoprev = erptwoprevold;
-	sigrptwoprev = sigrptwoprevold;
-	e0ptwoprev = e0ptwoprevold;
-	sig0ptwoprev = sig0ptwoprevold;
-
-	Rp = Rpold;
-	Rn = Rnold;
-
-	nloop = nloopold;
-
-	// Set trial strain
+	// Trial strain; trial history is set from committed (*old) state inside determineTrialState
 	def = strain;
-
-	// Calculate the trial state given the trial strain
-	this->determineTrialState(def);
+	determineTrialState(def);
 
 	return 0;
 }
@@ -371,50 +330,8 @@ int SteelMPF::setTrialStrain(double strain, double strainRate)
 
 int SteelMPF::setTrial (double strain, double &stress, double &tangent, double strainRate)
 {
-	// Reset history variables to last converged state
-	inc = incold;
-
-	Rptwoprev = Rptwoprevold;
-	Rntwoprev = Rntwoprevold;
-
-	outp = outpold;
-	outn = outnold;
-
-	erp = erpold;
-	sigrp = sigrpold;
-
-	ern = ernold;
-	sigrn = sigrnold;
-
-	erpmaxmax = erpmaxmaxold;
-	ernmaxmax = ernmaxmaxold;
-
-	e0p = e0pold;
-	sig0p = sig0pold;
-
-	e0n = e0nold;
-	sig0n = sig0nold;
-
-	erntwoprev = erntwoprevold;
-	sigrntwoprev = sigrntwoprevold;
-	e0ntwoprev = e0ntwoprevold;
-	sig0ntwoprev = sig0ntwoprevold;
-
-	erptwoprev = erptwoprevold;
-	sigrptwoprev = sigrptwoprevold;
-	e0ptwoprev = e0ptwoprevold;
-	sig0ptwoprev = sig0ptwoprevold;
-
-	Rp = Rpold;
-	Rn = Rnold;
-
-	nloop = nloopold;
-
-	// Set trial strain
 	def = strain;
-
-	// Calculate the trial state given the trial strain
-	this->determineTrialState(def);
+	determineTrialState(def);
 
 	stress = F; 
 	tangent = stif;

--- a/SRC/material/uniaxial/SteelMPF.cpp
+++ b/SRC/material/uniaxial/SteelMPF.cpp
@@ -37,6 +37,24 @@
 #include <elementAPI.h>
 #define OPS_Export 
 
+namespace {
+
+// Menegotto–Pinto along strain-stress chord: est = ε* (normalized strain).
+// *sigst = σ* (required, non-null). If tangent != nullptr, *tangent = dσ*/dε*; Et = chordSlope * etInner.
+inline void mpStressTangent(double est, double R, double b, double *sigst,
+	double *tangent = nullptr)
+{
+	const double eR = pow(est, R);
+	const double onePluseR = 1.0 + eR;
+	const double phi = pow(onePluseR, 1.0 / R);
+	const double c = (1.0 - b) / phi;
+	*sigst = b * est + c * est;
+	if (tangent != nullptr)
+		*tangent = b + c * (1.0 - eR / onePluseR);
+}
+
+} // namespace
+
 // Read input parameters and build the material
 OPS_Export void *OPS_SteelMPF(void)
 {
@@ -474,9 +492,10 @@ void SteelMPF::determineTrialState(double def)
 				sig0ptwoprev=sig0p;
 
 				double estp=(e-erp)/(e0p-erp);
-				double sigstp=bp*estp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*estp; 
+				double sigstp, etInnerp;
+				mpStressTangent(estp, Rp, bp, &sigstp, &etInnerp);
 				double sig=sigrp+sigstp*(sig0p-sigrp);
-				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
+				double Et=((sig0p-sigrp)/(e0p-erp))*etInnerp;
 
 				F = sig;
 				stif = Et;
@@ -489,9 +508,10 @@ void SteelMPF::determineTrialState(double def)
 				sig0ntwoprev=sig0n;
 
 				double estn=(e-ern)/(e0n-ern);
-				double sigstn=bn*estn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*estn;
+				double sigstn, etInnern;
+				mpStressTangent(estn, Rn, bn, &sigstn, &etInnern);
 				double sig=sigrn+sigstn*(sig0n-sigrn);
-				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+				double Et=((sig0n-sigrn)/(e0n-ern))*etInnern;
 
 				F = sig;
 				stif = Et;
@@ -605,20 +625,23 @@ void SteelMPF::determineTrialState(double def)
 				}
 
 				double estn=(e-ern)/(e0n-ern);
-				double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
+				double sigstn, etInnern;
+				mpStressTangent(estn, Rn, bn, &sigstn, &etInnern);
 
 				double sig=sigrn+sigstn*(sig0n-sigrn);
-				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1+pow(estn,Rn))));
+				double Et=((sig0n-sigrn)/(e0n-ern))*etInnern;
 
 				double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
+				double sigstnlimit, etInnerNlimit;
+				mpStressTangent(estnlimit, Rntwoprev, bn, &sigstnlimit, &etInnerNlimit);
 
 				double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
-				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
+				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*etInnerNlimit;
 
 				double Rcontrol=Rntwoprev;
 				double estcontrol=(ern-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstcontrol=bn*estcontrol+((1-bn)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
+				double sigstcontrol;
+				mpStressTangent(estcontrol, Rcontrol, bn, &sigstcontrol, nullptr);
 				double sigcontrol=sigrntwoprev+sigstcontrol*(sig0ntwoprev-sigrntwoprev);
 
 				if (sigrn < sigcontrol) {
@@ -651,16 +674,18 @@ void SteelMPF::determineTrialState(double def)
 				Rp=Rpold;
 
 				double estp=(e-erp)/(e0p-erp);
-				double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
+				double sigstp, etInnerp;
+				mpStressTangent(estp, Rp, bp, &sigstp, &etInnerp);
 
 				double sig=sigrp+sigstp*(sig0p-sigrp);
-				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1+pow(estp,Rp))));
+				double Et=((sig0p-sigrp)/(e0p-erp))*etInnerp;
 
 				double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
+				double sigstplimit, etInnerPlimit;
+				mpStressTangent(estplimit, Rptwoprev, bp, &sigstplimit, &etInnerPlimit);
 
 				double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
-				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
+				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*etInnerPlimit;
 
 				if (erp>erptwoprev && outp==0) {
 
@@ -739,20 +764,23 @@ void SteelMPF::determineTrialState(double def)
 				}
 
 				double estp=(e-erp)/(e0p-erp);
-				double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
+				double sigstp, etInnerp;
+				mpStressTangent(estp, Rp, bp, &sigstp, &etInnerp);
 
 				double sig=sigrp+sigstp*(sig0p-sigrp);
-				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
+				double Et=((sig0p-sigrp)/(e0p-erp))*etInnerp;
 
 				double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
+				double sigstplimit, etInnerPlimit;
+				mpStressTangent(estplimit, Rptwoprev, bp, &sigstplimit, &etInnerPlimit);
 
 				double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
-				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
+				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*etInnerPlimit;
 
 				double Rcontrol=Rptwoprev;
 				double estcontrol=(erp-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstcontrol=bp*estcontrol+((1-bp)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
+				double sigstcontrol;
+				mpStressTangent(estcontrol, Rcontrol, bp, &sigstcontrol, nullptr);
 				double sigcontrol=sigrptwoprev+sigstcontrol*(sig0ptwoprev-sigrptwoprev);
 
 				if (sigrp > sigcontrol) {
@@ -783,16 +811,18 @@ void SteelMPF::determineTrialState(double def)
 				Rn=Rnold;
 
 				double estn=(e-ern)/(e0n-ern);
-				double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
+				double sigstn, etInnern;
+				mpStressTangent(estn, Rn, bn, &sigstn, &etInnern);
 
 				double sig=sigrn+sigstn*(sig0n-sigrn);
-				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+				double Et=((sig0n-sigrn)/(e0n-ern))*etInnern;
 
 				double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
+				double sigstnlimit, etInnerNlimit;
+				mpStressTangent(estnlimit, Rntwoprev, bn, &sigstnlimit, &etInnerNlimit);
 
 				double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
-				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
+				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*etInnerNlimit;
 
 				if (ern < erntwoprev && outn == 0) {
 


### PR DESCRIPTION
## Fix `R` degradation in `SteelMPF` when strain history starts at zero

This PR fixes a bug in `SteelMPF` that caused incorrect degradation of the curvature parameter `R` when the strain history starts at $\varepsilon = 0$. 

The issue led to inconsistent responses for equivalent loading histories depending on whether `-prependZero` was used in the `Path` time series.

This update makes the behavior consistent in both cases (see commit [97bccae](https://github.com/OpenSees/OpenSees/commit/97bccae777cd2266743d367ec18cb64b1e2d5bc0)). The remaining commits only remove redundant computations; no other behavior was changed.

### Reproduction

<table>
<tr>
<td align="center"><b>Current behavior</b></td>
<td align="center"><b>Behavior with this PR</b></td>
</tr>
<tr>
<td>
<img width="100%" alt="current behavior" src="https://github.com/user-attachments/assets/0fb7e220-045a-4b96-b55e-a24921c061fb" />
</td>
<td>
<img width="100%" alt="fixed behavior" src="https://github.com/user-attachments/assets/634e66fc-1851-408d-afae-aa91497dfb22" />
</td>
</tr>
</table>

### Test script

```python
import matplotlib.pyplot as plt
import numpy as np
import openseespy.opensees as ops

E = 29000.0
FY = 50.0
B_P = 0.02
B_N = 0.02
R0 = 20.0
C_R1 = 0.925
C_R2 = 0.15
EPS_Y = FY / E

EPS_PEAK = 2.0 * EPS_Y
N = 10
D = np.linspace(0.0, EPS_PEAK, N, endpoint=False)
DISP_HISTORY = np.r_[D, EPS_PEAK - D, -D, -(EPS_PEAK - D)]


def run_simulation(disp_history, prepend_zero=False):
    ops.wipe()
    ops.model("basic", "-ndm", 1, "-ndf", 1)
    ops.node(1, 0.0)
    ops.fix(1, 1)
    ops.node(2, 0.0)
    ops.uniaxialMaterial("SteelMPF", 1, FY, FY, E, B_P, B_N, R0, C_R1, C_R2)
    ops.element("zeroLength", 1, 1, 2, "-mat", 1, "-dir", 1)

    dt = 1.0
    extra = ["-useLast"] + (["-prependZero"] if prepend_zero else [])
    ops.timeSeries("Path", 1, "-dt", dt, "-values", *disp_history, *extra)
    ops.pattern("Plain", 1, 1)
    ops.sp(2, 1, 1.0)
    ops.integrator("LoadControl", dt)
    ops.constraints("Transformation")
    ops.numberer("Plain")
    ops.system("UmfPack")
    ops.analysis("Static", "-noWarnings")

    n = len(disp_history)
    stress = np.zeros(n)
    strain = np.zeros(n)
    time = np.zeros(n)
    for i in range(n):
        if ops.analyze(1) != 0:
            raise RuntimeError("analyze failed at step %d/%d" % (i + 1, n))
        stress[i] = ops.eleResponse(1, "material", 1, "stress")[0]
        strain[i] = ops.eleResponse(1, "material", 1, "strain")[0]
        time[i] = ops.getTime()
    return stress, strain, time


def main():
    runs = (
        (run_simulation(DISP_HISTORY, False), "prepend_zero=False", "-x"),
        (run_simulation(DISP_HISTORY, True), "prepend_zero=True", "--o"),
    )

    fig, (ax_t, ax_ss) = plt.subplots(2, 1, figsize=(5.5, 6.0))
    for (s, e, t), lab, sty in runs:
        en = e / EPS_Y
        ax_t.plot(t, en, sty, label=lab, lw=1.2, markersize=4)
        ax_ss.plot(en, s / FY, sty, label=lab, lw=1.2, markersize=4)

    ax_t.set_ylabel(r"$\varepsilon / \varepsilon_y$")
    ax_t.set_xlabel("pseudo-time")
    ax_t.axhline(0.0, color="0.8", lw=0.8)
    ax_t.grid(True, alpha=0.35)

    ax_ss.set_xlabel(r"$\varepsilon / \varepsilon_y$")
    ax_ss.set_ylabel(r"$\sigma / f_y$")
    ax_ss.axhline(0.0, color="0.8", lw=0.8)
    ax_ss.axvline(0.0, color="0.8", lw=0.8)
    ax_ss.grid(True, alpha=0.35)
    ax_ss.legend(loc="best", fontsize=8)

    fig.tight_layout()
    fig.savefig("demo_prepend_zero_bug.png", dpi=150)
    plt.close(fig)
    print("Wrote demo_prepend_zero_bug.png")


if __name__ == "__main__":
    main()
```