### PR TITLE
Solve trivial update

### DIFF
--- a/SRC/system_of_eqn/linearSOE/bandGEN/BandGenLinLapackSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/bandGEN/BandGenLinLapackSolver.cpp
@@ -89,7 +89,11 @@ BandGenLinLapackSolver::solve(void)
 	return -1;
     }
 
-    int n = theSOE->size;    
+    int n = theSOE->size;
+
+    if (n == 0)
+	return 0;
+
     // check iPiv is large enough
     if (iPivSize < n) {
 	opserr << "WARNING BandGenLinLapackSolver::solve(void)- ";
@@ -157,6 +161,9 @@ BandGenLinLapackSolver::solve(void)
 int
 BandGenLinLapackSolver::setSize()
 {
+    if (theSOE->size == 0)
+	return 0;
+
     // if iPiv not big enough, free it and get one large enough
     if (iPivSize < theSOE->size) {
 	if (iPiv != 0)

--- a/SRC/system_of_eqn/linearSOE/bandSPD/BandSPDLinLapackSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/bandSPD/BandSPDLinLapackSolver.cpp
@@ -91,6 +91,18 @@ BandSPDLinLapackSolver::solve(void)
     if (n == 0)
 	return 0;
 
+    if (n == 1) {
+	// ignoring positive definiteness check for n = 1
+	double a = theSOE->A[0];
+	if (fabs(a) < 1.0e-15) {
+	    opserr << "WARNING BandSPDLinLapackSolver::solve() - singular 1x1 system\n";
+	    return -1;
+	}
+	theSOE->X[0] = theSOE->B[0] / a;
+	theSOE->factored = true;
+	return 0;
+    }
+
     int kd = theSOE->half_band -1;
     int ldA = kd +1;
     int nrhs = 1;

--- a/SRC/system_of_eqn/linearSOE/bandSPD/BandSPDLinLapackSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/bandSPD/BandSPDLinLapackSolver.cpp
@@ -87,6 +87,10 @@ BandSPDLinLapackSolver::solve(void)
     }
 
     int n = theSOE->size;
+
+    if (n == 0)
+	return 0;
+
     int kd = theSOE->half_band -1;
     int ldA = kd +1;
     int nrhs = 1;

--- a/SRC/system_of_eqn/linearSOE/diagonal/DistributedDiagonalSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/diagonal/DistributedDiagonalSolver.cpp
@@ -30,6 +30,7 @@
 #include <DistributedDiagonalSolver.h>
 #include <DistributedDiagonalSOE.h>
 #include <Channel.h>
+#include <OPS_Globals.h>
 
 DistributedDiagonalSolver::DistributedDiagonalSolver(int classTag)
 :LinearSOESolver(classTag),
@@ -68,7 +69,15 @@ DistributedDiagonalSolver::setSize(void)
 int 
 DistributedDiagonalSolver::solve(void)
 {
+  if (theSOE == 0) {
+    opserr << "WARNING DistributedDiagonalSolver::solve(void)- no SOE set\n";
+    return -1;
+  }
+
   int size = theSOE->size;
+  if (size == 0)
+    return 0;
+
   int processID = theSOE->processID;
 
   Channel **theChannels = theSOE->theChannels;

--- a/SRC/system_of_eqn/linearSOE/itpack/ItpackLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/itpack/ItpackLinSolver.cpp
@@ -124,8 +124,35 @@ ItpackLinSolver::setLinearSOE(ItpackLinSOE &theItpackSOE)
 int
 ItpackLinSolver::setSize(void)
 {
+  if (theSOE == 0) {
+    opserr << "WARNING ItpackLinSolver::setSize(void)- no LinearSOE set\n";
+    return -1;
+  }
+
   // Get number of equations from SOE
   n = theSOE->size;
+
+  if (n <= 0) {
+    n = 0;
+    if (iwksp != 0) {
+      delete [] iwksp;
+      iwksp = 0;
+    }
+    if (wksp != 0) {
+      delete [] wksp;
+      wksp = 0;
+    }
+    if (IA != 0) {
+      delete [] IA;
+      IA = 0;
+    }
+    if (JA != 0) {
+      delete [] JA;
+      JA = 0;
+    }
+    nwksp = 0;
+    return 0;
+  }
 
   if (n > 0) {
     if (iwksp != 0)
@@ -311,6 +338,13 @@ extern "C" int rssi_(int *n, int *ia, int *ja, double *a, double *rhs,
 int
 ItpackLinSolver::solve(void)
 {
+  if (theSOE == 0) {
+    opserr << "WARNING ItpackLinSolver::solve(void)- no LinearSOE set\n";
+    return -1;
+  }
+  if (n == 0)
+    return 0;
+
   // Let ITPACK fill in default parameter values
   dfault_(iparm, rparm);
 

--- a/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectBlockSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectBlockSolver.cpp
@@ -136,6 +136,20 @@ ProfileSPDLinDirectBlockSolver::solve(void)
     // copy B into X
     for (int ii=0; ii<n; ii++)
 	X[ii] = B[ii];
+
+    if (n == 1) {
+	// ignoring positive definiteness check for n = 1
+	double a = theSOE->A[0];
+	if (fabs(a) < 1.0e-15) {
+	    opserr << "ProfileSPDLinDirectBlockSolver::solve() - singular 1x1 (|aii| < 1e-15)\n";
+	    return -2;
+	}
+	X[0] = B[0] / a;
+	invD[0] = 1.0 / a;
+	theSOE->isAfactored = true;
+	theSOE->numInt = 0;
+	return 0;
+    }
     
     if (theSOE->isAfactored == false)  {
 

--- a/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectSkypackSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectSkypackSolver.cpp
@@ -163,6 +163,20 @@ ProfileSPDLinDirectSkypackSolver::solve(void)
     for (int ii=0; ii<theSize; ii++)
 	X[ii] = B[ii];
 
+    if (theSize == 1) {
+	// ignoring positive definiteness check for n = 1
+	double a = theSOE->A[0];
+	if (fabs(a) < 1.0e-15) {
+	    opserr << "ProfileSPDLinDirectSkypackSolver::solve() - singular 1x1 (|aii| < 1e-15)\n";
+	    return -2;
+	}
+	X[0] = B[0] / a;
+	invD[0] = 1.0 / a;
+	theSOE->isAfactored = true;
+	theSOE->numInt = 0;
+	return 0;
+    }
+
     char *FILE = "INCORE";
     
     if (theSOE->isAfactored == false)  {

--- a/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectSolver.cpp
@@ -143,6 +143,20 @@ ProfileSPDLinDirectSolver::solve(void)
     for (int ii=0; ii<theSize; ii++)
 	X[ii] = B[ii];
 
+    if (theSize == 1) {
+	// ignoring positive definiteness check for n = 1
+	double a = theSOE->A[0];
+	if (fabs(a) < 1.0e-15) {
+	    opserr << "ProfileSPDLinDirectSolver::solve() - singular 1x1 (|aii| < 1e-15)\n";
+	    return -2;
+	}
+	X[0] = B[0] / a;
+	invD[0] = 1.0 / a;
+	theSOE->isAfactored = true;
+	theSOE->numInt = 0;
+	return 0;
+    }
+
     /*
       for (int iii=0; iii<theSize; iii++) {
       int rowiiitop = RowTop[iii];

--- a/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectThreadSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/ProfileSPDLinDirectThreadSolver.cpp
@@ -187,6 +187,20 @@ ProfileSPDLinDirectThreadSolver::solve(void)
     // copy B into X
     for (int ii=0; ii<size; ii++)
 	X[ii] = B[ii];
+
+    if (size == 1) {
+	// ignoring positive definiteness check for n = 1
+	double a = A[0];
+	if (fabs(a) < 1.0e-15) {
+	    opserr << "ProfileSPDLinDirectThreadSolver::solve() - singular 1x1 (|aii| < 1e-15)\n";
+	    return -2;
+	}
+	X[0] = B[0] / a;
+	invD[0] = 1.0 / a;
+	theSOE->isAfactored = true;
+	theSOE->numInt = 0;
+	return 0;
+    }
     
     if (theSOE->isAfactored == false)  {
       // start threads running

--- a/SRC/system_of_eqn/linearSOE/profileSPD/SProfileSPDLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/SProfileSPDLinSolver.cpp
@@ -138,6 +138,21 @@ SProfileSPDLinSolver::solve(void)
 	doubleB[ii] = B[ii];
     }
 
+    if (theSize == 1) {
+	// ignoring positive definiteness check for n = 1
+	float a = theSOE->A[0];
+	if (fabs((double)a) < 1.0e-15) {
+	    opserr << "SProfileSPDLinSolver::solve() - singular 1x1 (|aii| < 1e-15)\n";
+	    return -2;
+	}
+	X[0] = B[0] / a;
+	doubleX[0] = (double)X[0];
+	invD[0] = 1.0f / a;
+	theSOE->isAfactored = true;
+	theSOE->numInt = 0;
+	return 0;
+    }
+
     /*
       for (int iii=0; iii<theSize; iii++) {
       int rowiiitop = RowTop[iii];


### PR DESCRIPTION
# Support trivial solves (0x0 and 1x1 systems)

Ensures common solvers handle trivial cases.

- Treat `n = 0` as a successful no-op.
- Solve `1x1` systems directly (`x = b/a`), bypassing factorization and SPD checks. This is especially helpful for beginners running SDF systems with softening, where the default SPD solver may fail due to negative stiffness even though the solution is trivial.