### PR TITLE
Add setTrialStrain and commitState for openseespy

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -202,6 +202,8 @@ private:
 int OPS_UniaxialMaterial();
 int OPS_testUniaxialMaterial();
 int OPS_setStrain();
+int OPS_setTrialStrain();
+int OPS_commitState();
 int OPS_getStrain();
 int OPS_getStress();
 int OPS_getTangent();

--- a/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesUniaxialMaterialCommands.cpp
@@ -850,6 +850,51 @@ int OPS_setStrain() {
   return 0;
 }
 
+int OPS_setTrialStrain() {
+    if (OPS_GetNumRemainingInputArgs() < 1) {
+        opserr << "testUniaxialMaterial - You must provide a strain "
+            "value.\n";
+        return -1;
+    }
+
+    UniaxialMaterial* material = theTestingUniaxialMaterial;
+
+    if (material == 0) {
+        opserr << "setStrain WARNING no active UniaxialMaterial - "
+            "use testUniaxialMaterial command.\n";
+        return -1;
+    }
+
+    double strain;
+    int numData = 1;
+    if (OPS_GetDoubleInput(&numData, &strain) < 0) {
+        opserr << "invalid double value\n";
+        return -1;
+    }
+
+    double strainRate = 0.0;
+    if (OPS_GetNumRemainingInputArgs() > 0) {
+        if (OPS_GetDoubleInput(&numData, &strainRate) < 0) {
+            opserr << "invalid strain rate\n";
+            return -1;
+        }
+    }
+
+    material->setTrialStrain(strain, strainRate);
+    return 0;
+}
+
+int OPS_commitState() {
+    UniaxialMaterial* material = theTestingUniaxialMaterial;
+
+    if (material == 0) {
+        opserr << "setStrain WARNING no active UniaxialMaterial - "
+            "use testUniaxialMaterial command.\n";
+        return -1;
+    }
+    material->commitState();
+}
+
 int OPS_getStrain() {
   UniaxialMaterial* material = theTestingUniaxialMaterial;
   if (material == 0) {

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -333,6 +333,30 @@ static PyObject *Py_ops_setStrain(PyObject *self, PyObject *args)
     return wrapper->getResults();
 }
 
+static PyObject* Py_ops_setTrialStrain(PyObject* self, PyObject* args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_setTrialStrain() < 0) {
+        opserr << (void*)0;
+        return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
+static PyObject* Py_ops_commitState(PyObject* self, PyObject* args)
+{
+    wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
+
+    if (OPS_commitState() < 0) {
+        opserr << (void*)0;
+        return NULL;
+    }
+
+    return wrapper->getResults();
+}
+
 static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 {
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
@@ -3063,6 +3087,8 @@ PythonWrapper::addOpenSeesCommands()
     addCommand("uniaxialMaterial", &Py_ops_UniaxialMaterial);
     addCommand("testUniaxialMaterial", &Py_ops_testUniaxialMaterial);
     addCommand("setStrain", &Py_ops_setStrain);
+    addCommand("setTrialStrain", &Py_ops_setTrialStrain);
+    addCommand("commitState", &Py_ops_commitState);
     addCommand("getStrain", &Py_ops_getStrain);
     addCommand("getStress", &Py_ops_getStress);
     addCommand("getTangent", &Py_ops_getTangent);


### PR DESCRIPTION
The uniaxial material testing workflow is less flexible in OpenSeesPy compared to the Tcl version. Specifically, while the Tcl version allows users to explicitly call `setTrialStrain` and `commitState` separately, OpenSeesPy only exposes a combined interface (`setStrain`), which internally performs both trial and commit operations. This PR introduces these two new functions to OpenSeesPy.

Previously in OpenSeesPy:
```python
ops.setStrain(eps)  # trial + commit combined
```

With this PR:
```python
ops.setTrialStrain(eps)   # apply trial strain
# inspect stress, tangent, etc.
ops.commitState()  # commit when appropriate
```
This provides finer control over the material state evolution.