### PR TITLE
Add optional sanitizer CMake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,33 @@ set(CMAKE_FORTRAN_STANDARD 08)
 set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> cqls <TARGET> <LINK_FLAGS> <OBJECTS>")
 #add_compile_options(-g)
 
+option(OPS_ENABLE_ASAN "Build C/C++ targets with AddressSanitizer instrumentation" OFF)
+option(OPS_ENABLE_UBSAN "Build C/C++ targets with UndefinedBehaviorSanitizer instrumentation" OFF)
+
+if(OPS_ENABLE_ASAN OR OPS_ENABLE_UBSAN)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(FATAL_ERROR "OPS_ENABLE_ASAN and OPS_ENABLE_UBSAN are supported only with GNU or Clang compilers.")
+  endif()
+endif()
+
+if(OPS_ENABLE_ASAN)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:C>:-fsanitize=address>
+    $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=address>
+    $<$<COMPILE_LANGUAGE:C>:-fno-omit-frame-pointer>
+    $<$<COMPILE_LANGUAGE:CXX>:-fno-omit-frame-pointer>
+  )
+  add_link_options(-fsanitize=address)
+endif()
+
+if(OPS_ENABLE_UBSAN)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:C>:-fsanitize=undefined>
+    $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=undefined>
+  )
+  add_link_options(-fsanitize=undefined)
+endif()
+
 # Warnings
 #opensees_add_cxx_flag(
 #    GNU  -Wall

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ https://OpenSees.github.io/OpenSeesDocumentation
 Steps to build OpenSees on Windows, Linux, and Mac:
 https://opensees.github.io/OpenSeesDocumentation/developer/build.html
 
+### Optional Sanitizer Builds
+
+Developers using GNU or Clang compilers can enable runtime instrumentation while configuring CMake:
+
+```console
+cmake -S . -B build/asan -DOPS_ENABLE_ASAN=ON
+cmake -S . -B build/ubsan -DOPS_ENABLE_UBSAN=ON
+```
+
+These options are disabled by default and are intended for debugging memory and undefined-behavior issues.
+
 ## Modeling Questions
 Issues related to modeling questions will be closed. Instead, post your modeling questions on the OpenSees 
 message board or in the OpenSees Facebook group.


### PR DESCRIPTION
## Summary
- Adds opt-in CMake options for AddressSanitizer and UndefinedBehaviorSanitizer builds
- Applies sanitizer compile/link flags only when explicitly enabled
- Documents the new developer options in the README

## Motivation
These options provide a lightweight path for contributors to run memory and undefined-behavior checks while keeping default OpenSees builds unchanged.

## Testing
Local verification on macOS arm64 with AppleClang 21:
- Ran `git diff --check`
- Ran `conan profile detect --force`
- Ran `conan install . --build=missing`
- Configured a sanitizer build with `cmake -S . -B build/sanitize-release-check -DCMAKE_TOOLCHAIN_FILE=build/Release/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DPython_EXECUTABLE=/opt/homebrew/bin/python3.11 -DPython3_ROOT_DIR=/opt/homebrew/opt/python@3.11 -DOPS_ENABLE_ASAN=ON -DOPS_ENABLE_UBSAN=ON`
- Built the main target with `cmake --build build/sanitize-release-check --target OpenSees -j8`
- Smoke-tested the built binary with `TCL_LIBRARY` pointed at Conan's Tcl init directory: `build/sanitize-release-check/OpenSees --version`
