### PR TITLE
Fix null deref in TwoNodeLink

### DIFF
--- a/SRC/element/twoNodeLink/LinearElasticSpring.cpp
+++ b/SRC/element/twoNodeLink/LinearElasticSpring.cpp
@@ -972,7 +972,7 @@ Response* LinearElasticSpring::setResponse(const char **argv, int argc,
 int LinearElasticSpring::getResponse(int responseID, Information &eleInfo)
 {
     Vector defoAndForce(numDIR*2);
-    Vector &theVec = *(eleInfo.theVector);
+    Vector *theVec = eleInfo.theVector;
     
     switch (responseID)  {
     case 1:  // global forces
@@ -1005,19 +1005,19 @@ int LinearElasticSpring::getResponse(int responseID, Information &eleInfo)
         return eleInfo.setVector(defoAndForce);
 
     case 20:
-      theVec(0) = trans(0,0);
-      theVec(1) = trans(0,1);
-      theVec(2) = trans(0,2);
+      (*theVec)(0) = trans(0,0);
+      (*theVec)(1) = trans(0,1);
+      (*theVec)(2) = trans(0,2);
       return 0;
     case 21:
-      theVec(0) = trans(1,0);
-      theVec(1) = trans(1,1);
-      theVec(2) = trans(1,2);
+      (*theVec)(0) = trans(1,0);
+      (*theVec)(1) = trans(1,1);
+      (*theVec)(2) = trans(1,2);
       return 0;
     case 22:
-      theVec(0) = trans(2,0);
-      theVec(1) = trans(2,1);
-      theVec(2) = trans(2,2);
+      (*theVec)(0) = trans(2,0);
+      (*theVec)(1) = trans(2,1);
+      (*theVec)(2) = trans(2,2);
       return 0;
       
     default:

--- a/SRC/element/twoNodeLink/TwoNodeLink.cpp
+++ b/SRC/element/twoNodeLink/TwoNodeLink.cpp
@@ -1289,8 +1289,8 @@ Response* TwoNodeLink::setResponse(const char **argv, int argc,
 int TwoNodeLink::getResponse(int responseID, Information &eleInfo)
 {
     Vector defoAndForce(numDIR*2);
-    Vector &theVec = *(eleInfo.theVector);
-    ID &theID = *(eleInfo.theID);    
+    Vector *theVec = eleInfo.theVector;
+    ID *theID = eleInfo.theID;
 	
     switch (responseID)  {
     case 1:  // global forces
@@ -1323,28 +1323,28 @@ int TwoNodeLink::getResponse(int responseID, Information &eleInfo)
         return eleInfo.setVector(defoAndForce);
 
     case 20:
-      theVec(0) = trans(0,0);
-      theVec(1) = trans(0,1);
-      theVec(2) = trans(0,2);
+      (*theVec)(0) = trans(0,0);
+      (*theVec)(1) = trans(0,1);
+      (*theVec)(2) = trans(0,2);
       return 0;
     case 21:
-      theVec(0) = trans(1,0);
-      theVec(1) = trans(1,1);
-      theVec(2) = trans(1,2);
+      (*theVec)(0) = trans(1,0);
+      (*theVec)(1) = trans(1,1);
+      (*theVec)(2) = trans(1,2);
       return 0;
     case 22:
-      theVec(0) = trans(2,0);
-      theVec(1) = trans(2,1);
-      theVec(2) = trans(2,2);
+      (*theVec)(0) = trans(2,0);
+      (*theVec)(1) = trans(2,1);
+      (*theVec)(2) = trans(2,2);
       return 0;
 
     case 23:
       for (int i = 0; i < numDIR; i++)
-	theID(i) = theMaterials[i]->getTag();
+	(*theID)(i) = theMaterials[i]->getTag();
       return 0;
     case 24:
       for (int i = 0; i < numDIR; i++)
-	theID(i) = (*dir)(i) + 1; // Add one to match user input
+	(*theID)(i) = (*dir)(i) + 1; // Add one to match user input
       return 0;
       
     default:

--- a/SRC/element/twoNodeLink/TwoNodeLinkSection.cpp
+++ b/SRC/element/twoNodeLink/TwoNodeLinkSection.cpp
@@ -1082,8 +1082,7 @@ int TwoNodeLinkSection::getResponse(int responseID, Information &eleInfo)
   int numDIR = theSection->getOrder();
   
     Vector defoAndForce(numDIR*2);
-    Vector &theVec = *(eleInfo.theVector);
-    ID &theID = *(eleInfo.theID);    
+    Vector *theVec = eleInfo.theVector;
     
     switch (responseID)  {
     case 1:  // global forces
@@ -1116,19 +1115,19 @@ int TwoNodeLinkSection::getResponse(int responseID, Information &eleInfo)
         return eleInfo.setVector(defoAndForce);
 
     case 20:
-      theVec(0) = trans(0,0);
-      theVec(1) = trans(0,1);
-      theVec(2) = trans(0,2);
+      (*theVec)(0) = trans(0,0);
+      (*theVec)(1) = trans(0,1);
+      (*theVec)(2) = trans(0,2);
       return 0;
     case 21:
-      theVec(0) = trans(1,0);
-      theVec(1) = trans(1,1);
-      theVec(2) = trans(1,2);
+      (*theVec)(0) = trans(1,0);
+      (*theVec)(1) = trans(1,1);
+      (*theVec)(2) = trans(1,2);
       return 0;
     case 22:
-      theVec(0) = trans(2,0);
-      theVec(1) = trans(2,1);
-      theVec(2) = trans(2,2);
+      (*theVec)(0) = trans(2,0);
+      (*theVec)(1) = trans(2,1);
+      (*theVec)(2) = trans(2,2);
       return 0;
 
     default:

--- a/SRC/element/zeroLength/ZeroLengthSection.cpp
+++ b/SRC/element/zeroLength/ZeroLengthSection.cpp
@@ -716,7 +716,7 @@ ZeroLengthSection::getResponse(int responseID, Information &eleInfo)
 {
     Vector q(order);
     Matrix kb(order,order);
-    Vector &theVec = *(eleInfo.theVector);
+    Vector *theVec = eleInfo.theVector;
     
     switch (responseID) {
     case 1:
@@ -736,19 +736,19 @@ ZeroLengthSection::getResponse(int responseID, Information &eleInfo)
       return eleInfo.setMatrix(kb);
 
     case 20:
-      theVec(0) = transformation(0,0);
-      theVec(1) = transformation(0,1);
-      theVec(2) = transformation(0,2);
+      (*theVec)(0) = transformation(0,0);
+      (*theVec)(1) = transformation(0,1);
+      (*theVec)(2) = transformation(0,2);
       return 0;
     case 21:
-      theVec(0) = transformation(1,0);
-      theVec(1) = transformation(1,1);
-      theVec(2) = transformation(1,2);
+      (*theVec)(0) = transformation(1,0);
+      (*theVec)(1) = transformation(1,1);
+      (*theVec)(2) = transformation(1,2);
       return 0;
     case 22:
-      theVec(0) = transformation(2,0);
-      theVec(1) = transformation(2,1);
-      theVec(2) = transformation(2,2);
+      (*theVec)(0) = transformation(2,0);
+      (*theVec)(1) = transformation(2,1);
+      (*theVec)(2) = transformation(2,2);
       return 0;
       
     default:


### PR DESCRIPTION
Depending on the response ID, theVector or theID may be null, so should only be dereferenced the response ID is checked.

Similar pattern was applied to a few other files to be safe, but for all current response IDs theVector happens to be non-null

Picked up when run with undefined behavior sanitizer

