### PR TITLE
UMFPACK: 64-bit index support

### DIFF
--- a/OTHER/UMFPACK/CMakeLists.txt
+++ b/OTHER/UMFPACK/CMakeLists.txt
@@ -55,6 +55,22 @@ add_umflib(umf_store_lu_drop      umf_store_lu.c   DROP)
 add_umflib(umfpack_solve          umfpack_solve.c)
 add_umflib(umfpack_di_wsolve      umfpack_solve.c  WSOLVE)
 
+# DLONG variants (SuiteSparse_long indices, umfpack_dl_* entry points)
+add_umflib(umf_triplet_nomap_nox_dl  umf_triplet.c DLONG)
+add_umflib(umf_triplet_map_x_dl      umf_triplet.c    DO_MAP  DO_VALUES DLONG)
+add_umflib(umf_triplet_map_nox_dl    umf_triplet.c    DO_MAP DLONG)
+add_umflib(umf_triplet_nomap_x_dl    umf_triplet.c            DO_VALUES DLONG)
+add_umflib(umf_ltsolve_dl            umf_ltsolve.c DLONG)
+add_umflib(umf_lhsolve_dl            umf_ltsolve.c    CONJUGATE_SOLVE DLONG)
+add_umflib(umf_utsolve_dl            umf_utsolve.c DLONG)
+add_umflib(umf_uhsolve_dl            umf_utsolve.c    CONJUGATE_SOLVE DLONG)
+add_umflib(umf_assemble_dl           umf_assemble.c DLONG)
+add_umflib(umf_assemble_dl_fixq      umf_assemble.c   FIXQ DLONG)
+add_umflib(umf_store_lu_dl          umf_store_lu.c DLONG)
+add_umflib(umf_store_lu_drop_dl     umf_store_lu.c   DROP DLONG)
+add_umflib(umfpack_solve_dl         umfpack_solve.c DLONG)
+add_umflib(umfpack_dl_wsolve        umfpack_solve.c  WSOLVE DLONG)
+
 #----------------------------------------------------------
 # source files
 #----------------------------------------------------------
@@ -162,9 +178,15 @@ add_library(UMF OBJECT ${UMFCH})
 add_library(UMFPACK_GN OBJECT ${GENERIC})
 add_library(UMFPACK_II OBJECT ${UMFINT})
 add_library(UMFPACK_DI OBJECT ${UMF} ${UMFPACK_USER})
+add_library(UMF_DL OBJECT ${UMFCH})
+add_library(UMFPACK_II_DL OBJECT ${UMFINT})
+add_library(UMFPACK_DL OBJECT ${UMFPACK_USER})
 target_compile_definitions(UMF         PRIVATE DINT)
 target_compile_definitions(UMFPACK_II  PRIVATE DINT)
 target_compile_definitions(UMFPACK_DI  PRIVATE DINT)
+target_compile_definitions(UMF_DL      PRIVATE DLONG)
+target_compile_definitions(UMFPACK_II_DL PRIVATE DLONG)
+target_compile_definitions(UMFPACK_DL  PRIVATE DLONG)
 
 #----------------------------------------------------------------------
 # Create the libumfpack.a library
@@ -174,9 +196,12 @@ add_library(UMFPACK #INTERFACE)
 #target_sources(umfpack
   #"-Wl,--whole-archive"
   $<TARGET_OBJECTS:UMFPACK_DI>
+  $<TARGET_OBJECTS:UMFPACK_DL>
   $<TARGET_OBJECTS:UMFPACK_II>
+  $<TARGET_OBJECTS:UMFPACK_II_DL>
   $<TARGET_OBJECTS:UMFPACK_GN>
   $<TARGET_OBJECTS:UMF>
+  $<TARGET_OBJECTS:UMF_DL>
   #${UMF_CREATED}
   #"-Wl,--no-whole-archive"
   #${AMD_LIBRARIES}

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
@@ -26,7 +26,7 @@
 // Written: fmk 
 // Created: 11/98
 //
-// Description: This file contains the class definition for 
+// Description: This file contains the class definition for
 // UmfpackGenLinSolver. It solves the UmfpackGenLinSOEobject by calling
 // UMFPACK5.7.1 routines.
 //
@@ -35,26 +35,67 @@
 #include <UmfpackGenLinSOE.h>
 #include <UmfpackGenLinSolver.h>
 #include <math.h>
+#include <cstring>
 #include <Channel.h>
 #include <FEM_ObjectBroker.h>
+#include <elementAPI.h>
 
 void* OPS_UmfpackGenLinSolver()
 {
-    UmfpackGenLinSolver *theSolver = new UmfpackGenLinSolver();
-    return new UmfpackGenLinSOE(*theSolver);  
+    bool useLongIndices = false;
+    if (OPS_GetNumRemainingInputArgs() > 0) {
+        const char *opt = OPS_GetString();
+        if (opt == nullptr) {
+            opt = "";
+        }
+        if (strcmp(opt, "useLongIndices") == 0 ||
+            strcmp(opt, "-useLongIndices") == 0) {
+            useLongIndices = true;
+        } else {
+            opserr << "WARNING UmfpackGenLinSolver: unknown option \"" << opt
+                   << "\" (expected useLongIndices or -useLongIndices)\n";
+            return nullptr;
+        }
+    }
+
+    UmfpackGenLinSolver *theSolver = new UmfpackGenLinSolver(useLongIndices);
+    return new UmfpackGenLinSOE(*theSolver);
 }
 
 UmfpackGenLinSolver::
-UmfpackGenLinSolver()
-    :LinearSOESolver(SOLVER_TAGS_UmfpackGenLinSolver), Symbolic(0), theSOE(0)
+UmfpackGenLinSolver(bool useLongIndices)
+    : LinearSOESolver(SOLVER_TAGS_UmfpackGenLinSolver),
+      useLongIndices(useLongIndices),
+      Symbolic(0),
+      theSOE(0)
 {
 }
-
 
 UmfpackGenLinSolver::~UmfpackGenLinSolver()
 {
     if (Symbolic != 0) {
-	umfpack_di_free_symbolic(&Symbolic);
+        if (useLongIndices) {
+            umfpack_dl_free_symbolic(&Symbolic);
+        } else {
+            umfpack_di_free_symbolic(&Symbolic);
+        }
+    }
+}
+
+void
+UmfpackGenLinSolver::syncIndexBuffers(void)
+{
+    if (!useLongIndices) return;
+
+    const int n = theSOE->X.Size();
+    const std::size_t nnz = theSOE->Ai.size();
+    Ap64.resize(static_cast<std::size_t>(n) + 1u);
+    Ai64.resize(nnz);
+    for (std::size_t i = 0; i < Ap64.size(); ++i) {
+        Ap64[i] = static_cast<SuiteSparse_long>(theSOE->Ap[i]);
+    }
+    for (std::size_t k = 0; k < nnz; ++k) {
+        Ai64[k] = static_cast<SuiteSparse_long>(theSOE->Ai[k]);
     }
 }
 
@@ -64,75 +105,147 @@ UmfpackGenLinSolver::solve(void)
     int n = theSOE->X.Size();
     int nnz = (int)theSOE->Ai.size();
     if (n == 0 || nnz==0) return 0;
-    
-    int* Ap = &(theSOE->Ap[0]);
-    int* Ai = &(theSOE->Ai[0]);
+
     double* Ax = &(theSOE->Ax[0]);
     double* X = &(theSOE->X(0));
     double* B = &(theSOE->B(0));
 
     // check if symbolic is done
     if (Symbolic == 0) {
-	opserr<<"WARNING: setSize has not been called -- Umfpackgenlinsolver::solve\n";
-	return -1;
+        opserr<<"WARNING: setSize has not been called -- Umfpackgenlinsolver::solve\n";
+        return -1;
     }
-    
-    // numerical analysis
+
     void* Numeric = 0;
-    int status = umfpack_di_numeric(Ap,Ai,Ax,Symbolic,&Numeric,Control,Info);
 
-    // check error
-    if (status!=UMFPACK_OK) {
-	opserr<<"WARNING: numeric analysis returns "<<status<<" -- Umfpackgenlinsolver::solve\n";
-	return -1;
-    }
+    if (useLongIndices) {
+        // numeric analysis
+        SuiteSparse_long *Ap = Ap64.data();
+        SuiteSparse_long *Ai = Ai64.data();
+        SuiteSparse_long status =
+            umfpack_dl_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
+        
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: numeric analysis returns " << status
+                   << " -- Umfpackgenlinsolver::solve\n";
+            return -1;
+        }
 
-    // solve
-    status = umfpack_di_solve(UMFPACK_A,Ap,Ai,Ax,X,B,Numeric,Control,Info);
+        // solve
+        status = umfpack_dl_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control,
+                                  Info);
+        
+        // delete Numeric
+        if (Numeric != 0) {
+            umfpack_dl_free_numeric(&Numeric);
+        }
 
-    // delete Numeric
-    if (Numeric != 0) {
-	umfpack_di_free_numeric(&Numeric);
-    }
-    
-    // check error
-    if (status!=UMFPACK_OK) {
-	opserr<<"WARNING: solving returns "<<status<<" -- Umfpackgenlinsolver::solve\n";
-	return -1;
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: solving returns " << status
+                   << " -- Umfpackgenlinsolver::solve\n";
+            return -1;
+        }
+    } else {
+        // numeric analysis
+        int *Ap = &(theSOE->Ap[0]);
+        int *Ai = &(theSOE->Ai[0]);
+        int status =
+            umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
+        
+        
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: numeric analysis returns " << status
+                   << " -- Umfpackgenlinsolver::solve\n";
+            return -1;
+        }
+
+        // solve
+        status = umfpack_di_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control,
+                                  Info);
+
+        // delete Numeric
+        if (Numeric != 0) {
+            umfpack_di_free_numeric(&Numeric);
+        }
+        
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: solving returns " << status
+                   << " -- Umfpackgenlinsolver::solve\n";
+            return -1;
+        }
     }
 
     return 0;
 }
 
-
 int
 UmfpackGenLinSolver::setSize()
 {
-    // set default control parameters
-    umfpack_di_defaults(Control);
-    Control[UMFPACK_PIVOT_TOLERANCE] = 1.0;
-    Control[UMFPACK_STRATEGY] = UMFPACK_STRATEGY_SYMMETRIC;
-
     int n = theSOE->X.Size();
     int nnz = (int)theSOE->Ai.size();
-    if (n == 0 || nnz==0) return 0;
-    
-    int* Ap = &(theSOE->Ap[0]);
-    int* Ai = &(theSOE->Ai[0]);
-    double* Ax = &(theSOE->Ax[0]);
-
-    // symbolic analysis
-    if (Symbolic != 0) {
-	umfpack_di_free_symbolic(&Symbolic);
+    if (n == 0 || nnz == 0) {
+        Ap64.clear();
+        Ai64.clear();
+        return 0;
     }
-    int status = umfpack_di_symbolic(n,n,Ap,Ai,Ax,&Symbolic,Control,Info);
 
-    // check error
-    if (status!=UMFPACK_OK) {
-	opserr<<"WARNING: symbolic analysis returns "<<status<<" -- Umfpackgenlinsolver::setsize\n";
-	Symbolic = 0;
-	return -1;
+    if (useLongIndices) {
+        // set default control parameters
+        umfpack_dl_defaults(Control);
+        Control[UMFPACK_PIVOT_TOLERANCE] = 1.0;
+        Control[UMFPACK_STRATEGY] = UMFPACK_STRATEGY_SYMMETRIC;
+
+        syncIndexBuffers();
+        SuiteSparse_long *Ap = Ap64.data();
+        SuiteSparse_long *Ai = Ai64.data();
+        double *Ax = theSOE->Ax.data();
+
+        // symbolic analysis
+        if (Symbolic != 0) {
+            umfpack_dl_free_symbolic(&Symbolic);
+        }
+        SuiteSparse_long status = umfpack_dl_symbolic(
+            (SuiteSparse_long)n, (SuiteSparse_long)n, Ap, Ai, Ax, &Symbolic,
+            Control, Info);
+
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: symbolic analysis returns " << status
+                   << " -- Umfpackgenlinsolver::setsize\n";
+            Symbolic = 0;
+            return -1;
+        }
+    } else {
+        // set default control parameters
+        umfpack_di_defaults(Control);
+        Control[UMFPACK_PIVOT_TOLERANCE] = 1.0;
+        Control[UMFPACK_STRATEGY] = UMFPACK_STRATEGY_SYMMETRIC;
+
+        int *Ap = theSOE->Ap.data();
+        int *Ai = theSOE->Ai.data();
+        double *Ax = theSOE->Ax.data();
+
+        // symbolic analysis
+        if (Symbolic != 0) {
+            umfpack_di_free_symbolic(&Symbolic);
+        }
+        int status =
+            umfpack_di_symbolic(n, n, Ap, Ai, Ax, &Symbolic, Control, Info);
+        
+        
+        // check error
+        if (status != UMFPACK_OK) {
+            opserr << "WARNING: symbolic analysis returns " << status
+                   << " -- Umfpackgenlinsolver::setsize\n";
+            Symbolic = 0;
+            return -1;
+        }
     }
+
     return 0;
 }
 
@@ -151,11 +264,10 @@ UmfpackGenLinSolver::sendSelf(int cTag, Channel &theChannel)
 }
 
 int
-UmfpackGenLinSolver::recvSelf(int ctag,
-			      Channel &theChannel, 
-			      FEM_ObjectBroker &theBroker)
+UmfpackGenLinSolver::recvSelf(int ctag, 
+                              Channel &theChannel,
+                              FEM_ObjectBroker &theBroker)
 {
     // nothing to do
     return 0;
 }
-

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
@@ -106,7 +106,7 @@ UmfpackGenLinSolver::solve(void)
     int nnz = (int)theSOE->Ai.size();
     if (n == 0 || nnz==0) return 0;
 
-    double* Ax = &(theSOE->Ax[0]);
+    double* Ax = theSOE->Ax.data();
     double* X = &(theSOE->X(0));
     double* B = &(theSOE->B(0));
 
@@ -127,7 +127,8 @@ UmfpackGenLinSolver::solve(void)
         
         // check error
         if (status != UMFPACK_OK) {
-            opserr << "WARNING: numeric analysis returns " << status
+            opserr << "WARNING: numeric analysis returns "
+                   << static_cast<int>(status)
                    << " -- Umfpackgenlinsolver::solve\n";
             return -1;
         }
@@ -143,14 +144,14 @@ UmfpackGenLinSolver::solve(void)
 
         // check error
         if (status != UMFPACK_OK) {
-            opserr << "WARNING: solving returns " << status
+            opserr << "WARNING: solving returns " << static_cast<int>(status)
                    << " -- Umfpackgenlinsolver::solve\n";
             return -1;
         }
     } else {
         // numeric analysis
-        int *Ap = &(theSOE->Ap[0]);
-        int *Ai = &(theSOE->Ai[0]);
+        int *Ap = theSOE->Ap.data();
+        int *Ai = theSOE->Ai.data();
         int status =
             umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
         
@@ -214,7 +215,8 @@ UmfpackGenLinSolver::setSize()
 
         // check error
         if (status != UMFPACK_OK) {
-            opserr << "WARNING: symbolic analysis returns " << status
+            opserr << "WARNING: symbolic analysis returns "
+                   << static_cast<int>(status)
                    << " -- Umfpackgenlinsolver::setsize\n";
             Symbolic = 0;
             return -1;

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.h
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.h
@@ -36,6 +36,7 @@
 #define UmfpackGenLinSolver_h
 
 #include <LinearSOESolver.h>
+#include <vector>
 #include "../../../../OTHER/UMFPACK/umfpack.h"
 
 class UmfpackGenLinSOE;
@@ -43,7 +44,7 @@ class UmfpackGenLinSOE;
 class UmfpackGenLinSolver : public LinearSOESolver
 {
   public:
-    UmfpackGenLinSolver();     
+    UmfpackGenLinSolver(bool useLongIndices = false);
     ~UmfpackGenLinSolver();
 
     int solve(void);
@@ -52,16 +53,20 @@ class UmfpackGenLinSolver : public LinearSOESolver
     int setLinearSOE(UmfpackGenLinSOE &theSOE);
     
     int sendSelf(int commitTag, Channel &theChannel);
-    int recvSelf(int commitTag, Channel &theChannel, 
-		 FEM_ObjectBroker &theBroker);    
-    
+    int recvSelf(int commitTag, Channel &theChannel,
+                 FEM_ObjectBroker &theBroker);
+
   protected:
 
   private:
+    void syncIndexBuffers(void);
+
+    bool useLongIndices;
     void *Symbolic;
     double Control[UMFPACK_CONTROL], Info[UMFPACK_INFO];
     UmfpackGenLinSOE *theSOE;
+    std::vector<SuiteSparse_long> Ap64;
+    std::vector<SuiteSparse_long> Ai64;
 };
 
 #endif
-


### PR DESCRIPTION
# UMFPACK: 64-bit index support

Adds support for UMFPACK’s 64-bit indices (`SuiteSparse_long`, `umfpack_dl_*`).  
For large systems, factorization can fail when 32-bit indices overflow. See a related user report: https://www.facebook.com/share/p/1CaJdUUJcw/.

The default remains 32-bit. Users can explicitly enable 64-bit via:
```python
ops.system("UmfPack", "-useLongIndices")
````

I primarily build with CMake, so Makefiles and Visual Studio project files were not updated.
Any help updating those would be appreciated.

As a follow-up, upgrading UMFPACK/AMD to 6.3.x would be beneficial. I was able to do this locally, but could not get it working with GitHub Actions.
