### PR TITLE
Umfpack reuse numeric

### DIFF
--- a/SRC/api/CMakeLists.txt
+++ b/SRC/api/CMakeLists.txt
@@ -4,7 +4,15 @@
 #                Pacific Earthquake Engineering Research Center
 #
 #==============================================================================
-add_library(OPS_Api OBJECT)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  add_library(OPS_Api OBJECT)
+  target_sources(OPS_Api PRIVATE win32Functions.cpp)
+  target_include_directories(OPS_Api PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+else()
+  # Header-only on Unix; OBJECT needs at least one source file.
+  add_library(OPS_Api INTERFACE)
+  target_include_directories(OPS_Api INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+endif()
 
 target_sources(OPS_InterpTcl
   PRIVATE
@@ -13,22 +21,8 @@ target_sources(OPS_InterpTcl
 )
 
 target_sources(OPS_Api
-    PUBLIC
-        #elementAPI_Dummy.cpp
-        #win32Functions.cpp
-    PUBLIC
-        elementAPI.h
-        GenericDict.h
-	#packages.h
+  INTERFACE
+    elementAPI.h
+    GenericDict.h
 )
-
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-target_sources(OPS_Api PUBLIC
-        win32Functions.cpp
-)
-
-endif()
-
-target_include_directories(OPS_Api PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSOE.cpp
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSOE.cpp
@@ -48,14 +48,16 @@
 #include <ID.h>
 
 UmfpackGenLinSOE::UmfpackGenLinSOE(UmfpackGenLinSolver &the_Solver)
-    :LinearSOE(the_Solver, LinSOE_TAGS_UmfpackGenLinSOE), X(), B(), Ap(), Ai(), Ax()
+    :LinearSOE(the_Solver, LinSOE_TAGS_UmfpackGenLinSOE),
+     factored(false), X(), B(), Ap(), Ai(), Ax()
 {
     the_Solver.setLinearSOE(*this);
 }
 
 
 UmfpackGenLinSOE::UmfpackGenLinSOE()
-    :LinearSOE(LinSOE_TAGS_UmfpackGenLinSOE), X(), B(), Ap(), Ai(), Ax()
+    :LinearSOE(LinSOE_TAGS_UmfpackGenLinSOE),
+     factored(false), X(), B(), Ap(), Ai(), Ax()
 {
 }
 
@@ -133,6 +135,7 @@ UmfpackGenLinSOE::setSize(Graph &theGraph)
     }
 
     // invoke setSize() on the Solver
+    factored = false;
     LinearSOESolver *the_Solver = this->getSolver();
     int solverOK = the_Solver->setSize();
     if (solverOK < 0) {
@@ -280,6 +283,7 @@ void
 UmfpackGenLinSOE::zeroA(void)
 {
     Ax.assign(Ax.size(),0.0);
+    factored = false;
 }
 
 void

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSOE.h
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSOE.h
@@ -76,7 +76,8 @@ public:
     friend class UmfpackGenLinSolver;
 
 protected:
-    
+    bool factored;
+
 private:
     Vector X,B;
     std::vector<int> Ap, Ai;

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.cpp
@@ -67,12 +67,22 @@ UmfpackGenLinSolver(bool useLongIndices)
     : LinearSOESolver(SOLVER_TAGS_UmfpackGenLinSolver),
       useLongIndices(useLongIndices),
       Symbolic(0),
+      Numeric(0),
       theSOE(0)
 {
 }
 
 UmfpackGenLinSolver::~UmfpackGenLinSolver()
 {
+    if (Numeric != 0) {
+        if (useLongIndices) {
+#ifdef _UMFPACK_DLONG
+            umfpack_dl_free_numeric(&Numeric);
+#endif
+        } else {
+            umfpack_di_free_numeric(&Numeric);
+        }
+    }
     if (Symbolic != 0) {
         if (useLongIndices) {
 #ifdef _UMFPACK_DLONG
@@ -118,34 +128,30 @@ UmfpackGenLinSolver::solve(void)
         return -1;
     }
 
-    void* Numeric = 0;
-
     if (useLongIndices) {
 #ifdef _UMFPACK_DLONG
-        // numeric analysis
         SuiteSparse_long *Ap = Ap64.data();
         SuiteSparse_long *Ai = Ai64.data();
+
+        if (theSOE->factored == false) {
+            if (Numeric != 0) {
+                umfpack_dl_free_numeric(&Numeric);
+            }
+            SuiteSparse_long status =
+                umfpack_dl_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
+
+            if (status != UMFPACK_OK) {
+                opserr << "WARNING: numeric analysis returns "
+                       << static_cast<int>(status)
+                       << " -- Umfpackgenlinsolver::solve\n";
+                return -1;
+            }
+            theSOE->factored = true;
+        }
+
         SuiteSparse_long status =
-            umfpack_dl_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
-        
-        // check error
-        if (status != UMFPACK_OK) {
-            opserr << "WARNING: numeric analysis returns "
-                   << static_cast<int>(status)
-                   << " -- Umfpackgenlinsolver::solve\n";
-            return -1;
-        }
+            umfpack_dl_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control, Info);
 
-        // solve
-        status = umfpack_dl_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control,
-                                  Info);
-        
-        // delete Numeric
-        if (Numeric != 0) {
-            umfpack_dl_free_numeric(&Numeric);
-        }
-
-        // check error
         if (status != UMFPACK_OK) {
             opserr << "WARNING: solving returns " << static_cast<int>(status)
                    << " -- Umfpackgenlinsolver::solve\n";
@@ -153,30 +159,27 @@ UmfpackGenLinSolver::solve(void)
         }
 #endif
     } else {
-        // numeric analysis
         int *Ap = theSOE->Ap.data();
         int *Ai = theSOE->Ai.data();
+
+        if (theSOE->factored == false) {
+            if (Numeric != 0) {
+                umfpack_di_free_numeric(&Numeric);
+            }
+            int status =
+                umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
+
+            if (status != UMFPACK_OK) {
+                opserr << "WARNING: numeric analysis returns " << status
+                       << " -- Umfpackgenlinsolver::solve\n";
+                return -1;
+            }
+            theSOE->factored = true;
+        }
+
         int status =
-            umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
-        
-        
-        // check error
-        if (status != UMFPACK_OK) {
-            opserr << "WARNING: numeric analysis returns " << status
-                   << " -- Umfpackgenlinsolver::solve\n";
-            return -1;
-        }
+            umfpack_di_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control, Info);
 
-        // solve
-        status = umfpack_di_solve(UMFPACK_A, Ap, Ai, Ax, X, B, Numeric, Control,
-                                  Info);
-
-        // delete Numeric
-        if (Numeric != 0) {
-            umfpack_di_free_numeric(&Numeric);
-        }
-        
-        // check error
         if (status != UMFPACK_OK) {
             opserr << "WARNING: solving returns " << status
                    << " -- Umfpackgenlinsolver::solve\n";
@@ -195,7 +198,26 @@ UmfpackGenLinSolver::setSize()
     if (n == 0 || nnz == 0) {
         Ap64.clear();
         Ai64.clear();
+        if (Numeric != 0) {
+            if (useLongIndices) {
+#ifdef _UMFPACK_DLONG
+                umfpack_dl_free_numeric(&Numeric);
+#endif
+            } else {
+                umfpack_di_free_numeric(&Numeric);
+            }
+        }
         return 0;
+    }
+
+    if (Numeric != 0) {
+        if (useLongIndices) {
+#ifdef _UMFPACK_DLONG
+            umfpack_dl_free_numeric(&Numeric);
+#endif
+        } else {
+            umfpack_di_free_numeric(&Numeric);
+        }
     }
 
     if (useLongIndices) {

--- a/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.h
+++ b/SRC/system_of_eqn/linearSOE/umfGEN/UmfpackGenLinSolver.h
@@ -63,6 +63,7 @@ class UmfpackGenLinSolver : public LinearSOESolver
 
     bool useLongIndices;
     void *Symbolic;
+    void *Numeric;
     double Control[UMFPACK_CONTROL], Info[UMFPACK_INFO];
     UmfpackGenLinSOE *theSOE;
     std::vector<SuiteSparse_long> Ap64;


### PR DESCRIPTION
Repeatedly computing the numeric factorization made Umfpack much slower than necessary when used with Modified or Krylov Newton methods.