### PR TITLE
Fix memory leak with fiber section

### DIFF
--- a/SRC/material/section/TclModelBuilderSectionCommand.cpp
+++ b/SRC/material/section/TclModelBuilderSectionCommand.cpp
@@ -1811,9 +1811,10 @@ buildSection(Tcl_Interp *interp, TclModelBuilder *theTclModelBuilder,
 
 	 //SectionForceDeformation *section = new FiberSection(secTag, numFibers, fiber);
    
-	 // Delete fibers created for patches and layers
-	 for (i = numSectionRepresFibers; i < numFibers; i++)
-	   delete fiber[i];
+   // Delete temporary fibers created from patches/layers. Fibers added
+   // explicitly via the `fiber` command are owned by FiberSectionRepr.
+   for (i = numSectionRepresFibers; i < numFibers; i++)
+     delete fiber[i];
 
          if (section == 0)
          {
@@ -1869,9 +1870,10 @@ buildSection(Tcl_Interp *interp, TclModelBuilder *theTclModelBuilder,
 	 else
 	   section = new FiberSection3d(secTag, numFibers, fiber, theTorsion, currentSectionComputeCentroid);
    
-	 // Delete fibers
-	 for (i = numSectionRepresFibers; i < numFibers; i++)
-	   delete fiber[i];
+   // Delete temporary fibers created from patches/layers. Fibers added
+   // explicitly via the `fiber` command are owned by FiberSectionRepr.
+   for (i = numSectionRepresFibers; i < numFibers; i++)
+     delete fiber[i];
 
          if (section == 0)
          {
@@ -2070,11 +2072,11 @@ buildSectionInt(Tcl_Interp *interp, TclModelBuilder *theTclModelBuilder,
 
 	 SectionForceDeformation *section = new FiberSection2dInt(secTag, numFibers, fiber, numHFibers, Hfiber, NStrip1, t1, NStrip2, t2, NStrip3, t3);
 
-	 // Delete fibers
-	 for (i = 0; i < numFibers; i++)
+	 // Delete temporary fibers created from patches/layers only.
+	 for (i = numSectionRepresFibers; i < numFibers; i++)
 	   delete fiber[i];
 
-	 for (i = 0; i < numHFibers; i++)
+	 for (i = numSectionRepresHFibers; i < numHFibers; i++)
 	   delete Hfiber[i];
 
          if (section == 0)
@@ -2120,8 +2122,8 @@ buildSectionInt(Tcl_Interp *interp, TclModelBuilder *theTclModelBuilder,
 	 SectionForceDeformation *section = 0;
 	 section = new FiberSection3d(secTag, numFibers, fiber, theTorsion, currentSectionComputeCentroid);
    
-	 // Delete fibers
-	 for (i = 0; i < numFibers; i++)
+	 // Delete temporary fibers created from patches/layers only.
+	 for (i = numSectionRepresFibers; i < numFibers; i++)
 	   delete fiber[i];
 
          if (section == 0)

--- a/SRC/material/section/repres/section/FiberSectionRepr.cpp
+++ b/SRC/material/section/repres/section/FiberSectionRepr.cpp
@@ -155,12 +155,21 @@ FiberSectionRepr::~FiberSectionRepr(void)
       delete [] reinfLayer;
    } 
    
-   if (theFibers != 0)
-       delete [] theFibers;  // NOTE: don't delete fiber objects themselves
-                             //       leave this to FiberSection destructor
+   if (theFibers != 0) {
+      for (i = 0; i < numFibers; i++)
+         if (theFibers[i])
+            delete theFibers[i];
 
-      if (theHFibers != 0)
-       delete [] theHFibers;  // NOTE: don't delete fiber objects themselves
+      delete [] theFibers;
+   }
+
+   if (theHFibers != 0) {
+      for (i = 0; i < numHFibers; i++)
+         if (theHFibers[i])
+            delete theHFibers[i];
+
+      delete [] theHFibers;
+   }
 
 }
         


### PR DESCRIPTION
The fibers defined explicitly were being leaked.
Fibers created from patches and layers were fine.

e.g.,
```tcl
wipe

model Basic -ndm 3 -ndf 6

uniaxialMaterial Concrete04 3 30000000 0.002 0.003 25742960202.74281
uniaxialMaterial Elastic 8 195775212.34185904 0

section Fiber 2 -torsion 8 -noCentroid {
    fiber -0.2735697428058517 0.27356946908712976 0.0030012031999142453 3
    fiber -0.20920587973824514 0.2705671430928951 0.0034989745241276126 3
    fiber -0.15 0.27 0.0036 3
    fiber -0.09000000000000001 0.27 0.0036 3
    fiber -0.029999999999999995 0.27 0.0036 3
    fiber 0.029999999999999995 0.27 0.0036 3
    fiber 0.09000000000000001 0.27 0.0036 3
    fiber 0.15 0.27 0.0036 3
}
```

@mhscott I think this is the best place for them to be deleted, but I could be wrong.