### PR TITLE
Newton solvers: add -factorOnce and consolidate Tcl/OPS parsers

### DIFF
--- a/SRC/analysis/algorithm/equiSolnAlgo/AcceleratedNewton.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/AcceleratedNewton.cpp
@@ -46,12 +46,236 @@
 #include <Vector.h>
 #include <ID.h>
 
+#include <KrylovAccelerator.h>
+#include <RaphsonAccelerator.h>
+#include <SecantAccelerator1.h>
+#include <SecantAccelerator2.h>
+#include <SecantAccelerator3.h>
+#include <PeriodicAccelerator.h>
+
+#include <elementAPI.h>
+#include <string.h>
+#include <stdlib.h>
 #include <fstream>
 
+// OPS_* accelerated-Newton parsers (shared Tcl/Python); test set by caller.
+
+static void
+parseAcceleratorArgs(int &incrementTangent, int &iterateTangent,
+		     int &maxDim, int &factorOnce,
+		     int &numTerms, bool &cutOut, double R[2],
+		     bool wantMaxDim, bool wantNumTerms, bool wantCutOut)
+{
+    bool iterateSeen = false;
+    bool factorOnceExplicit = false;
+
+    while (OPS_GetNumRemainingInputArgs() > 0) {
+	const char *flag = OPS_GetString();
+
+	if (strcmp(flag, "-iterate") == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+	    const char *flag2 = OPS_GetString();
+	    iterateSeen = true;
+	    if (strcmp(flag2, "current") == 0)
+		iterateTangent = CURRENT_TANGENT;
+	    else if (strcmp(flag2, "initial") == 0)
+		iterateTangent = INITIAL_TANGENT;
+	    else if (strcmp(flag2, "noTangent") == 0)
+		iterateTangent = NO_TANGENT;
+	}
+	else if (strcmp(flag, "-increment") == 0 && OPS_GetNumRemainingInputArgs() > 0) {
+	    const char *flag2 = OPS_GetString();
+	    if (strcmp(flag2, "current") == 0)
+		incrementTangent = CURRENT_TANGENT;
+	    else if (strcmp(flag2, "initial") == 0)
+		incrementTangent = INITIAL_TANGENT;
+	    else if (strcmp(flag2, "noTangent") == 0)
+		incrementTangent = NO_TANGENT;
+	}
+	else if (wantMaxDim && strcmp(flag, "-maxDim") == 0
+		 && OPS_GetNumRemainingInputArgs() > 0) {
+	    int numdata = 1;
+	    if (OPS_GetIntInput(&numdata, &maxDim) < 0) {
+		opserr << "WARNING accelerated-Newton failed to read maxDim\n";
+		// leave maxDim at its previous value and keep parsing
+	    }
+	}
+	else if (wantNumTerms && strcmp(flag, "-numTerms") == 0
+		 && OPS_GetNumRemainingInputArgs() > 0) {
+	    int numdata = 1;
+	    if (OPS_GetIntInput(&numdata, &numTerms) < 0) {
+		opserr << "WARNING SecantNewton failed to read numTerms\n";
+	    }
+	}
+	else if (wantCutOut
+		 && (strcmp(flag, "-cutOut") == 0 || strcmp(flag, "-cutout") == 0)
+		 && OPS_GetNumRemainingInputArgs() > 1) {
+	    int numdata = 2;
+	    if (OPS_GetDoubleInput(&numdata, R) < 0) {
+		opserr << "WARNING SecantNewton failed to read cutOut values R1 and R2\n";
+	    } else {
+		cutOut = true;
+	    }
+	}
+	else if (strcmp(flag, "-factorIncrementOnce") == 0
+		 || strcmp(flag, "-FactorIncrementOnce") == 0
+		 || strcmp(flag, "-factorOnce") == 0
+		 || strcmp(flag, "-factoronce") == 0
+		 || strcmp(flag, "-FactorOnce") == 0) {
+	    factorOnce = 1;
+	    factorOnceExplicit = true;
+	}
+    }
+
+    if (!iterateSeen && factorOnceExplicit && factorOnce != 0) {
+	iterateTangent = NO_TANGENT;
+	opserr << "WARNING accelerated-Newton: -factorOnce without -iterate: "
+		  "using -iterate noTangent\n";
+    }
+
+    if (factorOnce != 0 && iterateTangent != NO_TANGENT
+	&& !(incrementTangent == INITIAL_TANGENT
+	     && iterateTangent == INITIAL_TANGENT)) {
+	opserr << "WARNING accelerated-Newton: -factorOnce / -increment initial "
+		  "is disabled when -iterate is not noTangent. For a fixed "
+		  "stiffness matrix with factor-once on the increment, use "
+		  "-iterate noTangent.\n";
+	factorOnce = 0;
+    }
+
+    if (incrementTangent == INITIAL_TANGENT
+	&& (iterateTangent == NO_TANGENT || iterateTangent == INITIAL_TANGENT))
+	factorOnce = 1;
+}
+
+void *
+OPS_KrylovNewton()
+{
+    int incrementTangent = CURRENT_TANGENT;
+    int iterateTangent = CURRENT_TANGENT;
+    int maxDim = 3;
+    int factorOnce = 0;
+    int numTerms = 0;
+    bool cutOut = false;
+    double R[2];
+
+    parseAcceleratorArgs(incrementTangent, iterateTangent, maxDim, factorOnce,
+			 numTerms, cutOut, R,
+			 /*wantMaxDim=*/true,
+			 /*wantNumTerms=*/false,
+			 /*wantCutOut=*/false);
+
+    Accelerator *theAccel = new KrylovAccelerator(maxDim, iterateTangent);
+    return new AcceleratedNewton(theAccel, incrementTangent, factorOnce);
+}
+
+void *
+OPS_RaphsonNewton()
+{
+    int incrementTangent = CURRENT_TANGENT;
+    int iterateTangent = CURRENT_TANGENT;
+    int maxDim = 0;
+    int factorOnce = 0;
+    int numTerms = 0;
+    bool cutOut = false;
+    double R[2];
+
+    parseAcceleratorArgs(incrementTangent, iterateTangent, maxDim, factorOnce,
+			 numTerms, cutOut, R,
+			 /*wantMaxDim=*/false,
+			 /*wantNumTerms=*/false,
+			 /*wantCutOut=*/false);
+
+    Accelerator *theAccel = new RaphsonAccelerator(iterateTangent);
+    return new AcceleratedNewton(theAccel, incrementTangent, factorOnce);
+}
+
+void *
+OPS_SecantNewton()
+{
+    int incrementTangent = CURRENT_TANGENT;
+    int iterateTangent = CURRENT_TANGENT;
+    int maxDim = 3;
+    int factorOnce = 0;
+    int numTerms = 2;
+    bool cutOut = false;
+    double R[2];
+
+    parseAcceleratorArgs(incrementTangent, iterateTangent, maxDim, factorOnce,
+			 numTerms, cutOut, R,
+			 /*wantMaxDim=*/true,
+			 /*wantNumTerms=*/true,
+			 /*wantCutOut=*/true);
+
+    Accelerator *theAccel = 0;
+    if (numTerms <= 1) {
+	if (cutOut)
+	    theAccel = new SecantAccelerator1(maxDim, iterateTangent, R[0], R[1]);
+	else
+	    theAccel = new SecantAccelerator1(maxDim, iterateTangent);
+    } else if (numTerms == 2) {
+	if (cutOut)
+	    theAccel = new SecantAccelerator2(maxDim, iterateTangent, R[0], R[1]);
+	else
+	    theAccel = new SecantAccelerator2(maxDim, iterateTangent);
+    } else {
+	if (cutOut)
+	    theAccel = new SecantAccelerator3(maxDim, iterateTangent, R[0], R[1]);
+	else
+	    theAccel = new SecantAccelerator3(maxDim, iterateTangent);
+    }
+
+    return new AcceleratedNewton(theAccel, incrementTangent, factorOnce);
+}
+
+void *
+OPS_PeriodicNewton()
+{
+    int incrementTangent = CURRENT_TANGENT;
+    int iterateTangent = CURRENT_TANGENT;
+    int maxDim = 3;
+    int factorOnce = 0;
+    int numTerms = 0;
+    bool cutOut = false;
+    double R[2];
+
+    parseAcceleratorArgs(incrementTangent, iterateTangent, maxDim, factorOnce,
+			 numTerms, cutOut, R,
+			 /*wantMaxDim=*/true,
+			 /*wantNumTerms=*/false,
+			 /*wantCutOut=*/false);
+
+    Accelerator *theAccel = new PeriodicAccelerator(maxDim, iterateTangent);
+    return new AcceleratedNewton(theAccel, incrementTangent, factorOnce);
+}
+
+void *
+OPS_MillerNewton()
+{
+    int incrementTangent = CURRENT_TANGENT;
+    int iterateTangent = CURRENT_TANGENT;
+    int maxDim = 3;
+    int factorOnce = 0;
+    int numTerms = 0;
+    bool cutOut = false;
+    double R[2];
+
+    parseAcceleratorArgs(incrementTangent, iterateTangent, maxDim, factorOnce,
+			 numTerms, cutOut, R,
+			 /*wantMaxDim=*/true,
+			 /*wantNumTerms=*/false,
+			 /*wantCutOut=*/false);
+
+    opserr << "WARNING MillerNewton: Miller acceleration is deactivated; "
+	   << "using AcceleratedNewton without MillerAccelerator.\n";
+
+    Accelerator *theAccel = 0;
+    return new AcceleratedNewton(theAccel, incrementTangent, factorOnce);
+}
+
 // Constructor
-AcceleratedNewton::AcceleratedNewton(int theTangentToUse)
+AcceleratedNewton::AcceleratedNewton(int theTangentToUse, int factOnce)
   :EquiSolnAlgo(EquiALGORITHM_TAGS_AcceleratedNewton),
-   theTest(0), tangent(theTangentToUse),
+   theTest(0), tangent(theTangentToUse), factorOnce(factOnce),
    theAccelerator(0), vAccel(0), 
    numFactorizations(0), numIterations(0)
 //   totalTimer(), totalTimeReal(0.0), totalTimeCPU(0.0),
@@ -61,11 +285,24 @@ AcceleratedNewton::AcceleratedNewton(int theTangentToUse)
 
 }
 
+// Deferred ConvergenceTest (OPS factories); owns theAccel.
+AcceleratedNewton::AcceleratedNewton(Accelerator *theAccel,
+				     int theTangentToUse,
+				     int factOnce)
+  :EquiSolnAlgo(EquiALGORITHM_TAGS_AcceleratedNewton),
+   theTest(0), tangent(theTangentToUse), factorOnce(factOnce),
+   theAccelerator(theAccel), vAccel(0),
+   numFactorizations(0), numIterations(0)
+{
+
+}
+
 AcceleratedNewton::AcceleratedNewton(ConvergenceTest &theT,
 				     Accelerator *theAccel,
-				     int theTangentToUse)
+				     int theTangentToUse,
+				     int factOnce)
   :EquiSolnAlgo(EquiALGORITHM_TAGS_AcceleratedNewton),
-   theTest(&theT), tangent(theTangentToUse),
+   theTest(&theT), tangent(theTangentToUse), factorOnce(factOnce),
    theAccelerator(theAccel), vAccel(0), 
    numFactorizations(0), numIterations(0)
 //   totalTimer(), totalTimeReal(0.0), totalTimeCPU(0.0),
@@ -91,6 +328,15 @@ int
 AcceleratedNewton::setConvergenceTest(ConvergenceTest *newTest)
 {
   theTest = newTest;
+  return 0;
+}
+
+int
+AcceleratedNewton::domainChanged(void)
+{
+  // Cached factorization invalid after domain change / setSize - reform increment tangent next solve.
+  if (factorOnce == 2)
+    factorOnce = 1;
   return 0;
 }
 
@@ -138,15 +384,19 @@ AcceleratedNewton::solveCurrentStep(void)
     return -2;
   }
 
-  // Evaluate system Jacobian J = R'(y)|y_0
-  if (theIntegrator->formTangent(tangent) < 0){
-    opserr << "WARNING AcceleratedNewton::solveCurrentStep() -";
-    opserr << "the Integrator failed in formTangent()\n";
-    return -1;
+  // Increment-side formTangent only; iterate-side uses accelerator/updateTangent.
+  if (factorOnce != 2) {
+    if (theIntegrator->formTangent(tangent) < 0){
+      opserr << "WARNING AcceleratedNewton::solveCurrentStep() -";
+      opserr << "the Integrator failed in formTangent()\n";
+      return -1;
+    }
+    if (factorOnce == 1)
+      factorOnce = 2;
+
+    // Count factorization of the first tangent
+    numFactorizations++;
   }
-  
-  // Count factorization of the first tangent
-  numFactorizations++;
   
   // set itself as the ConvergenceTest objects EquiSolnAlgo
   theTest->setEquiSolnAlgo(*this);
@@ -252,12 +502,13 @@ AcceleratedNewton::getTest(void)
 int
 AcceleratedNewton::sendSelf(int cTag, Channel &theChannel)
 {
-  static ID data(2);
+  static ID data(3);
   data(0) = tangent;
   if (theAccelerator != 0)
     data(1) = theAccelerator->getClassTag();
   else
     data(1) = -1;
+  data(2) = factorOnce;
 
   int res = theChannel.sendID(0, cTag, data);
   if (res < 0) {
@@ -280,7 +531,7 @@ int
 AcceleratedNewton::recvSelf(int cTag, Channel &theChannel, 
 			    FEM_ObjectBroker &theBroker)
 {
-  static ID data(2);
+  static ID data(3);
   int res = theChannel.recvID(0, cTag, data);
 
   if (res < 0) {
@@ -288,7 +539,8 @@ AcceleratedNewton::recvSelf(int cTag, Channel &theChannel,
     return -1;
   }
 
-  tangent = data(0) = tangent;
+  tangent = data(0);
+  factorOnce = (data.Size() > 2) ? data(2) : 0;
 
   if (data(1) != -1) {
 

--- a/SRC/analysis/algorithm/equiSolnAlgo/AcceleratedNewton.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/AcceleratedNewton.h
@@ -45,12 +45,15 @@ class Accelerator;
 class AcceleratedNewton: public EquiSolnAlgo
 {
  public:
-  AcceleratedNewton(int tangent = CURRENT_TANGENT);
+  AcceleratedNewton(int tangent = CURRENT_TANGENT, int factorOnce = 0);
+  AcceleratedNewton(Accelerator *theAccel, int tangent = CURRENT_TANGENT,
+		    int factorOnce = 0);
   AcceleratedNewton(ConvergenceTest &theTest, Accelerator *theAccel,
-		    int tangent = CURRENT_TANGENT);
+		    int tangent = CURRENT_TANGENT, int factorOnce = 0);
   ~AcceleratedNewton();
   
-  int solveCurrentStep(void);    
+  int solveCurrentStep(void);
+  int domainChanged(void);
   int setConvergenceTest(ConvergenceTest *theNewTest);
   ConvergenceTest *getTest(void);     
   
@@ -73,7 +76,10 @@ class AcceleratedNewton: public EquiSolnAlgo
  private:
   ConvergenceTest *theTest;
   int tangent;
-  
+  // factorOnce: 0=every step; 1->2 after increment formTangent; 2=skip (reuse factor).
+  // domainChanged() resets 2->1.
+  int factorOnce;
+
   Accelerator *theAccelerator;
   
   // Storate for accelerated mod-Newton prediction

--- a/SRC/analysis/algorithm/equiSolnAlgo/ExpressNewton.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/ExpressNewton.cpp
@@ -71,16 +71,19 @@ void *OPS_ExpressNewton()
   }
   while (OPS_GetNumRemainingInputArgs() > 0) {
     const char *type = OPS_GetString();
-    if ((strcmp(type,"-initialTangent") == 0) || (strcmp(type,"-InitialTangent") == 0)) {
+    if ((strcmp(type,"-initialTangent") == 0) || (strcmp(type,"-InitialTangent") == 0)
+	|| (strcmp(type,"-initial") == 0) || (strcmp(type,"-Initial") == 0)) {
       formTangent = INITIAL_TANGENT;
-    } else if ((strcmp(type,"-currentTangent") == 0) || (strcmp(type,"-CurrentTangent") ==0 )) {
+      factorOnce = 1; // fixed initial tangent -> factor-once
+    } else if ((strcmp(type,"-currentTangent") == 0) || (strcmp(type,"-CurrentTangent") == 0)) {
       formTangent = CURRENT_TANGENT;
-    } else if ((strcmp(type,"-factorOnce") == 0) || (strcmp(type,"-FactorOnce") ==0 )) {
+    } else if ((strcmp(type,"-factorOnce") == 0) || (strcmp(type,"-factoronce") == 0)
+	       || (strcmp(type,"-FactorOnce") == 0)) {
       factorOnce = 1;
     }
   }
-    
-    return new ExpressNewton(nIter,kMultiplier,formTangent,factorOnce);
+
+  return new ExpressNewton(nIter, kMultiplier, formTangent, factorOnce);
 }
 
 // Constructor
@@ -101,6 +104,15 @@ ExpressNewton::ExpressNewton(int ni, double km, int tg, int fo)
 ExpressNewton::~ExpressNewton()
 {
 
+}
+
+int
+ExpressNewton::domainChanged(void)
+{
+  // Domain change after setSize: stale A if we skipped formTangent - reform next solve.
+  if (factorOnce == 2)
+    factorOnce = 1;
+  return 0;
 }
 
 int 

--- a/SRC/analysis/algorithm/equiSolnAlgo/ExpressNewton.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/ExpressNewton.h
@@ -51,6 +51,7 @@ class ExpressNewton: public EquiSolnAlgo
     ~ExpressNewton();
 
     int solveCurrentStep(void);
+    int domainChanged(void);
     int setConvergenceTest(ConvergenceTest *theNewTest);
     
     virtual int sendSelf(int commitTag, Channel &theChannel);
@@ -62,6 +63,8 @@ class ExpressNewton: public EquiSolnAlgo
   protected:
     
   private:
+    // factorOnce: 0=every iter; 1->2 after one formTangent; 2=skip formTangent (reuse factor).
+    // domainChanged() resets 2->1.
     int factorOnce;
     int nIter;
     double kMultiplier1, kMultiplier2;

--- a/SRC/analysis/algorithm/equiSolnAlgo/ModifiedNewton.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/ModifiedNewton.cpp
@@ -56,19 +56,21 @@ void* OPS_ModifiedNewton()
   double iFactor = 0;
   double cFactor = 1;
 
-  if (OPS_GetNumRemainingInputArgs() > 0) {
+  while (OPS_GetNumRemainingInputArgs() > 0) {
     const char* type = OPS_GetString();
-    if (strcmp(type,"-secant") == 0) {
+    if (strcmp(type,"-secant") == 0 || strcmp(type,"-Secant") == 0) {
       formTangent = CURRENT_SECANT;
-    } else if (strcmp(type,"-factoronce")==0 || strcmp(type,"-FactorOnce")==0)  {
+    } else if (strcmp(type,"-factorOnce") == 0 || strcmp(type,"-factoronce") == 0
+	       || strcmp(type,"-FactorOnce") == 0) {
       factoronce = 1;
-    } else if (strcmp(type,"-initial") == 0) {
+    } else if (strcmp(type,"-initial") == 0 || strcmp(type,"-Initial") == 0) {
       formTangent = INITIAL_TANGENT;
+      factoronce = 1; // -initial implies factor-once
     } else if(strcmp(type,"-hall")==0 || strcmp(type,"-Hall")==0) {
       formTangent = HALL_TANGENT;
       iFactor = 0.1;
       cFactor = 0.9;
-      if (OPS_GetNumRemainingInputArgs() == 2) {
+      if (OPS_GetNumRemainingInputArgs() >= 2) {
         double data[2];
         int numData = 2;
         if(OPS_GetDoubleInput(&numData,&data[0]) < 0) {
@@ -80,14 +82,15 @@ void* OPS_ModifiedNewton()
       }
     }
   }
-  
-  return new ModifiedNewton(formTangent, iFactor, cFactor,factoronce);
+
+  return new ModifiedNewton(formTangent, iFactor, cFactor, factoronce);
 }
 
 // Constructor
 ModifiedNewton::ModifiedNewton(int theTangentToUse, double iFact, double cFact, int factOnce)
 :EquiSolnAlgo(EquiALGORITHM_TAGS_ModifiedNewton),
- tangent(theTangentToUse), iFactor(iFact), cFactor(cFact), factorOnce(factOnce)
+ tangent(theTangentToUse), numIterations(0), factorOnce(factOnce),
+ iFactor(iFact), cFactor(cFact)
 {
   
 }
@@ -95,7 +98,8 @@ ModifiedNewton::ModifiedNewton(int theTangentToUse, double iFact, double cFact, 
 
 ModifiedNewton::ModifiedNewton(ConvergenceTest &theT, int theTangentToUse, double iFact, double cFact, int factOnce)
 :EquiSolnAlgo(EquiALGORITHM_TAGS_ModifiedNewton),
- tangent(theTangentToUse), iFactor(iFact), cFactor(cFact), factorOnce(factOnce)
+ tangent(theTangentToUse), numIterations(0), factorOnce(factOnce),
+ iFactor(iFact), cFactor(cFact)
 {
 
 }
@@ -104,6 +108,15 @@ ModifiedNewton::ModifiedNewton(ConvergenceTest &theT, int theTangentToUse, doubl
 ModifiedNewton::~ModifiedNewton()
 {
 
+}
+
+int
+ModifiedNewton::domainChanged(void)
+{
+  // Domain change: cached factorization invalid after setSize - reform tangent next solve.
+  if (factorOnce == 2)
+    factorOnce = 1;
+  return 0;
 }
 
 

--- a/SRC/analysis/algorithm/equiSolnAlgo/ModifiedNewton.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/ModifiedNewton.h
@@ -52,7 +52,8 @@ class ModifiedNewton: public EquiSolnAlgo
   ModifiedNewton(ConvergenceTest &theTest, int tangent = CURRENT_TANGENT, double iFactor = 0.0, double cFactor = 1.0, int factOnce=0);
   ~ModifiedNewton();
 
-    int solveCurrentStep(void);    
+    int solveCurrentStep(void);
+    int domainChanged(void);
     int getNumIterations(void);
 
     virtual int sendSelf(int commitTag, Channel &theChannel);
@@ -66,6 +67,8 @@ class ModifiedNewton: public EquiSolnAlgo
   private:
     int tangent;
     int numIterations;
+    // factorOnce: 0=every iter; 1->2 after one formTangent; 2=skip formTangent (reuse factor).
+    // domainChanged() resets 2->1.
     int factorOnce;
 
     double iFactor;

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
@@ -40,6 +40,82 @@
 #include <ConvergenceTest.h>
 #include <ID.h>
 
+#include <InitialInterpolatedLineSearch.h>
+#include <BisectionLineSearch.h>
+#include <SecantLineSearch.h>
+#include <RegulaFalsiLineSearch.h>
+
+#include <elementAPI.h>
+#include <string.h>
+
+// Shared Tcl/Python OPS_NewtonLineSearch; ConvergenceTest attached by interpreter.
+void* OPS_NewtonLineSearch()
+{
+    double tol        = 0.8;
+    int    maxIter    = 10;
+    double maxEta     = 10.0;
+    double minEta     = 0.1;
+    int    pFlag      = 1;
+    int    typeSearch = 0;
+
+    int numdata = 1;
+
+    while (OPS_GetNumRemainingInputArgs() > 0) {
+	const char* flag = OPS_GetString();
+
+	if (strcmp(flag, "-tol") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    if (OPS_GetDoubleInput(&numdata, &tol) < 0) {
+		opserr << "WARNING NewtonLineSearch failed to read tol\n";
+		return 0;
+	    }
+	} else if (strcmp(flag, "-maxIter") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    if (OPS_GetIntInput(&numdata, &maxIter) < 0) {
+		opserr << "WARNING NewtonLineSearch failed to read maxIter\n";
+		return 0;
+	    }
+	} else if (strcmp(flag, "-pFlag") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    if (OPS_GetIntInput(&numdata, &pFlag) < 0) {
+		opserr << "WARNING NewtonLineSearch failed to read pFlag\n";
+		return 0;
+	    }
+	} else if (strcmp(flag, "-minEta") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    if (OPS_GetDoubleInput(&numdata, &minEta) < 0) {
+		opserr << "WARNING NewtonLineSearch failed to read minEta\n";
+		return 0;
+	    }
+	} else if (strcmp(flag, "-maxEta") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    if (OPS_GetDoubleInput(&numdata, &maxEta) < 0) {
+		opserr << "WARNING NewtonLineSearch failed to read maxEta\n";
+		return 0;
+	    }
+	} else if (strcmp(flag, "-type") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	    const char* flag2 = OPS_GetString();
+	    if (strcmp(flag2, "Bisection") == 0)
+		typeSearch = 1;
+	    else if (strcmp(flag2, "Secant") == 0)
+		typeSearch = 2;
+	    else if (strcmp(flag2, "RegulaFalsi") == 0)
+		typeSearch = 3;
+	    else if (strcmp(flag2, "LinearInterpolated") == 0)
+		typeSearch = 3;
+	    else if (strcmp(flag2, "InitialInterpolated") == 0)
+		typeSearch = 0;
+	}
+    }
+
+    LineSearch *theLineSearch = 0;
+    if (typeSearch == 0)
+	theLineSearch = new InitialInterpolatedLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+    else if (typeSearch == 1)
+	theLineSearch = new BisectionLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+    else if (typeSearch == 2)
+	theLineSearch = new SecantLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+    else if (typeSearch == 3)
+	theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+
+    return new NewtonLineSearch(theLineSearch);
+}
+
 
 //Null Constructor
 NewtonLineSearch::NewtonLineSearch( )
@@ -57,6 +133,18 @@ NewtonLineSearch::NewtonLineSearch( ConvergenceTest &theT,
 {
   theOtherTest = theTest->getCopy(10);
   theOtherTest->setEquiSolnAlgo(*this);
+}
+
+
+// Constructor with deferred ConvergenceTest assignment.
+// The test is wired in later via setConvergenceTest() (e.g. by the
+// interpreter-level setAlgorithm() / StaticAnalysis bookkeeping). Keeps
+// argument-parsing factories like OPS_NewtonLineSearch() free from any
+// dependency on a specific interpreter's "current test" state.
+NewtonLineSearch::NewtonLineSearch(LineSearch *theSearch)
+:EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonLineSearch),
+ theTest(0), theOtherTest(0), theLineSearch(theSearch)
+{
 }
 
 

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.cpp
@@ -47,6 +47,7 @@
 
 #include <elementAPI.h>
 #include <string.h>
+#include <SolutionAlgorithm.h>
 
 // Shared Tcl/Python OPS_NewtonLineSearch; ConvergenceTest attached by interpreter.
 void* OPS_NewtonLineSearch()
@@ -57,13 +58,17 @@ void* OPS_NewtonLineSearch()
     double minEta     = 0.1;
     int    pFlag      = 1;
     int    typeSearch = 0;
+    int    factorOnce = 0;
 
     int numdata = 1;
 
     while (OPS_GetNumRemainingInputArgs() > 0) {
 	const char* flag = OPS_GetString();
 
-	if (strcmp(flag, "-tol") == 0 && OPS_GetNumRemainingInputArgs()>0) {
+	if (strcmp(flag, "-factorOnce") == 0 || strcmp(flag, "-factoronce") == 0
+	    || strcmp(flag, "-FactorOnce") == 0) {
+	    factorOnce = 1;
+	} else if (strcmp(flag, "-tol") == 0 && OPS_GetNumRemainingInputArgs()>0) {
 	    if (OPS_GetDoubleInput(&numdata, &tol) < 0) {
 		opserr << "WARNING NewtonLineSearch failed to read tol\n";
 		return 0;
@@ -113,23 +118,23 @@ void* OPS_NewtonLineSearch()
     else if (typeSearch == 3)
 	theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
 
-    return new NewtonLineSearch(theLineSearch);
+    return new NewtonLineSearch(theLineSearch, factorOnce);
 }
 
 
 //Null Constructor
 NewtonLineSearch::NewtonLineSearch( )
 :EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonLineSearch),
- theTest(0), theOtherTest(0), theLineSearch(0)
+ theTest(0), theOtherTest(0), theLineSearch(0), factorOnce(0)
 {   
 }
 
 
 //Constructor 
 NewtonLineSearch::NewtonLineSearch( ConvergenceTest &theT, 
-				   LineSearch *theSearch) 
+				   LineSearch *theSearch, int factOnce) 
 :EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonLineSearch),
- theTest(&theT), theLineSearch(theSearch)
+ theTest(&theT), theOtherTest(0), theLineSearch(theSearch), factorOnce(factOnce)
 {
   theOtherTest = theTest->getCopy(10);
   theOtherTest->setEquiSolnAlgo(*this);
@@ -141,9 +146,9 @@ NewtonLineSearch::NewtonLineSearch( ConvergenceTest &theT,
 // interpreter-level setAlgorithm() / StaticAnalysis bookkeeping). Keeps
 // argument-parsing factories like OPS_NewtonLineSearch() free from any
 // dependency on a specific interpreter's "current test" state.
-NewtonLineSearch::NewtonLineSearch(LineSearch *theSearch)
+NewtonLineSearch::NewtonLineSearch(LineSearch *theSearch, int factOnce)
 :EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonLineSearch),
- theTest(0), theOtherTest(0), theLineSearch(theSearch)
+ theTest(0), theOtherTest(0), theLineSearch(theSearch), factorOnce(factOnce)
 {
 }
 
@@ -165,6 +170,14 @@ NewtonLineSearch::setConvergenceTest(ConvergenceTest *newTest)
       delete theOtherTest;
     theOtherTest = theTest->getCopy(10);
     theOtherTest->setEquiSolnAlgo(*this);
+    return 0;
+}
+
+int
+NewtonLineSearch::domainChanged(void)
+{
+    if (factorOnce == 2)
+	factorOnce = 1;
     return 0;
 }
 
@@ -208,11 +221,16 @@ NewtonLineSearch::solveCurrentStep(void)
 	const Vector &Resid0 = theSOE->getB() ;
 	
 	//form the tangent
-        if (theIntegrator->formTangent() < 0){
-	    opserr << "WARNING NewtonLineSearch::solveCurrentStep() -";
-	    opserr << "the Integrator failed in formTangent()\n";
-	    return -1;
-	}		    
+	if (factorOnce != 2) {
+	    SOLUTION_ALGORITHM_tangentFlag = CURRENT_TANGENT;
+	    if (theIntegrator->formTangent(CURRENT_TANGENT) < 0) {
+		opserr << "WARNING NewtonLineSearch::solveCurrentStep() -";
+		opserr << "the Integrator failed in formTangent()\n";
+		return -1;
+	    }
+	    if (factorOnce == 1)
+		factorOnce = 2;
+	}
 	
 	//solve 
 	if (theSOE->solve() < 0) {
@@ -281,8 +299,9 @@ NewtonLineSearch::getConvergenceTest(void)
 int
 NewtonLineSearch::sendSelf(int cTag, Channel &theChannel)
 {
-  static ID data(1);
+  static ID data(2);
   data(0) = theLineSearch->getClassTag();
+  data(1) = factorOnce;
   if (theChannel.sendID(0, cTag, data) < 0) {
     opserr << "NewtonLineSearch::sendSelf(int cTag, Channel &theChannel)   - failed to send date\n";
     return -1;
@@ -301,13 +320,14 @@ NewtonLineSearch::recvSelf(int cTag,
 			Channel &theChannel, 
 			FEM_ObjectBroker &theBroker)
 {
-  static ID data(1);
+  static ID data(2);
   if (theChannel.recvID(0, cTag, data) < 0) {
     opserr << "NewtonLineSearch::recvSelf(int cTag, Channel &theChannel) - failed to recv data\n";
     return -1;
   }
 
   int lineSearchClassTag = data(0);
+  factorOnce = (data.Size() > 1) ? data(1) : 0;
 
   if (theLineSearch == 0 || theLineSearch->getClassTag() != lineSearchClassTag) {
     if (theLineSearch != 0)

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.h
@@ -46,6 +46,7 @@ class NewtonLineSearch: public EquiSolnAlgo
   public:
     NewtonLineSearch( );    
     NewtonLineSearch(ConvergenceTest &theTest, LineSearch *theLineSearch);
+    NewtonLineSearch(LineSearch *theLineSearch);
     ~NewtonLineSearch( );
 
     int solveCurrentStep(void);    

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonLineSearch.h
@@ -45,11 +45,13 @@ class NewtonLineSearch: public EquiSolnAlgo
 {
   public:
     NewtonLineSearch( );    
-    NewtonLineSearch(ConvergenceTest &theTest, LineSearch *theLineSearch);
-    NewtonLineSearch(LineSearch *theLineSearch);
+    NewtonLineSearch(ConvergenceTest &theTest, LineSearch *theLineSearch,
+		      int factorOnce = 0);
+    NewtonLineSearch(LineSearch *theLineSearch, int factorOnce = 0);
     ~NewtonLineSearch( );
 
-    int solveCurrentStep(void);    
+    int solveCurrentStep(void);
+    int domainChanged(void);
     int setConvergenceTest(ConvergenceTest *theNewTest);
     ConvergenceTest *getConvergenceTest(void);     
     
@@ -65,6 +67,9 @@ class NewtonLineSearch: public EquiSolnAlgo
     ConvergenceTest *theTest;
     ConvergenceTest *theOtherTest;
     LineSearch *theLineSearch;
+    // factorOnce: 0=every iter; 1->2 after one formTangent; 2=skip formTangent (reuse factor).
+    // domainChanged() resets 2->1.
+    int factorOnce;
 };
 
 #endif

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonRaphson.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonRaphson.cpp
@@ -56,6 +56,7 @@ void* OPS_NewtonRaphsonAlgorithm()
     int formTangent = CURRENT_TANGENT;
     double iFactor = 0;
     double cFactor = 1;
+    int factorOnce = 0;
 
     while (OPS_GetNumRemainingInputArgs() > 0) {
       const char* type = OPS_GetString();
@@ -67,15 +68,19 @@ void* OPS_NewtonRaphsonAlgorithm()
 	formTangent = INITIAL_TANGENT;
 	iFactor = 1.;
 	cFactor = 0;
+	factorOnce = 1; // -initial implies factor-once
       } else if(strcmp(type,"-intialThenCurrent")==0 || strcmp(type,"-intialCurrent")==0) {
 	formTangent = INITIAL_THEN_CURRENT_TANGENT;
 	iFactor = 0;
 	cFactor = 1.0;
+      } else if(strcmp(type,"-factorOnce")==0 || strcmp(type,"-factoronce")==0
+		|| strcmp(type,"-FactorOnce")==0) {
+	factorOnce = 1;
       } else if(strcmp(type,"-hall")==0 || strcmp(type,"-Hall")==0) {
 	formTangent = HALL_TANGENT;
 	iFactor = 0.1;
 	cFactor = 0.9;
-	if (OPS_GetNumRemainingInputArgs() == 2) {
+	if (OPS_GetNumRemainingInputArgs() >= 2) {
 	  double data[2];
 	  int numData = 2;
 	  if(OPS_GetDoubleInput(&numData,&data[0]) < 0) {
@@ -88,29 +93,32 @@ void* OPS_NewtonRaphsonAlgorithm()
       }
     }
 
-    return new NewtonRaphson(formTangent, iFactor, cFactor);
+    return new NewtonRaphson(formTangent, iFactor, cFactor, factorOnce);
 
 }
 
 // Constructor
-NewtonRaphson::NewtonRaphson(int theTangentToUse, double iFact, double cFact)
+NewtonRaphson::NewtonRaphson(int theTangentToUse, double iFact, double cFact, int factOnce)
 :EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonRaphson),
- tangent(theTangentToUse), iFactor(iFact), cFactor(cFact)
+ tangent(theTangentToUse), numIterations(0), factorOnce(factOnce),
+ iFactor(iFact), cFactor(cFact)
 {
 
 }
 
 NewtonRaphson::NewtonRaphson()
 	:EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonRaphson),
-	tangent(CURRENT_TANGENT), iFactor(0.), cFactor(1.)
+	tangent(CURRENT_TANGENT), numIterations(0), factorOnce(0),
+	iFactor(0.), cFactor(1.)
 {
 
 }
 
 
-NewtonRaphson::NewtonRaphson(ConvergenceTest &theT, int theTangentToUse, double iFact, double cFact)
+NewtonRaphson::NewtonRaphson(ConvergenceTest &theT, int theTangentToUse, double iFact, double cFact, int factOnce)
 :EquiSolnAlgo(EquiALGORITHM_TAGS_NewtonRaphson),
- tangent(theTangentToUse), iFactor(iFact), cFactor(cFact)
+ tangent(theTangentToUse), numIterations(0), factorOnce(factOnce),
+ iFactor(iFact), cFactor(cFact)
 {
 
 }
@@ -120,6 +128,15 @@ NewtonRaphson::~NewtonRaphson()
 {
   
 
+}
+
+int
+NewtonRaphson::domainChanged(void)
+{
+  // Domain change: cached factorization invalid after setSize - reform tangent next solve.
+  if (factorOnce == 2)
+    factorOnce = 1;
+  return 0;
 }
 
 
@@ -160,6 +177,7 @@ NewtonRaphson::solveCurrentStep(void)
     do {
 
       if (tangent == INITIAL_THEN_CURRENT_TANGENT) {
+	// Alternating tangents per iteration - factorOnce not used here.
 	if (numIterations == 0) {
 	  SOLUTION_ALGORITHM_tangentFlag = INITIAL_TANGENT;
 	  if (theIntegrator->formTangent(INITIAL_TANGENT) < 0){
@@ -176,13 +194,17 @@ NewtonRaphson::solveCurrentStep(void)
 	  } 
 	}
       }	else {
-	
-	SOLUTION_ALGORITHM_tangentFlag = tangent;
-	if (theIntegrator->formTangent(tangent, iFactor, cFactor) < 0){
+
+	if (factorOnce != 2) {
+	  SOLUTION_ALGORITHM_tangentFlag = tangent;
+	  if (theIntegrator->formTangent(tangent, iFactor, cFactor) < 0){
 	    opserr << "WARNING NewtonRaphson::solveCurrentStep() -";
 	    opserr << "the Integrator failed in formTangent()\n";
 	    return -1;
-	}		    
+	  }
+	  if (factorOnce == 1)
+	    factorOnce = 2;
+	}
       } 
       if (theSOE->solve() < 0) {
 	opserr << "WARNING NewtonRaphson::solveCurrentStep() -";
@@ -222,10 +244,11 @@ NewtonRaphson::solveCurrentStep(void)
 int
 NewtonRaphson::sendSelf(int cTag, Channel &theChannel)
 {
-  static Vector data(3);
+  static Vector data(4);
   data(0) = tangent;
   data(1) = iFactor;
   data(2) = cFactor;
+  data(3) = factorOnce;
   return theChannel.sendVector(this->getDbTag(), cTag, data);
 }
 
@@ -234,11 +257,12 @@ NewtonRaphson::recvSelf(int cTag,
 			Channel &theChannel, 
 			FEM_ObjectBroker &theBroker)
 {
-  static Vector data(3);
+  static Vector data(4);
   theChannel.recvVector(this->getDbTag(), cTag, data);
   tangent = int(data(0));
   iFactor = data(1);
   cFactor = data(2);
+  factorOnce = (data.Size() > 3) ? int(data(3)) : 0;
   return 0;
 }
 

--- a/SRC/analysis/algorithm/equiSolnAlgo/NewtonRaphson.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/NewtonRaphson.h
@@ -49,12 +49,13 @@ class NewtonRaphson: public EquiSolnAlgo
 {
   public:
   NewtonRaphson();
-  NewtonRaphson(int tangent, double iFactor = 0.0, double cFactor = 1.0);    
-  NewtonRaphson(ConvergenceTest &theTest, int tangent = CURRENT_TANGENT, double iFactor = 0.0, double cFactor = 1.0);
+  NewtonRaphson(int tangent, double iFactor = 0.0, double cFactor = 1.0, int factorOnce = 0);
+  NewtonRaphson(ConvergenceTest &theTest, int tangent = CURRENT_TANGENT, double iFactor = 0.0, double cFactor = 1.0, int factorOnce = 0);
   ~NewtonRaphson();
   
-  int solveCurrentStep(void);    
-    
+  int solveCurrentStep(void);
+  int domainChanged(void);
+
   virtual int sendSelf(int commitTag, Channel &theChannel);
   virtual int recvSelf(int commitTag, Channel &theChannel, 
 		       FEM_ObjectBroker &theBroker);
@@ -68,7 +69,10 @@ class NewtonRaphson: public EquiSolnAlgo
  private:
   int tangent;
   int numIterations;
-  
+  // factorOnce: 0=every iter; 1->2 after one formTangent; 2=skip formTangent (reuse factor).
+  // domainChanged() resets 2->1.
+  int factorOnce;
+
   double iFactor;
   double cFactor;
 };

--- a/SRC/analysis/algorithm/equiSolnAlgo/accelerator/SecantAccelerator3.cpp
+++ b/SRC/analysis/algorithm/equiSolnAlgo/accelerator/SecantAccelerator3.cpp
@@ -109,8 +109,8 @@ SecantAccelerator3::accelerate(Vector &vStar, LinearSOE &theSOE,
   // Current right hand side
   const Vector &rNew  = theSOE.getB();
 
-  // Store for next iteration
-  *r_1 = vStar;
+  // Local copy: incoming raw Newton increment before acceleration changes vStar
+  Vector rawNewton(vStar);
 
   // No acceleration on first iteration
   if (iteration == 0) {
@@ -120,14 +120,14 @@ SecantAccelerator3::accelerate(Vector &vStar, LinearSOE &theSOE,
     // Store gamma in rOld ... \gamma = R_i - R_{i-1}
     rOld->addVector(-1.0, rNew, 1.0);
 
-    // Store alpha in r_1 ... \alpha = r_i - r_{i-1}
-    r_1->addVector(-1.0, vStar, 1.0);
+    // Store alpha in r_1 ... \alpha = r_i - r_{i-1} (r_1 still holds r_{i-1} from last call)
+    r_1->addVector(-1.0, rawNewton, 1.0);
     
     double den = 1.0 / ((*vOld)^(*rOld));
     double C   = ((*vOld)^rNew) * den;
     double A   = 1.0-C;
     double B   = -C - ((*r_1)^rNew) * den + C*((*r_1)^(*rOld)) * den;
-    double D   = -C - A*(vStar^(*rOld))*den;
+    double D   = -C - A*(rawNewton^(*rOld))*den;
     double DA  = D/A;
 
     //opserr << "D = " << D << endln;
@@ -149,6 +149,7 @@ SecantAccelerator3::accelerate(Vector &vStar, LinearSOE &theSOE,
   // Store old values for next iteration
   *rOld = rNew;
   *vOld = vStar;
+  *r_1 = rawNewton;
 
   iteration++;
 

--- a/SRC/analysis/algorithm/equiSolnAlgo/accelerator/SecantAccelerator3.h
+++ b/SRC/analysis/algorithm/equiSolnAlgo/accelerator/SecantAccelerator3.h
@@ -69,7 +69,7 @@ class SecantAccelerator3: public Accelerator
   Vector *vOld;
   Vector *rOld;
   Vector *r_1;
-    
+
   int maxIterations;
   int theTangent;
   bool cutOut;

--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -275,6 +275,9 @@ OpenSeesCommands::eigen(int typeSolver, double shift,
 	    theAnalysisModel = new AnalysisModel();
 	if (theTest == 0)
 	    theTest = new CTestNormUnbalance(1.0e-6,25,0);
+	if (theAlgorithm != 0) {
+	    theAlgorithm->setConvergenceTest(theTest);
+	}
 	if (theAlgorithm == 0) {
 	    theAlgorithm = new NewtonRaphson(*theTest);
 	}
@@ -598,6 +601,9 @@ OpenSeesCommands::setStaticAnalysis(bool suppress)
     if (theTest == 0) {
 	theTest = new CTestNormUnbalance(1.0e-6,25,0);
     }
+    if (theAlgorithm != 0) {
+	theAlgorithm->setConvergenceTest(theTest);
+    }
     if (theAlgorithm == 0) {
       if (!suppress) {
 	opserr << "WARNING analysis Static - no Algorithm yet specified, \n";
@@ -704,6 +710,9 @@ OpenSeesCommands::setPFEMAnalysis(bool suppress)
 	//theTest = new CTestNormUnbalance(1e-2,10000,1,2,3);
 	theTest = new CTestPFEM(1e-2,1e-2,1e-2,1e-2,1e-4,1e-3,10000,100,1,2);
     }
+    if (theAlgorithm != 0) {
+	theAlgorithm->setConvergenceTest(theTest);
+    }
     if(theAlgorithm == 0) {
 	theAlgorithm = new NewtonRaphson(*theTest);
     }
@@ -766,6 +775,10 @@ OpenSeesCommands::setVariableAnalysis(bool suppress)
 
     if (theTest == 0) {
 	theTest = new CTestNormUnbalance(1.0e-6,25,0);
+    }
+
+    if (theAlgorithm != 0) {
+	theAlgorithm->setConvergenceTest(theTest);
     }
 
     if (theAlgorithm == 0) {
@@ -849,6 +862,9 @@ OpenSeesCommands::setTransientAnalysis(bool suppress)
     }
     if (theTest == 0) {
 	theTest = new CTestNormUnbalance(1.0e-6,25,0);
+    }
+    if (theAlgorithm != 0) {
+	theAlgorithm->setConvergenceTest(theTest);
     }
     if (theAlgorithm == 0) {
       if (!suppress) {
@@ -1889,6 +1905,10 @@ int OPS_Algorithm()
     } else if (strcmp(type, "ModifiedNewton") == 0) {
 	theAlgo = (EquiSolnAlgo*) OPS_ModifiedNewton();
 
+    } else if ((strcmp(type, "NewtonHallM") == 0)
+	       || (strcmp(type, "NewtonHall") == 0)) {
+	theAlgo = (EquiSolnAlgo*) OPS_NewtonHallM();
+
     } else if (strcmp(type, "KrylovNewton") == 0) {
 	theAlgo = (EquiSolnAlgo*) OPS_KrylovNewton();
 
@@ -2654,395 +2674,6 @@ int OPS_printModel()
     // close the output file
     outputFile.close();
     return res;
-}
-
-void* OPS_KrylovNewton()
-{
-    if (cmds == 0) return 0;
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag,"-iterate") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		iterateTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		iterateTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		iterateTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-increment") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		incrementTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		incrementTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		incrementTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-maxDim") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    maxDim = atoi(flag);
-	    int numdata = 1;
-	    if (OPS_GetIntInput(&numdata, &maxDim) < 0) {
-		opserr<< "WARNING KrylovNewton failed to read maxDim\n";
-		return 0;
-	    }
-	}
-    }
-
-    ConvergenceTest* theTest = cmds->getCTest();
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return 0;
-    }
-
-    Accelerator *theAccel;
-    theAccel = new KrylovAccelerator(maxDim, iterateTangent);
-
-    return new AcceleratedNewton(*theTest, theAccel, incrementTangent);
-}
-
-void* OPS_RaphsonNewton()
-{
-    if (cmds == 0) return 0;
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag,"-iterate") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		iterateTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		iterateTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		iterateTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-increment") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		incrementTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		incrementTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		incrementTangent = NO_TANGENT;
-	    }
-	}
-    }
-
-    ConvergenceTest* theTest = cmds->getCTest();
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return 0;
-    }
-
-    Accelerator *theAccel;
-    theAccel = new RaphsonAccelerator(iterateTangent);
-
-    return new AcceleratedNewton(*theTest, theAccel, incrementTangent);
-}
-
-void* OPS_MillerNewton()
-{
-    if (cmds == 0) return 0;
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag,"-iterate") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		iterateTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		iterateTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		iterateTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-increment") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		incrementTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		incrementTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		incrementTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-maxDim") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    maxDim = atoi(flag);
-	    int numdata = 1;
-	    if (OPS_GetIntInput(&numdata, &maxDim) < 0) {
-		opserr<< "WARNING KrylovNewton failed to read maxDim\n";
-		return 0;
-	    }
-	}
-    }
-
-    ConvergenceTest* theTest = cmds->getCTest();
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return 0;
-    }
-
-    Accelerator *theAccel = 0;
-    return new AcceleratedNewton(*theTest, theAccel, incrementTangent);
-}
-
-void* OPS_SecantNewton()
-{
-    if (cmds == 0) return 0;
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    int numTerms = 2;
-    bool cutOut = false;
-    double R[2];
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag,"-iterate") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		iterateTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		iterateTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		iterateTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-increment") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		incrementTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		incrementTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		incrementTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-maxDim") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    int numdata = 1;
-	    if (OPS_GetIntInput(&numdata, &maxDim) < 0) {
-		opserr<< "WARNING SecantNewton failed to read maxDim\n";
-		return 0;
-	    }
-	} else if (strcmp(flag,"-numTerms") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    int numdata = 1;
-	    if (OPS_GetIntInput(&numdata, &numTerms) < 0) {
-		opserr<< "WARNING SecantNewton failed to read maxDim\n";
-		return 0;
-	    }
-	} else if ((strcmp(flag,"-cutOut") == 0 || strcmp(flag,"-cutout") == 0)
-		   && OPS_GetNumRemainingInputArgs() > 1) {
-	  int numdata = 2;
-	  if (OPS_GetDoubleInput(&numdata, R) < 0) {
-	    opserr << "WARNING SecantNewton failed to read cutOut values R1 and R2" << endln;
-	    return 0;
-	  }
-	  cutOut = true;
-	}
-    }
-
-    ConvergenceTest* theTest = cmds->getCTest();
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return 0;
-    }
-
-    Accelerator *theAccel = 0;
-    if (numTerms <= 1)
-      if (cutOut)
-	theAccel = new SecantAccelerator1(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator1(maxDim, iterateTangent);
-    if (numTerms >= 3)
-      if (cutOut)
-	theAccel = new SecantAccelerator3(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator3(maxDim, iterateTangent);
-    if (numTerms == 2)
-      if (cutOut)
-	theAccel = new SecantAccelerator2(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator2(maxDim, iterateTangent);            
-
-    return new AcceleratedNewton(*theTest, theAccel, incrementTangent);
-}
-
-void* OPS_PeriodicNewton()
-{
-    if (cmds == 0) return 0;
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag,"-iterate") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		iterateTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		iterateTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		iterateTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-increment") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2,"current") == 0) {
-		incrementTangent = CURRENT_TANGENT;
-	    }
-	    if (strcmp(flag2,"initial") == 0) {
-		incrementTangent = INITIAL_TANGENT;
-	    }
-	    if (strcmp(flag2,"noTangent") == 0) {
-		incrementTangent = NO_TANGENT;
-	    }
-	} else if (strcmp(flag,"-maxDim") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    maxDim = atoi(flag);
-	    int numdata = 1;
-	    if (OPS_GetIntInput(&numdata, &maxDim) < 0) {
-		opserr<< "WARNING KrylovNewton failed to read maxDim\n";
-		return 0;
-	    }
-	}
-    }
-
-    ConvergenceTest* theTest = cmds->getCTest();
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return 0;
-    }
-
-    Accelerator *theAccel;
-    theAccel = new PeriodicAccelerator(maxDim, iterateTangent);
-
-    return new AcceleratedNewton(*theTest, theAccel, incrementTangent);
-}
-
-void* OPS_NewtonLineSearch()
-{
-    if (cmds == 0) return 0;
-    ConvergenceTest* theTest = cmds->getCTest();
-
-    if (theTest == 0) {
-	opserr << "ERROR: No ConvergenceTest yet specified\n";
-	return 0;
-    }
-
-    // set some default variable
-    double tol        = 0.8;
-    int    maxIter    = 10;
-    double maxEta     = 10.0;
-    double minEta     = 0.1;
-    int    pFlag      = 1;
-    int    typeSearch = 0;
-
-    int numdata = 1;
-
-    while (OPS_GetNumRemainingInputArgs() > 0) {
-	const char* flag = OPS_GetString();
-
-	if (strcmp(flag, "-tol") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    if (OPS_GetDoubleInput(&numdata, &tol) < 0) {
-		opserr << "WARNING NewtonLineSearch failed to read tol\n";
-		return 0;
-	    }
-
-	} else if (strcmp(flag, "-maxIter") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    if (OPS_GetIntInput(&numdata, &maxIter) < 0) {
-		opserr << "WARNING NewtonLineSearch failed to read maxIter\n";
-		return 0;
-	    }
-
-	} else if (strcmp(flag, "-pFlag") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    if (OPS_GetIntInput(&numdata, &pFlag) < 0) {
-		opserr << "WARNING NewtonLineSearch failed to read pFlag\n";
-		return 0;
-	    }
-
-	} else if (strcmp(flag, "-minEta") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    if (OPS_GetDoubleInput(&numdata, &minEta) < 0) {
-		opserr << "WARNING NewtonLineSearch failed to read minEta\n";
-		return 0;
-	    }
-
-	} else if (strcmp(flag, "-maxEta") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-
-	    if (OPS_GetDoubleInput(&numdata, &maxEta) < 0) {
-		opserr << "WARNING NewtonLineSearch failed to read maxEta\n";
-		return 0;
-	    }
-
-	} else if (strcmp(flag, "-type") == 0 && OPS_GetNumRemainingInputArgs()>0) {
-	    const char* flag2 = OPS_GetString();
-
-	    if (strcmp(flag2, "Bisection") == 0)
-		typeSearch = 1;
-	    else if (strcmp(flag2, "Secant") == 0)
-		typeSearch = 2;
-	    else if (strcmp(flag2, "RegulaFalsi") == 0)
-		typeSearch = 3;
-	    else if (strcmp(flag2, "LinearInterpolated") == 0)
-		typeSearch = 3;
-	    else if (strcmp(flag2, "InitialInterpolated") == 0)
-		typeSearch = 0;
-	}
-    }
-
-    LineSearch *theLineSearch = 0;
-    if (typeSearch == 0)
-	theLineSearch = new InitialInterpolatedLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-
-    else if (typeSearch == 1)
-	theLineSearch = new BisectionLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-    else if (typeSearch == 2)
-	theLineSearch = new SecantLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-    else if (typeSearch == 3)
-	theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-
-    return new NewtonLineSearch(*theTest, theLineSearch);
 }
 
 int OPS_getCTestNorms()

--- a/SRC/interpreter/OpenSeesCommands.h
+++ b/SRC/interpreter/OpenSeesCommands.h
@@ -579,6 +579,7 @@ void* OPS_ExplicitDifference();
 void* OPS_LinearAlgorithm();
 void* OPS_NewtonRaphsonAlgorithm();
 void* OPS_ModifiedNewton();
+void* OPS_NewtonHallM();
 void* OPS_Broyden();
 void* OPS_BFGS();
 

--- a/SRC/runtime/commands/analysis/algorithm.cpp
+++ b/SRC/runtime/commands/analysis/algorithm.cpp
@@ -410,9 +410,13 @@ TclCommand_newNewtonLineSearch(ClientData clientData, Tcl_Interp *interp, Tcl_Si
   double minEta = 0.1;
   int pFlag = 1;
   int typeSearch = 0;
+  int factorOnce = 0;
 
   for (int i=2; i<argc; i++) {
-    if (strcmp(argv[i], "-tol") == 0) {
+    if (strcmp(argv[i], "-factorOnce") == 0 || strcmp(argv[i], "-factoronce") == 0
+        || strcmp(argv[i], "-FactorOnce") == 0) {
+      factorOnce = 1;
+    } else if (strcmp(argv[i], "-tol") == 0) {
       if (++i >= argc) {
         opserr << OpenSees::PromptValueError 
                << "Flag -tol requires follow up argument\n";
@@ -569,7 +573,7 @@ TclCommand_newNewtonLineSearch(ClientData clientData, Tcl_Interp *interp, Tcl_Si
     theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
 
 
-  builder->set(new NewtonLineSearch(theLineSearch));
+  builder->set(new NewtonLineSearch(theLineSearch, factorOnce));
   return TCL_OK;
 }
 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -157,25 +157,7 @@ extern "C" int         OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp
 #include <ModifiedNewton.h>
 #include <Broyden.h>
 #include <BFGS.h>
-#include <KrylovNewton.h>
-#include <PeriodicNewton.h>
-#include <AcceleratedNewton.h>
 #include <ExpressNewton.h>
-
-// accelerators
-#include <RaphsonAccelerator.h>
-#include <PeriodicAccelerator.h>
-#include <KrylovAccelerator.h>
-#include <SecantAccelerator1.h>
-#include <SecantAccelerator2.h>
-#include <SecantAccelerator3.h>
-//#include <MillerAccelerator.h>
-
-// line searches
-#include <BisectionLineSearch.h>
-#include <InitialInterpolatedLineSearch.h>
-#include <RegulaFalsiLineSearch.h>
-#include <SecantLineSearch.h>
 
 // constraint handlers
 #include <PlainHandler.h>
@@ -215,6 +197,15 @@ extern void *OPS_NewtonRaphsonAlgorithm(void);
 extern void *OPS_ExpressNewton(void);
 extern void *OPS_ModifiedNewton(void);
 extern void *OPS_NewtonHallM(void);
+extern void *OPS_KrylovNewton(void);
+extern void *OPS_RaphsonNewton(void);
+extern void *OPS_MillerNewton(void);
+extern void *OPS_SecantNewton(void);
+extern void *OPS_PeriodicNewton(void);
+extern void *OPS_LinearAlgorithm(void);
+extern void *OPS_Broyden(void);
+extern void *OPS_BFGS(void);
+extern void *OPS_NewtonLineSearch(void);
 
 extern void *OPS_Newmark(void);
 extern void *OPS_StagedNewmark(void);
@@ -2585,6 +2576,9 @@ specifyAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 
 	if (theTest == 0) 
 	  theTest = new CTestNormUnbalance(1.0e-6,25,0);       
+
+	if (theAlgorithm != 0)
+	    theAlgorithm->setConvergenceTest(theTest);
 	
 	if (theAlgorithm == 0) {
 	    opserr << "WARNING analysis Static - no Algorithm yet specified, \n";
@@ -2675,6 +2669,8 @@ specifyAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
             //theTest = new CTestNormUnbalance(1e-2,10000,1,2,3);
             theTest = new CTestPFEM(1e-2,1e-2,1e-2,1e-2,1e-4,1e-3,10000,100,1,2);
         }
+        if (theAlgorithm != 0)
+            theAlgorithm->setConvergenceTest(theTest);
         if(theAlgorithm == 0) {
             theAlgorithm = new NewtonRaphson(*theTest);
         }
@@ -2711,6 +2707,9 @@ specifyAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 
 	if (theTest == 0) 
 	  theTest = new CTestNormUnbalance(1.0e-6,25,0);       
+
+	if (theAlgorithm != 0)
+	    theAlgorithm->setConvergenceTest(theTest);
 	
 	if (theAlgorithm == 0) {
 	    opserr << "WARNING analysis Transient - no Algorithm yet specified, \n";
@@ -2809,6 +2808,9 @@ specifyAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 
 	if (theTest == 0) 
 	  theTest = new CTestNormUnbalance(1.0e-6,25,0);       
+
+	if (theAlgorithm != 0)
+	    theAlgorithm->setConvergenceTest(theTest);
 	
 	if (theAlgorithm == 0) {
 	    opserr << "WARNING analysis Transient - no Algorithm yet specified, \n";
@@ -3917,20 +3919,12 @@ specifyAlgorithm(ClientData clientData, Tcl_Interp *interp, int argc,
 
   // check argv[1] for type of Algorithm and create the object
   if (strcmp(argv[1],"Linear") == 0) {
-    int formTangent = CURRENT_TANGENT;
-    int factorOnce = 0;
-    int count = 2;
-    while (count < argc) {
-      if ((strcmp(argv[count],"-secant") == 0) || (strcmp(argv[count],"-Secant") == 0)) {
-	formTangent = CURRENT_SECANT;
-      } else if ((strcmp(argv[count],"-initial") == 0) || (strcmp(argv[count],"-Initial") == 0)) {
-	formTangent = INITIAL_TANGENT;
-      } else if ((strcmp(argv[count],"-factorOnce") == 0) || (strcmp(argv[count],"-FactorOnce") ==0 )) {
-	factorOnce = 1;
-      }
-      count++;
-    }
-    theNewAlgo = new Linear(formTangent, factorOnce);
+    void *theLinearAlgo = OPS_LinearAlgorithm();
+    if (theLinearAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theLinearAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"Newton") == 0) {
@@ -3964,348 +3958,75 @@ specifyAlgorithm(ClientData clientData, Tcl_Interp *interp, int argc,
   }
 
   else if (strcmp(argv[1],"KrylovNewton") == 0) {
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-iterate") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  iterateTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  iterateTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  iterateTangent = NO_TANGENT;
-      } 
-      else if (strcmp(argv[i],"-increment") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  incrementTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  incrementTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  incrementTangent = NO_TANGENT;
-      }
-      else if (strcmp(argv[i],"-maxDim") == 0 && i+1 < argc) {
-	i++;
-	maxDim = atoi(argv[i]);
-      }
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    Accelerator *theAccel;
-    theAccel = new KrylovAccelerator(maxDim, iterateTangent);
-
-    theNewAlgo = new AcceleratedNewton(*theTest, theAccel, incrementTangent);
+    void *theAccelAlgo = OPS_KrylovNewton();
+    if (theAccelAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theAccelAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"RaphsonNewton") == 0) {
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-iterate") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  iterateTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  iterateTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  iterateTangent = NO_TANGENT;
-      } 
-      else if (strcmp(argv[i],"-increment") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  incrementTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  incrementTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  incrementTangent = NO_TANGENT;
-      }
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    Accelerator *theAccel;
-    theAccel = new RaphsonAccelerator(iterateTangent);
-
-    theNewAlgo = new AcceleratedNewton(*theTest, theAccel, incrementTangent);
+    void *theAccelAlgo = OPS_RaphsonNewton();
+    if (theAccelAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theAccelAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"MillerNewton") == 0) {
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-iterate") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  iterateTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  iterateTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  iterateTangent = NO_TANGENT;
-      } 
-      else if (strcmp(argv[i],"-increment") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  incrementTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  incrementTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  incrementTangent = NO_TANGENT;
-      }
-      else if (strcmp(argv[i],"-maxDim") == 0 && i+1 < argc) {
-	i++;
-	maxDim = atoi(argv[i]);
-      }
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    Accelerator *theAccel = 0;
-    //theAccel = new MillerAccelerator(maxDim, 0.01, iterateTangent);
-
-    theNewAlgo = new AcceleratedNewton(*theTest, theAccel, incrementTangent);
+    void *theAccelAlgo = OPS_MillerNewton();
+    if (theAccelAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theAccelAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"SecantNewton") == 0) {
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    int numTerms = 2;
-    bool cutOut = false;
-    double R[2];
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-iterate") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  iterateTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  iterateTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  iterateTangent = NO_TANGENT;
-      } 
-      else if (strcmp(argv[i],"-increment") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  incrementTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  incrementTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  incrementTangent = NO_TANGENT;
-      }
-      else if (strcmp(argv[i],"-maxDim") == 0 && i+1 < argc) {
-	i++;
-	maxDim = atoi(argv[i]);
-      }
-      else if (strcmp(argv[i],"-numTerms") == 0 && i+1 < argc) {
-	i++;
-	numTerms = atoi(argv[i]);
-      }
-      else if ((strcmp(argv[i],"-cutOut") ==0 || strcmp(argv[i],"-cutout") == 0) && i+2 < argc) {
-	i++;
-	R[0] = atof(argv[i]);
-	i++;
-	R[1] = atof(argv[i]);
-	cutOut = true;
-      }         
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    Accelerator *theAccel = 0;
-    if (numTerms <= 1)
-      if (cutOut)
-	theAccel = new SecantAccelerator1(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator1(maxDim, iterateTangent);
-    if (numTerms >= 3)
-      if (cutOut)
-	theAccel = new SecantAccelerator3(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator3(maxDim, iterateTangent);
-    if (numTerms == 2)
-      if (cutOut)
-	theAccel = new SecantAccelerator2(maxDim, iterateTangent, R[0], R[1]);
-      else
-	theAccel = new SecantAccelerator2(maxDim, iterateTangent);            
-
-    theNewAlgo = new AcceleratedNewton(*theTest, theAccel, incrementTangent);
+    void *theAccelAlgo = OPS_SecantNewton();
+    if (theAccelAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theAccelAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"PeriodicNewton") == 0) {
-    int incrementTangent = CURRENT_TANGENT;
-    int iterateTangent = CURRENT_TANGENT;
-    int maxDim = 3;
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-iterate") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  iterateTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  iterateTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  iterateTangent = NO_TANGENT;
-      } 
-      else if (strcmp(argv[i],"-increment") == 0 && i+1 < argc) {
-	i++;
-	if (strcmp(argv[i],"current") == 0)
-	  incrementTangent = CURRENT_TANGENT;
-	if (strcmp(argv[i],"initial") == 0)
-	  incrementTangent = INITIAL_TANGENT;
-	if (strcmp(argv[i],"noTangent") == 0)
-	  incrementTangent = NO_TANGENT;
-      }
-      else if (strcmp(argv[i],"-maxDim") == 0 && i+1 < argc) {
-	i++;
-	maxDim = atoi(argv[i]);
-      }
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    Accelerator *theAccel;
-    theAccel = new PeriodicAccelerator(maxDim, iterateTangent); 
-
-    theNewAlgo = new AcceleratedNewton(*theTest, theAccel, incrementTangent);
+    void *theAccelAlgo = OPS_PeriodicNewton();
+    if (theAccelAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theAccelAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"Broyden") == 0) {
-    int formTangent = CURRENT_TANGENT;
-    int count = -1;
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-secant") == 0) {
-	formTangent = CURRENT_SECANT;
-      } else if (strcmp(argv[i],"-initial") == 0) {
-	formTangent = INITIAL_TANGENT;
-      } else if (strcmp(argv[i++],"-count") == 0 && i < argc) {
-	count = atoi(argv[i]);
-      }
-    }
-
-    if (count == -1)
-      theNewAlgo = new Broyden(*theTest, formTangent); 
-    else
-      theNewAlgo = new Broyden(*theTest, formTangent, count); 
+    void *theBroydenAlgo = OPS_Broyden();
+    if (theBroydenAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theBroydenAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"BFGS") == 0) {
-    int formTangent = CURRENT_TANGENT;
-    int count = -1;
-    for (int i = 2; i < argc; i++) {
-      if (strcmp(argv[i],"-secant") == 0) {
-	formTangent = CURRENT_SECANT;
-      } else if (strcmp(argv[i],"-initial") == 0) {
-	formTangent = INITIAL_TANGENT;
-      } else if (strcmp(argv[i++],"-count") == 0 && i < argc) {
-	count = atoi(argv[i]);
-      }
-    }
-
-    if (theTest == 0) {
-      opserr << "ERROR: No ConvergenceTest yet specified\n";
-      return TCL_ERROR;	  
-    }
-
-    if (count == -1)
-      theNewAlgo = new BFGS(*theTest, formTangent); 
-    else
-      theNewAlgo = new BFGS(*theTest, formTangent, count); 
+    void *theBFGSAlgo = OPS_BFGS();
+    if (theBFGSAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theBFGSAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
-  
+
   else if (strcmp(argv[1],"NewtonLineSearch") == 0) {
-      if (theTest == 0) {
-	  opserr << "ERROR: No ConvergenceTest yet specified\n";
-	  return TCL_ERROR;	  
-      }
-
-      int    count = 2;
-      
-      // set some default variable
-      double tol        = 0.8;
-      int    maxIter    = 10;
-      double maxEta     = 10.0;
-      double minEta     = 0.1;
-      int    pFlag      = 1;
-      int    typeSearch = 0;
-      
-      while (count < argc) {
-	if (strcmp(argv[count], "-tol") == 0) {
-	  count++;
-	  if (Tcl_GetDouble(interp, argv[count], &tol) != TCL_OK)	
-	    return TCL_ERROR;	      	  
-	  count++;
-	} else if (strcmp(argv[count], "-maxIter") == 0) {
-	  count++;
-	  if (Tcl_GetInt(interp, argv[count], &maxIter) != TCL_OK)	
-	    return TCL_ERROR;	      	  
-	  count++;	  
-	} else if (strcmp(argv[count], "-pFlag") == 0) {
-	  count++;
-	  if (Tcl_GetInt(interp, argv[count], &pFlag) != TCL_OK)	
-	    return TCL_ERROR;	      	  
-	  count++;
-	} else if (strcmp(argv[count], "-minEta") == 0) {
-	  count++;
-	  if (Tcl_GetDouble(interp, argv[count], &minEta) != TCL_OK)	
-	    return TCL_ERROR;	      	  
-	  count++;
-	} else if (strcmp(argv[count], "-maxEta") == 0) {
-	  count++;
-	  if (Tcl_GetDouble(interp, argv[count], &maxEta) != TCL_OK)	
-	    return TCL_ERROR;	      	  
-	  count++;
-	} else if (strcmp(argv[count], "-type") == 0) {
-	  count++;
-	  if (strcmp(argv[count], "Bisection") == 0) 
-	    typeSearch = 1;
-	  else if (strcmp(argv[count], "Secant") == 0) 
-	    typeSearch = 2;
-	  else if (strcmp(argv[count], "RegulaFalsi") == 0) 
-	    typeSearch = 3;
-	  else if (strcmp(argv[count], "LinearInterpolated") == 0) 
-	    typeSearch = 3;
-	  else if (strcmp(argv[count], "InitialInterpolated") == 0) 
-	    typeSearch = 0;
-	  count++;
-	} else
-	  count++;
-      }
-      
-      LineSearch *theLineSearch = 0;      
-      if (typeSearch == 0)
-	theLineSearch = new InitialInterpolatedLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-							  
-      else if (typeSearch == 1)
-	theLineSearch = new BisectionLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-      else if (typeSearch == 2)
-	theLineSearch = new SecantLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-      else if (typeSearch == 3)
-	theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-
-      theNewAlgo = new NewtonLineSearch(*theTest, theLineSearch); 
+    void *theNLSAlgo = OPS_NewtonLineSearch();
+    if (theNLSAlgo == 0)
+      return TCL_ERROR;
+    theNewAlgo = (EquiSolnAlgo *)theNLSAlgo;
+    if (theTest != 0)
+      theNewAlgo->setConvergenceTest(theTest);
   }
 
   else if (strcmp(argv[1],"ExpressNewton") == 0) {
@@ -5816,6 +5537,8 @@ eigenAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 	    theAnalysisModel = new AnalysisModel();
 	if (theTest == 0) 
 	  theTest = new CTestNormUnbalance(1.0e-6,25,0);       
+	if (theAlgorithm != 0)
+	    theAlgorithm->setConvergenceTest(theTest);
 	if (theAlgorithm == 0) {
 	  theAlgorithm = new NewtonRaphson(*theTest); 
 	}


### PR DESCRIPTION
This PR aims to improve a bit the efficiency of the Newton family of algorithms. Many files are touched, but the changes are conceptually small: it is mostly reorganization and parsing around how these solvers are built and how -factorOnce is interpreted.

Changes include:

1. Add -factorOnce support across the Newton family (Newton, Modified, Express, Accelerated, NewtonLineSearch). After the stiffness is formed and factored once, later Newton iterations in the same equilibrium solve reuse that factorization; reuse can continue across subsequent solves until something triggers a full domainChanged() path (for example nodes/elements added or removed, or anything that changes the equation system so the old factors are invalid). Then we form and factor again so the linear system size and storage stay consistent.
2. Accelerated Newton: -factorOnce is tied to forming the increment tangent once. If the user’s combination of -increment and -iterate flags would be inconsistent with that, we warn and default to either -iterate noTangent or disabling -factorOnce, depending on the case.
3. If -initial is used as the increment/iterate tangent in the supported Newton-style paths, factorOnce is turned on automatically.
4. Consolidate Tcl/Python algorithm construction in OpenSeesCommands and tcl/commands so both paths call the same OPS_ factories.
5, Attach the default convergence test to the algorithm during analysis setup so the algorithm and the interpreter’s default test stay wired together consistently (you can set the algorithm and still rely on the usual default test behavior).
6. Fixed bug in SecantAccelerator3: the secant update used vStar after it had already been overwritten, so the inner products / differences were taken against the wrong vector.