### PR TITLE
Expose METIS 5 mesh-partition controls in OpenSeesMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,25 +53,14 @@ find_package(MPI)
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
  MESSAGE("STATUS" "COMPILER: Clang (macOS Configuration)")
 
- set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+ if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+   set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING
+       "Minimum macOS version targeted by the build")
+ endif()
  set(BUILD_SHARED_LIBS OFF)
 
- # 1. Ask gfortran for the absolute path to the static (.a) files
- execute_process(COMMAND gfortran --print-file-name=libgfortran.a OUTPUT_VARIABLE GF_STATIC OUTPUT_STRIP_TRAILING_WHITESPACE)
- execute_process(COMMAND gfortran --print-file-name=libquadmath.a OUTPUT_VARIABLE QM_STATIC OUTPUT_STRIP_TRAILING_WHITESPACE)
- execute_process(COMMAND gfortran --print-file-name=libgcc.a OUTPUT_VARIABLE GCC_STATIC OUTPUT_STRIP_TRAILING_WHITESPACE)
-
- # 2. CLEAR THE IMPLICIT DYNAMIC FLAGS
- # This prevents CMake from adding '-lgfortran -lquadmath' to the end of the command
- set(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "")
-
- # 3. Force the linker to use these specific archive files
- # link_libraries applies to all targets created after this line
- link_libraries("${GF_STATIC}" "${QM_STATIC}" "${GCC_STATIC}")
-    
- # Optional: ensure we search for static libs first for other dependencies
- set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dylib")
- # set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+ # Use the Fortran runtime selected by CMake's toolchain. Injecting static GCC
+ # runtimes into every C++ target can conflict with MPI and Tcl on macOS.
  set(BUILD_SHARED_LIBS OFF)
  # set(CMAKE_EXE_LINKER_FLAGS "-static")
 
@@ -429,6 +418,7 @@ endif()
 if(MPI_FOUND)
   message(STATUS "MPI was found.")
   message(STATUS "MPI was found .. path added ${MPI_C_INCLUDE_DIRS} ${MPI_FOUND}")
+  find_package(METIS 5 REQUIRED)
   include_directories(SYSTEM ${MPI_C_INCLUDE_DIRS})
   #add_subdirectory("${PROJECT_SOURCE_DIR}/OTHER/MUMPS_5.4.1")
   #if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -540,6 +530,15 @@ add_library(OPS_MaterialFortran    OBJECT)
 add_library(OPS_Damage             OBJECT)
 add_library(OPS_Database           OBJECT)
 add_library(OPS_INTERPRETER        OBJECT)
+
+# Build the METIS mesh-partitioning command whenever MPI is available.  The
+# interpreter object library is shared by the serial and MPI executables, so
+# this feature cannot depend on a compile definition set only on OpenSeesMP.
+if(MPI_FOUND)
+    target_compile_definitions(OPS_INTERPRETER PRIVATE OPS_PARTITION_WITH_METIS)
+    target_include_directories(OPS_INTERPRETER BEFORE PRIVATE ${METIS_INCLUDES})
+    target_link_libraries(OPS_INTERPRETER PUBLIC MPI::MPI_CXX ${METIS_LIBRARIES})
+endif()
 
 
 
@@ -702,7 +701,7 @@ target_link_libraries(OpenSees
   OPS_Recorder
   ${CMAKE_DL_LIBS}
   HDF5::HDF5
-  tcl::tcl
+  ${TCL_LIBRARIES}
   ZLIB::ZLIB
   Eigen3::Eigen
 )
@@ -726,16 +725,21 @@ if(MPI_FOUND)
       ${OPS_SRC_DIR}/actor/machineBroker/MPI_MachineBroker.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/diagonal/MPIDiagonalSOE.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/diagonal/MPIDiagonalSolver.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSOE.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/sparseGEN/DistributedSparseGenColLinSOE.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/sparseGEN/DistributedSparseGenRowLinSOE.cpp
       ${OPS_SRC_DIR}/domain/subdomain/ActorSubdomain.cpp
       ${OPS_SRC_DIR}/domain/subdomain/ShadowSubdomain.cpp
     )
+
+    if(MUMPS_DIR)
+      target_sources(OpenSeesSP PRIVATE
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSOE.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
+      )
+    endif()
 
 
     target_include_directories(OpenSeesSP PRIVATE ${MUMPS_DIR}/_deps/mumps-src/include ${MPI_CXX_INCLUDE_DIRS})
@@ -761,7 +765,7 @@ if(MPI_FOUND)
        ${MUMPS_LIBRARIES}
        ${CMAKE_DL_LIBS}
        HDF5::HDF5
-       tcl::tcl
+       ${TCL_LIBRARIES}
        ZLIB::ZLIB
        Eigen3::Eigen
        ${MPI_CXX_LIBRARIES}
@@ -790,19 +794,24 @@ if(MPI_FOUND)
       ${OPS_SRC_DIR}/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/diagonal/MPIDiagonalSOE.cpp
       ${OPS_SRC_DIR}/system_of_eqn/linearSOE/diagonal/MPIDiagonalSolver.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSOE.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.cpp
-      ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
       ${OPS_SRC_DIR}/domain/subdomain/ActorSubdomain.cpp
       ${OPS_SRC_DIR}/domain/subdomain/ShadowSubdomain.cpp
     )
+
+    if(MUMPS_DIR)
+      target_sources(OpenSeesMP PRIVATE
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSOE.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsSolver.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSOE.cpp
+        ${OPS_SRC_DIR}/system_of_eqn/linearSOE/mumps/MumpsParallelSolver.cpp
+      )
+    endif()
 
     target_include_directories(OpenSeesMP PRIVATE ${MUMPS_DIR}/_deps/mumps-src/include ${MPI_CXX_INCLUDE_DIRS})
 
     target_compile_options(OpenSeesMP PRIVATE ${MPI_CXX_COMPILE_FLAGS})
 
-    if (NOT DEFINED MUMPS_DIR)
+    if (TARGET mumps)
         add_dependencies(OpenSeesMP mumps)
     endif()
 
@@ -820,13 +829,13 @@ if(MPI_FOUND)
        OPS_Reliability
        OPS_ReliabilityTcl
        OPS_Recorder
-       METIS
+       ${METIS_LIBRARIES}
        SUPERLU_DIST
        OPS_Numerics
        ${MUMPS_LIBRARIES}
        ${CMAKE_DL_LIBS}
        HDF5::HDF5
-       tcl::tcl	
+       ${TCL_LIBRARIES}
        ZLIB::ZLIB		
        Eigen3::Eigen
        ${MPI_CXX_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,8 +535,10 @@ add_library(OPS_INTERPRETER        OBJECT)
 # interpreter object library is shared by the serial and MPI executables, so
 # this feature cannot depend on a compile definition set only on OpenSeesMP.
 if(MPI_FOUND)
-    target_compile_definitions(OPS_INTERPRETER PRIVATE OPS_PARTITION_WITH_METIS)
-    target_include_directories(OPS_INTERPRETER BEFORE PRIVATE ${METIS_INCLUDES})
+    target_compile_definitions(OPS_INTERPRETER PRIVATE
+        OPS_PARTITION_WITH_METIS
+        OPS_METIS_HEADER="${METIS_INCLUDES}/metis.h"
+    )
     target_link_libraries(OPS_INTERPRETER PUBLIC MPI::MPI_CXX ${METIS_LIBRARIES})
 endif()
 
@@ -743,7 +745,7 @@ if(MPI_FOUND)
 
 
     target_include_directories(OpenSeesSP PRIVATE ${MUMPS_DIR}/_deps/mumps-src/include ${MPI_CXX_INCLUDE_DIRS})
-    target_compile_options(OpenSeesSP PRIVATE ${MPI_CXX_COMPILE_FLAGS})
+    target_compile_options(OpenSeesSP PRIVATE ${MPI_CXX_COMPILE_OPTIONS})
 
     if (DEFINED OPENMPI)
         target_compile_definitions(OpenSeesSP
@@ -809,7 +811,7 @@ if(MPI_FOUND)
 
     target_include_directories(OpenSeesMP PRIVATE ${MUMPS_DIR}/_deps/mumps-src/include ${MPI_CXX_INCLUDE_DIRS})
 
-    target_compile_options(OpenSeesMP PRIVATE ${MPI_CXX_COMPILE_FLAGS})
+    target_compile_options(OpenSeesMP PRIVATE ${MPI_CXX_COMPILE_OPTIONS})
 
     if (TARGET mumps)
         add_dependencies(OpenSeesMP mumps)

--- a/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
+++ b/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
@@ -15,6 +15,8 @@ command distributes its elements.
 
 ## Results
 
+### macOS / MPICH
+
 | Ranks | Objective | METIS value | Elements per rank | Sum | Maximum imbalance |
 |---:|---|---:|---|---:|---:|
 | 2 | volume | 42 | 832, 828 | 1,660 | 0.24% |
@@ -26,6 +28,21 @@ The four-rank volume run was repeated with seed 42 and produced the same
 objective value and per-rank element counts. An invalid objective was rejected
 on every rank with a Tcl error.
 
+### Ubuntu / Open MPI
+
+A clean Ubuntu 24.04 ARM64 build linked against Open MPI 4.1.6 and system
+METIS 5.1.0 passed the same six pytest cases. Its four-rank volume reference
+run produced objective value 113 and element counts 420, 419, 410, and 411
+(1.20% maximum imbalance).
+
+### Ubuntu / MPICH
+
+An independent Ubuntu build linked against MPICH 4.2.0 also passed all six
+cases. Ubuntu's ARM64 Hydra/PMIx package combination created singleton
+communicators even for a minimal MPI program, so that binary was launched by
+Open MPI's PMIx-aware launcher. The MPI implementation loaded by OpenSeesMP
+remained MPICH.
+
 ## Run
 
 ```sh
@@ -35,4 +52,13 @@ mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl cut 42
 ```
 
 OpenSeesMP now synchronizes ranks before `MPI_Finalize`, and all benchmark runs
-exit cleanly under MPICH after printing their final results.
+exit cleanly after printing their final results.
+
+The pytest launcher and executable can be selected without editing the test:
+
+```sh
+OPENSEESMP=/path/to/OpenSeesMP \
+MPIEXEC=/path/to/mpiexec \
+MPIEXEC_FLAGS="--oversubscribe" \
+python -m pytest -q tests/test_metis_partition_benchmark.py
+```

--- a/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
+++ b/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
@@ -1,0 +1,38 @@
+# OpenSeesMP METIS partition benchmark
+
+The benchmark constructs a 40-by-20 two-dimensional truss grid containing
+1,660 elements. Every MPI rank constructs the same model before the `partition`
+command distributes its elements.
+
+## Environment
+
+- macOS 26.5.2, Apple Silicon
+- OpenSees 3.8.0 (`098e28c`)
+- MPICH 5.0.1
+- METIS 5.1.0
+- Tcl 8.6.18
+- Release build targeting macOS 26.0
+
+## Results
+
+| Ranks | Objective | METIS value | Elements per rank | Sum | Maximum imbalance |
+|---:|---|---:|---|---:|---:|
+| 2 | volume | 42 | 832, 828 | 1,660 | 0.24% |
+| 4 | volume | 112 | 410, 417, 416, 417 | 1,660 | 0.48% |
+| 8 | volume | 186 | 209, 211, 208, 211, 211, 202, 211, 197 | 1,660 | 1.69% |
+| 4 | cut | 65 | 408, 411, 421, 420 | 1,660 | 1.45% |
+
+The four-rank volume run was repeated with seed 42 and produced the same
+objective value and per-rank element counts. An invalid objective was rejected
+on every rank with a Tcl error.
+
+## Run
+
+```sh
+export TCL_LIBRARY=/opt/homebrew/opt/tcl-tk@8/lib/tcl8.6
+mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl volume 42
+mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl cut 42
+```
+
+OpenSeesMP now synchronizes ranks before `MPI_Finalize`, and all benchmark runs
+exit cleanly under MPICH after printing their final results.

--- a/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
+++ b/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
@@ -31,17 +31,25 @@ on every rank with a Tcl error.
 ### Ubuntu / Open MPI
 
 A clean Ubuntu 24.04 ARM64 build linked against Open MPI 4.1.6 and system
-METIS 5.1.0 passed the same six pytest cases. Its four-rank volume reference
+METIS 5.1.0 passed all seven pytest cases. Its four-rank volume reference
 run produced objective value 113 and element counts 420, 419, 410, and 411
 (1.20% maximum imbalance).
 
 ### Ubuntu / MPICH
 
-An independent Ubuntu build linked against MPICH 4.2.0 also passed all six
+An independent Ubuntu build linked against MPICH 4.2.0 also passed all seven
 cases. Ubuntu's ARM64 Hydra/PMIx package combination created singleton
 communicators even for a minimal MPI program, so that binary was launched by
 Open MPI's PMIx-aware launcher. The MPI implementation loaded by OpenSeesMP
 remained MPICH.
+
+## Partition-state regression
+
+`metisPartitionState.tcl` adds a four-rank structural model that verifies
+partitioned state beyond element counts. It checks that element loads follow
+their owning elements, nodal mass remains on exactly one rank, floating fixed
+nodes retain their constraints and nodal loads, and mesh-to-floating plus
+floating-to-floating `equalDOF` constraints remain complete.
 
 ## Run
 

--- a/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
+++ b/EXAMPLES/ParallelModelMP/METIS_PARTITION_BENCHMARK.md
@@ -59,8 +59,8 @@ mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl volume 42
 mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl cut 42
 ```
 
-OpenSeesMP now synchronizes ranks before `MPI_Finalize`, and all benchmark runs
-exit cleanly after printing their final results.
+All benchmark runs exit cleanly through `MPI_Finalize` after printing their
+final results.
 
 The pytest launcher and executable can be selected without editing the test:
 

--- a/EXAMPLES/ParallelModelMP/metisPartitionBenchmark.tcl
+++ b/EXAMPLES/ParallelModelMP/metisPartitionBenchmark.tcl
@@ -1,0 +1,46 @@
+# Reproducible METIS partition benchmark for OpenSeesMP.
+# Run with: mpiexec -n 4 OpenSeesMP metisPartitionBenchmark.tcl
+
+puts "METIS_BENCHMARK_START rank=[getPID] ranks=[getNP]"
+flush stdout
+
+model BasicBuilder -ndm 2 -ndf 2
+uniaxialMaterial Elastic 1 2.0e11
+
+set nx 40
+set ny 20
+set objective volume
+set seed 42
+if {$argc > 0} {
+    set objective [lindex $argv 0]
+}
+if {$argc > 1} {
+    set seed [lindex $argv 1]
+}
+set nodeTag 1
+for {set j 0} {$j <= $ny} {incr j} {
+    for {set i 0} {$i <= $nx} {incr i} {
+        node $nodeTag [expr {double($i)}] [expr {double($j)}]
+        incr nodeTag
+    }
+}
+
+set eleTag 1
+for {set j 0} {$j <= $ny} {incr j} {
+    for {set i 0} {$i < $nx} {incr i} {
+        set n1 [expr {$j * ($nx + 1) + $i + 1}]
+        element truss $eleTag $n1 [expr {$n1 + 1}] 0.01 1
+        incr eleTag
+    }
+}
+for {set j 0} {$j < $ny} {incr j} {
+    for {set i 0} {$i <= $nx} {incr i} {
+        set n1 [expr {$j * ($nx + 1) + $i + 1}]
+        element truss $eleTag $n1 [expr {$n1 + $nx + 1}] 0.01 1
+        incr eleTag
+    }
+}
+
+set totalBefore [getNumElements]
+partition -objective $objective -ncuts 4 -niter 20 -ufactor 30 -seed $seed -info
+puts "METIS_BENCHMARK rank=[getPID] ranks=[getNP] before=$totalBefore after=[getNumElements]"

--- a/EXAMPLES/ParallelModelMP/metisPartitionState.tcl
+++ b/EXAMPLES/ParallelModelMP/metisPartitionState.tcl
@@ -1,0 +1,51 @@
+# Regression model for partitioned loads, mass, floating nodes, and equalDOF.
+# Run with: mpiexec -n 4 OpenSeesMP metisPartitionState.tcl
+
+proc csv {values} {
+    return [join [lsort -integer $values] ,]
+}
+
+model BasicBuilder -ndm 2 -ndf 3
+geomTransf Linear 1
+
+# Five mesh nodes and four floating nodes exercise both METIS node ownership
+# and nodes that do not occur in the element connectivity.
+for {set tag 1} {$tag <= 5} {incr tag} {
+    node $tag [expr {double($tag - 1)}] 0.0
+}
+node 100 2.0 1.0
+node 101 5.0 0.0
+node 102 5.0 1.0
+node 103 6.0 0.0
+
+foreach tag {1 2 3 4 5 100 101 102 103} {
+    mass $tag [expr {double($tag)}] 0.0 0.0
+}
+
+for {set tag 1} {$tag <= 4} {incr tag} {
+    element elasticBeamColumn $tag $tag [expr {$tag + 1}] \
+        0.02 2.0e11 8.0e-6 1
+}
+
+# A mesh-to-floating pair must follow the mesh node on every rank where the
+# constraint is needed. A floating-to-floating pair must have one owner.
+equalDOF 3 100 1 2 3
+equalDOF 101 102 1 2 3
+fix 103 1 1 1
+
+timeSeries Linear 1
+pattern Plain 1 1 {
+    load 100 10.0 0.0 0.0
+    load 103 20.0 0.0 0.0
+    eleLoad -ele 1 2 3 4 -type -beamUniform -2.0 0.0
+}
+
+partition -objective volume -seed 42
+
+set localNodes [lsort -integer [getNodeTags]]
+set masses {}
+foreach tag $localNodes {
+    lappend masses "$tag:[format %.1f [nodeMass $tag 1]]"
+}
+
+puts "METIS_STATE rank=[getPID] ranks=[getNP] nodes=[csv $localNodes] elements=[csv [getEleTags]] eleloads=[csv [getEleLoadTags 1]] nodeloads=[csv [getNodeLoadTags 1]] fixed=[csv [getFixedNodes]] constrained=[csv [getConstrainedNodes]] mp100=[csv [getRetainedNodes 100]] mp102=[csv [getRetainedNodes 102]] masses=[join $masses ,]"

--- a/SRC/actor/machineBroker/MPI_MachineBroker.cpp
+++ b/SRC/actor/machineBroker/MPI_MachineBroker.cpp
@@ -63,6 +63,7 @@ MPI_MachineBroker::~MPI_MachineBroker()
   delete [] theChannels;
   delete usedChannels;
 
+  MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();
 }
 
@@ -124,4 +125,3 @@ MPI_MachineBroker::freeProcess
   // channel not found!
   return -1;
 }
-

--- a/SRC/actor/machineBroker/MPI_MachineBroker.cpp
+++ b/SRC/actor/machineBroker/MPI_MachineBroker.cpp
@@ -63,7 +63,6 @@ MPI_MachineBroker::~MPI_MachineBroker()
   delete [] theChannels;
   delete usedChannels;
 
-  MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();
 }
 

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -58,7 +58,7 @@
 #include <BackgroundMesh.h>
 #ifdef OPS_PARTITION_WITH_METIS
 #include <mpi.h>
-#include <metis.h>
+#include OPS_METIS_HEADER
 #endif
 
 #ifdef _OPENMP

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -1992,7 +1992,7 @@ int OPS_partition() {
     int ufactor = 30;
     int seed = -1;
     int objective = METIS_OBJTYPE_VOL;
-    int info = 0;
+    bool printInfo = false;
     while (OPS_GetNumRemainingInputArgs() > 0) {
         int num = 1;
         auto opt = OPS_GetString();
@@ -2044,7 +2044,7 @@ int OPS_partition() {
                 return -1;
             }
         } else if (strcmp(opt, "-info") == 0) {
-            info = METIS_DBG_INFO;
+            printInfo = true;
         } else {
             opserr << "WARNING: unknown partition option " << opt << "\n";
             return -1;
@@ -2154,7 +2154,6 @@ int OPS_partition() {
         options[METIS_OPTION_NUMBERING] = 0;
         options[METIS_OPTION_UFACTOR] = ufactor;
         options[METIS_OPTION_SEED] = seed;
-        options[METIS_OPTION_DBGLVL] = info;
 
         // number of parts to partition
         idx_t nparts = np;
@@ -2180,7 +2179,7 @@ int OPS_partition() {
             return -1;
         }
 
-        if (info != 0) {
+        if (printInfo) {
             opserr << "METIS partition: objective="
                    << (objective == METIS_OBJTYPE_CUT ? "cut" : "volume")
                    << " value=" << objval

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -56,7 +56,7 @@
 #include <TetMesh.h>
 #include <Damping.h>
 #include <BackgroundMesh.h>
-#ifdef _PARALLEL_INTERPRETERS
+#ifdef OPS_PARTITION_WITH_METIS
 #include <mpi.h>
 #include <metis.h>
 #endif
@@ -1963,7 +1963,16 @@ int OPS_setStartNodeTag() {
 }
 
 int OPS_partition() {
-#ifdef _PARALLEL_INTERPRETERS
+#ifdef OPS_PARTITION_WITH_METIS
+    int mpiInitialized = 0;
+    int mpiFinalized = 0;
+    MPI_Initialized(&mpiInitialized);
+    MPI_Finalized(&mpiFinalized);
+    if (!mpiInitialized || mpiFinalized) {
+        opserr << "WARNING: partition requires an active MPI runtime\n";
+        return -1;
+    }
+
     // domain
     Domain* domain = OPS_GetDomain();
     if (domain ==0) {
@@ -1981,12 +1990,14 @@ int OPS_partition() {
     int ncuts = 1;
     int niter = 10;
     int ufactor = 30;
+    int seed = -1;
+    int objective = METIS_OBJTYPE_VOL;
     int info = 0;
     while (OPS_GetNumRemainingInputArgs() > 0) {
         int num = 1;
         auto opt = OPS_GetString();
         if (strcmp(opt, "-ncuts") == 0) {
-            if (OPS_GetNumRemainingInputArgs() > 0 &&
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
                 OPS_GetIntInput(&num, &ncuts) < 0) {
                 opserr << "WARNING: failed to get ncuts\n";
                 return -1;
@@ -1995,7 +2006,7 @@ int OPS_partition() {
                 ncuts = 1;
             }
         } else if (strcmp(opt, "-niter") == 0) {
-            if (OPS_GetNumRemainingInputArgs() > 0 &&
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
                 OPS_GetIntInput(&num, &niter) < 0) {
                 opserr << "WARNING: failed to get niter\n";
                 return -1;
@@ -2004,16 +2015,39 @@ int OPS_partition() {
                 niter = 10;
             }
         } else if (strcmp(opt, "-ufactor") == 0) {
-            if (OPS_GetNumRemainingInputArgs() > 0 &&
-                OPS_GetIntInput(&num, &ncuts) < 0) {
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
+                OPS_GetIntInput(&num, &ufactor) < 0) {
                 opserr << "WARNING: failed to get ufactor\n";
                 return -1;
             }
             if (ufactor < 1) {
                 ufactor = 30;
             }
+        } else if (strcmp(opt, "-seed") == 0) {
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
+                OPS_GetIntInput(&num, &seed) < 0) {
+                opserr << "WARNING: failed to get partition seed\n";
+                return -1;
+            }
+        } else if (strcmp(opt, "-objective") == 0) {
+            if (OPS_GetNumRemainingInputArgs() < 1) {
+                opserr << "WARNING: partition objective must be cut or volume\n";
+                return -1;
+            }
+            const char *value = OPS_GetString();
+            if (strcmp(value, "cut") == 0) {
+                objective = METIS_OBJTYPE_CUT;
+            } else if (strcmp(value, "volume") == 0) {
+                objective = METIS_OBJTYPE_VOL;
+            } else {
+                opserr << "WARNING: partition objective must be cut or volume\n";
+                return -1;
+            }
         } else if (strcmp(opt, "-info") == 0) {
             info = METIS_DBG_INFO;
+        } else {
+            opserr << "WARNING: unknown partition option " << opt << "\n";
+            return -1;
         }
     }
 
@@ -2114,11 +2148,12 @@ int OPS_partition() {
         idx_t options[METIS_NOPTIONS];
         METIS_SetDefaultOptions(options);
         options[METIS_OPTION_PTYPE] = METIS_PTYPE_KWAY;
-        options[METIS_OPTION_OBJTYPE] = METIS_OBJTYPE_VOL;
+        options[METIS_OPTION_OBJTYPE] = objective;
         options[METIS_OPTION_NCUTS] = ncuts;
         options[METIS_OPTION_NITER] = niter;
         options[METIS_OPTION_NUMBERING] = 0;
         options[METIS_OPTION_UFACTOR] = ufactor;
+        options[METIS_OPTION_SEED] = seed;
         options[METIS_OPTION_DBGLVL] = info;
 
         // number of parts to partition
@@ -2143,6 +2178,17 @@ int OPS_partition() {
         } else if (res == METIS_ERROR) {
             opserr << "WARNING: metis error\n";
             return -1;
+        }
+
+        if (info != 0) {
+            opserr << "METIS partition: objective="
+                   << (objective == METIS_OBJTYPE_CUT ? "cut" : "volume")
+                   << " value=" << objval
+                   << " parts=" << nparts
+                   << " ncuts=" << ncuts
+                   << " niter=" << niter
+                   << " ufactor=" << ufactor
+                   << " seed=" << seed << endln;
         }
     }
 

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -2205,6 +2205,16 @@ int OPS_partition() {
         return -1;
     }
 
+    auto indexOf = [](idx_t id) -> idx_t {
+        return (id < 0) ? static_cast<idx_t>(-id - 1) : id;
+    };
+
+    // Nodes that appear in the mesh connectivity (same on every rank).
+    std::vector<char> inMesh(nn, 0);
+    for (idx_t node : eind) {
+        inMesh[node] = 1;
+    }
+
     // get nodes in current processor and remove elements
     for (int i = 0; i < ne; ++i) {
 
@@ -2228,7 +2238,43 @@ int OPS_partition() {
         }
     }
 
-    // get nodes in current processor and remove mp
+    // Give nodes connected by an MP constraint consistent ownership on every
+    // rank. Local element-retention marks cannot be used here because they
+    // differ between ranks.
+    {
+        auto &mps = domain->getMPs();
+        MP_Constraint *mp = 0;
+        while ((mp = mps()) != 0) {
+            const idx_t retained =
+                indexOf(nind[mp->getNodeRetained()]);
+            const idx_t constrained =
+                indexOf(nind[mp->getNodeConstrained()]);
+            if (inMesh[retained] && !inMesh[constrained]) {
+                npart[constrained] = npart[retained];
+            } else if (inMesh[constrained] && !inMesh[retained]) {
+                npart[retained] = npart[constrained];
+            } else if (!inMesh[retained] && !inMesh[constrained]) {
+                const idx_t owner =
+                    (npart[retained] < npart[constrained])
+                        ? npart[retained]
+                        : npart[constrained];
+                npart[retained] = owner;
+                npart[constrained] = owner;
+            }
+        }
+    }
+
+    // Retain nodes without a local element on their METIS owner so their
+    // constraints, mass, and nodal loads are not discarded on every rank.
+    for (auto &item : nind) {
+        auto &id = item.second;
+        if (id >= 0 && npart[id] == pid) {
+            id = -id - 1;
+        }
+    }
+
+    // Keep MP constraints that touch a locally retained node and pull in the
+    // partner node so the constraint is complete on that rank.
     auto &mps = domain->getMPs();
     MP_Constraint *mp = 0;
     while ((mp = mps()) != 0) {
@@ -2249,7 +2295,8 @@ int OPS_partition() {
         }
     }
 
-    // remove nodes
+    // Remove unused nodes. Interface copies retain their geometry but carry
+    // mass only on the npart owner, matching nodal-load ownership.
     for (const auto& item: nind) {
         int ndtag = item.first;
         auto id = item.second;
@@ -2261,6 +2308,21 @@ int OPS_partition() {
             auto pc = domain->removePressure_Constraint(ndtag);
             if (pc != 0) {
                 delete pc;
+            }
+        } else {
+            id = -id - 1;
+            if (npart[id] != pid) {
+                Node *node = domain->getNode(ndtag);
+                if (node != 0) {
+                    Matrix zeroMass(node->getNumberDOF(),
+                                    node->getNumberDOF());
+                    zeroMass.Zero();
+                    if (node->setMass(zeroMass) < 0) {
+                        opserr << "WARNING: failed to zero mass on node "
+                               << ndtag << " for partition ownership\n";
+                        return -1;
+                    }
+                }
             }
         }
     }
@@ -2300,13 +2362,13 @@ int OPS_partition() {
             }
         }
 
-        // remove elemental loads
+        // Element partitions are ordinary nonnegative part IDs, so retain a
+        // load only on the rank that owns its element.
         auto& eloads = lp->getElementalLoads();
         ElementalLoad* eload = 0;
         while ((eload = eloads()) != 0) {
             int e = eload->getElementTag();
-            auto id = epart[eindex[e]];
-            if (id >= 0) {
+            if (epart[eindex[e]] != pid) {
                 lp->removeElementalLoad(eload->getTag());
                 delete eload;
             }

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -1986,6 +1986,12 @@ int OPS_partition() {
 
     if (np == 1) return 0;
 
+    if (pid == 0 && domain->getNumEQs() > 0) {
+        opserr << "WARNING: partition does not yet support EQ_Constraint ("
+               << domain->getNumEQs()
+               << " found); results may be incorrect\n";
+    }
+
     // parameters
     int ncuts = 1;
     int niter = 10;

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/CMakeLists.txt
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/CMakeLists.txt
@@ -34,7 +34,6 @@ target_sources(OPS_PFEM
         PFEMSolver_LumpM.cpp
         PFEMSolver_LumpM.cpp
         PFEMSolver_Umfpack.cpp
-        PFEMSolver_Mumps.cpp	
     PUBLIC
         PFEMCompressibleLinSOE.h
         PFEMCompressibleSolver.h
@@ -48,8 +47,11 @@ target_sources(OPS_PFEM
         PFEMSolver_LumpM.h
         PFEMSolver_LumpM.h
         PFEMSolver_Umfpack.h
-        PFEMSolver_Mumps.h	
 )
+
+if(MUMPS_DIR)
+    target_sources(OPS_PFEM PRIVATE PFEMSolver_Mumps.cpp PUBLIC PFEMSolver_Mumps.h)
+endif()
 
 if(MPI_FOUND)
 
@@ -58,35 +60,46 @@ target_sources(OpenSeesMP
         DistributedSuperLU.cpp
         DistributedSparseGenColLinSOE.cpp
         DistributedSparseGenRowLinSOE.cpp
-        PFEMSolver_Mumps.cpp
         PFEMSolver_LumpM.cpp
-        PFEMCompressibleSolver_Mumps.cpp
     PUBLIC
         DistributedSuperLU.h
         DistributedSparseGenColLinSOE.h
         DistributedSparseGenRowLinSOE.h
+)
+
+if(MUMPS_DIR)
+    target_sources(OpenSeesMP PRIVATE
+        PFEMSolver_Mumps.cpp
+        PFEMCompressibleSolver_Mumps.cpp
+      PUBLIC
         PFEMSolver_Mumps.h
         PFEMCompressibleSolver_Mumps.h
-)
+    )
+endif()
 
 target_sources(OpenSeesSP
     PRIVATE 
         DistributedSuperLU.cpp
         DistributedSparseGenColLinSOE.cpp
         DistributedSparseGenRowLinSOE.cpp
-        PFEMSolver_Mumps.cpp
         PFEMSolver_LumpM.cpp
-        PFEMCompressibleSolver_Mumps.cpp
     PUBLIC
         DistributedSuperLU.h
         DistributedSparseGenColLinSOE.h
         DistributedSparseGenRowLinSOE.h
+)
+
+if(MUMPS_DIR)
+    target_sources(OpenSeesSP PRIVATE
+        PFEMSolver_Mumps.cpp
+        PFEMCompressibleSolver_Mumps.cpp
+      PUBLIC
         PFEMSolver_Mumps.h
         PFEMCompressibleSolver_Mumps.h
-)
+    )
+endif()
 
 endif()
 
 
 target_include_directories(OPS_SysOfEqn PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
@@ -66,7 +66,7 @@
 
 #endif
 
-SuperLUStat_t stat;
+static SuperLUStat_t superLUStat;
 SuperMatrix A;
 gridinfo_t grid;
 MPI_Comm comm_SuperLU;
@@ -188,7 +188,7 @@ DistributedSuperLU::solve(void)
     //
 
     pdgssvx_ABglobal(&options, &A, &ScalePermstruct, Xptr, ldb, nrhs, &grid,
-		     &LUstruct, berr, &stat, &info);
+		     &LUstruct, berr, &superLUStat, &info);
 
     if (theSOE->factored == false) {
       options.Fact = FACTORED;      
@@ -254,7 +254,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables.
   //
-  PStatInit(&stat);
+  PStatInit(&superLUStat);
   
   //
   // Create compressed column matrix for A. 
@@ -294,7 +294,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables. 
   //
-  PStatInit(&stat);
+  PStatInit(&superLUStat);
 
   return 0;
 }
@@ -413,7 +413,6 @@ DistributedSuperLU::recvSelf(int cTag,
   opserr << "DistributedSuperLU::recvSelf(int cTag, Channel &theChannel) - END\n";
   return 0;
 }
-
 
 
 

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -94,6 +94,7 @@ OPS_Stream *opserrPtr = &sserr;
 #include <vector>
 
 #include <elementAPI.h>
+#include <OpenSeesCommands.h>
 extern "C" int         OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp * interp, int cArg, int mArg, TCL_Char * *argv, Domain * domain);
 
 #include <packages.h>
@@ -1911,6 +1912,11 @@ opsPartition(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **arg
     }
   }
   partitionModel(eleTag);
+#elif defined(_PARALLEL_INTERPRETERS)
+  OPS_ResetInputNoBuilder(clientData, interp, 1, argc, argv, &theDomain);
+  if (OPS_partition() < 0) {
+    return TCL_ERROR;
+  }
 #endif
   return TCL_OK;
 }

--- a/cmake/cmake/FindMETIS.cmake
+++ b/cmake/cmake/FindMETIS.cmake
@@ -40,7 +40,7 @@ macro(_metis_check_version)
   else()
     set(METIS_VERSION ${METIS_MAJOR_VERSION}.${METIS_MINOR_VERSION}.${METIS_SUBMINOR_VERSION})
   endif()
-  if(${METIS_VERSION} VERSION_LESS ${Metis_FIND_VERSION})
+  if("${METIS_VERSION}" VERSION_LESS "${METIS_FIND_VERSION}")
     set(METIS_VERSION_OK FALSE)
   else()
     set(METIS_VERSION_OK TRUE)
@@ -48,15 +48,15 @@ macro(_metis_check_version)
 
   if(NOT METIS_VERSION_OK)
     message(STATUS "Metis version ${METIS_VERSION} found in ${METIS_INCLUDES}, "
-                   "but at least version ${Metis_FIND_VERSION} is required")
+                   "but at least version ${METIS_FIND_VERSION} is required")
   endif(NOT METIS_VERSION_OK)
 endmacro(_metis_check_version)
 
-  if(METIS_INCLUDES AND Metis_FIND_VERSION)
-    _metis_check_version()
-  else()
-    set(METIS_VERSION_OK TRUE)
-  endif()
+if(METIS_INCLUDES AND METIS_FIND_VERSION)
+  _metis_check_version()
+else()
+  set(METIS_VERSION_OK TRUE)
+endif()
 
 
 find_library(METIS_LIBRARIES metis PATHS $ENV{METISDIR} ${LIB_INSTALL_DIR} PATH_SUFFIXES lib)
@@ -66,4 +66,3 @@ find_package_handle_standard_args(METIS DEFAULT_MSG
                                   METIS_INCLUDES METIS_LIBRARIES METIS_VERSION_OK)
 
 mark_as_advanced(METIS_INCLUDES METIS_LIBRARIES)
-

--- a/tests/test_metis_partition_benchmark.py
+++ b/tests/test_metis_partition_benchmark.py
@@ -11,11 +11,13 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EXE = ROOT / "build" / "mpich-release" / "OpenSeesMP"
 BENCHMARK = ROOT / "EXAMPLES" / "ParallelModelMP" / "metisPartitionBenchmark.tcl"
+STATE_MODEL = ROOT / "EXAMPLES" / "ParallelModelMP" / "metisPartitionState.tcl"
 HOMEBREW_TCL_LIBRARY = Path("/opt/homebrew/opt/tcl-tk@8/lib/tcl8.6")
 ROW = re.compile(
     r"METIS_BENCHMARK rank=(?P<rank>\d+) ranks=(?P<ranks>\d+) "
     r"before=(?P<before>\d+)\s+after=(?P<after>\d+)"
 )
+STATE_ROW = re.compile(r"^METIS_STATE (?P<fields>.+)$", re.MULTILINE)
 
 
 def executable():
@@ -33,15 +35,14 @@ def mpi_launcher():
     return launcher
 
 
-def run_benchmark(ranks, objective="volume", seed=42):
+def run_model(ranks, script, *args):
     env = os.environ.copy()
     if "TCL_LIBRARY" not in env and HOMEBREW_TCL_LIBRARY.is_dir():
         env["TCL_LIBRARY"] = str(HOMEBREW_TCL_LIBRARY)
     launcher_flags = shlex.split(os.environ.get("MPIEXEC_FLAGS", ""))
     result = subprocess.run(
         [mpi_launcher(), *launcher_flags, "-n", str(ranks),
-         str(executable()), str(BENCHMARK),
-         objective, str(seed)],
+         str(executable()), str(script), *map(str, args)],
         cwd=ROOT,
         env=env,
         text=True,
@@ -49,10 +50,39 @@ def run_benchmark(ranks, objective="volume", seed=42):
         stderr=subprocess.STDOUT,
         timeout=30,
     )
+    return result
+
+
+def run_benchmark(ranks, objective="volume", seed=42):
+    result = run_model(ranks, BENCHMARK, objective, seed)
     return result, [
         {key: int(value) for key, value in match.groupdict().items()}
         for match in ROW.finditer(result.stdout)
     ]
+
+
+def csv_ints(value):
+    return [] if not value else [int(item) for item in value.split(",")]
+
+
+def state_rows(output):
+    rows = []
+    for match in STATE_ROW.finditer(output):
+        fields = dict(item.split("=", 1)
+                      for item in match.group("fields").split())
+        row = {
+            "rank": int(fields["rank"]),
+            "ranks": int(fields["ranks"]),
+        }
+        for name in ("nodes", "elements", "eleloads", "nodeloads",
+                     "fixed", "constrained", "mp100", "mp102"):
+            row[name] = csv_ints(fields[name])
+        row["masses"] = {
+            int(item.split(":", 1)[0]): float(item.split(":", 1)[1])
+            for item in fields["masses"].split(",") if item
+        }
+        rows.append(row)
+    return rows
 
 
 @pytest.mark.parametrize("ranks", [2, 4, 8])
@@ -99,3 +129,52 @@ def test_invalid_objective_is_rejected_on_every_rank():
     assert result.returncode == 0
     assert not rows
     assert result.stdout.count("partition objective must be cut or volume") == 2
+
+
+def test_partition_preserves_load_mass_and_constraint_ownership():
+    result = run_model(4, STATE_MODEL)
+    rows = state_rows(result.stdout)
+
+    assert result.returncode == 0, result.stdout
+    assert len(rows) == 4, result.stdout
+    assert {row["rank"] for row in rows} == set(range(4))
+    rows_by_rank = {row["rank"]: row for row in rows}
+
+    # Each element and its element load belong to exactly one, identical rank.
+    for row in rows:
+        assert row["eleloads"] == row["elements"]
+    assert sorted(tag for row in rows for tag in row["elements"]) == [1, 2, 3, 4]
+
+    expected_nodes = {1, 2, 3, 4, 5, 100, 101, 102, 103}
+    mass_owners = {}
+    for tag in expected_nodes:
+        owners = [row["rank"] for row in rows
+                  if row["masses"].get(tag, 0.0) > 0.0]
+        assert len(owners) == 1, (tag, rows, result.stdout)
+        owner = owners[0]
+        assert rows_by_rank[owner]["masses"][tag] == pytest.approx(float(tag))
+        mass_owners[tag] = owner
+
+    # The mesh-to-floating MP pair has the same owner and is complete on every
+    # rank that retains the mesh interface node.
+    assert mass_owners[3] == mass_owners[100]
+    ranks_with_3 = {row["rank"] for row in rows if 3 in row["nodes"]}
+    ranks_with_100 = {row["rank"] for row in rows if 100 in row["nodes"]}
+    assert ranks_with_100 == ranks_with_3
+    for row in rows:
+        assert row["mp100"] == ([3] if row["rank"] in ranks_with_3 else [])
+
+    # A floating-to-floating MP pair and a fixed floating node each survive on
+    # exactly one rank, with their constraint and applied nodal load intact.
+    assert mass_owners[101] == mass_owners[102]
+    for row in rows:
+        has_floating_pair = row["rank"] == mass_owners[101]
+        assert (101 in row["nodes"]) == has_floating_pair
+        assert (102 in row["nodes"]) == has_floating_pair
+        assert row["mp102"] == ([101] if has_floating_pair else [])
+
+    fixed_rows = [row for row in rows if 103 in row["fixed"]]
+    assert [row["rank"] for row in fixed_rows] == [mass_owners[103]]
+    assert sorted(tag for row in rows for tag in row["nodeloads"]) == [100, 103]
+    assert all(tag in row["nodes"]
+               for row in rows for tag in row["nodeloads"])

--- a/tests/test_metis_partition_benchmark.py
+++ b/tests/test_metis_partition_benchmark.py
@@ -1,0 +1,85 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EXE = ROOT / "build" / "mpich-release" / "OpenSeesMP"
+BENCHMARK = ROOT / "EXAMPLES" / "ParallelModelMP" / "metisPartitionBenchmark.tcl"
+ROW = re.compile(
+    r"METIS_BENCHMARK rank=(?P<rank>\d+) ranks=(?P<ranks>\d+) "
+    r"before=(?P<before>\d+)\s+after=(?P<after>\d+)"
+)
+
+
+def executable():
+    path = Path(os.environ.get("OPENSEESMP", DEFAULT_EXE))
+    if not path.is_file():
+        pytest.skip(f"OpenSeesMP executable not found: {path}")
+    return path
+
+
+def run_benchmark(ranks, objective="volume", seed=42):
+    env = os.environ.copy()
+    env.setdefault("TCL_LIBRARY", "/opt/homebrew/opt/tcl-tk@8/lib/tcl8.6")
+    result = subprocess.run(
+        ["mpiexec", "-n", str(ranks), str(executable()), str(BENCHMARK),
+         objective, str(seed)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+    )
+    return result, [
+        {key: int(value) for key, value in match.groupdict().items()}
+        for match in ROW.finditer(result.stdout)
+    ]
+
+
+@pytest.mark.parametrize("ranks", [2, 4, 8])
+def test_volume_partition_conserves_and_balances_elements(ranks):
+    result, rows = run_benchmark(ranks)
+
+    assert result.returncode == 0, result.stdout
+    assert len(rows) == ranks, result.stdout
+    assert {row["rank"] for row in rows} == set(range(ranks))
+    assert {row["ranks"] for row in rows} == {ranks}
+    assert {row["before"] for row in rows} == {1660}
+    assert sum(row["after"] for row in rows) == 1660
+
+    average = 1660 / ranks
+    imbalance = max(row["after"] for row in rows) / average - 1
+    assert imbalance <= 0.03
+
+
+def test_seed_is_deterministic():
+    first, first_rows = run_benchmark(4, seed=42)
+    second, second_rows = run_benchmark(4, seed=42)
+
+    assert first.returncode == second.returncode == 0
+    first_counts = sorted((row["rank"], row["after"]) for row in first_rows)
+    second_counts = sorted((row["rank"], row["after"]) for row in second_rows)
+    assert first_counts == second_counts
+
+
+def test_cut_objective():
+    result, rows = run_benchmark(4, objective="cut")
+
+    assert result.returncode == 0, result.stdout
+    assert "METIS partition: objective=cut" in result.stdout
+    assert sum(row["after"] for row in rows) == 1660
+
+
+def test_invalid_objective_is_rejected_on_every_rank():
+    result, rows = run_benchmark(2, objective="bogus")
+
+    # OpenSees currently exits zero for Tcl script errors, so verify the
+    # interpreter diagnostics rather than the process status.
+    assert result.returncode == 0
+    assert not rows
+    assert result.stdout.count("partition objective must be cut or volume") == 2

--- a/tests/test_metis_partition_benchmark.py
+++ b/tests/test_metis_partition_benchmark.py
@@ -1,5 +1,7 @@
 import os
 import re
+import shlex
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -9,6 +11,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EXE = ROOT / "build" / "mpich-release" / "OpenSeesMP"
 BENCHMARK = ROOT / "EXAMPLES" / "ParallelModelMP" / "metisPartitionBenchmark.tcl"
+HOMEBREW_TCL_LIBRARY = Path("/opt/homebrew/opt/tcl-tk@8/lib/tcl8.6")
 ROW = re.compile(
     r"METIS_BENCHMARK rank=(?P<rank>\d+) ranks=(?P<ranks>\d+) "
     r"before=(?P<before>\d+)\s+after=(?P<after>\d+)"
@@ -22,11 +25,22 @@ def executable():
     return path
 
 
+def mpi_launcher():
+    command = os.environ.get("MPIEXEC", "mpiexec")
+    launcher = shutil.which(command)
+    if launcher is None:
+        pytest.skip(f"MPI launcher not found: {command}")
+    return launcher
+
+
 def run_benchmark(ranks, objective="volume", seed=42):
     env = os.environ.copy()
-    env.setdefault("TCL_LIBRARY", "/opt/homebrew/opt/tcl-tk@8/lib/tcl8.6")
+    if "TCL_LIBRARY" not in env and HOMEBREW_TCL_LIBRARY.is_dir():
+        env["TCL_LIBRARY"] = str(HOMEBREW_TCL_LIBRARY)
+    launcher_flags = shlex.split(os.environ.get("MPIEXEC_FLAGS", ""))
     result = subprocess.run(
-        ["mpiexec", "-n", str(ranks), str(executable()), str(BENCHMARK),
+        [mpi_launcher(), *launcher_flags, "-n", str(ranks),
+         str(executable()), str(BENCHMARK),
          objective, str(seed)],
         cwd=ROOT,
         env=env,
@@ -62,6 +76,7 @@ def test_seed_is_deterministic():
     second, second_rows = run_benchmark(4, seed=42)
 
     assert first.returncode == second.returncode == 0
+    assert len(first_rows) == len(second_rows) == 4
     first_counts = sorted((row["rank"], row["after"]) for row in first_rows)
     second_counts = sorted((row["rank"], row["after"]) for row in second_rows)
     assert first_counts == second_counts
@@ -72,6 +87,7 @@ def test_cut_objective():
 
     assert result.returncode == 0, result.stdout
     assert "METIS partition: objective=cut" in result.stdout
+    assert len(rows) == 4
     assert sum(row["after"] for row in rows) == 1660
 
 


### PR DESCRIPTION
# Expose METIS 5 mesh-partition controls in OpenSeesMP

## Summary

This change connects OpenSeesMP's Tcl `partition` command to the existing
METIS mesh-partition implementation and exposes commonly used METIS 5 tuning
controls. It also fixes the existing `-ufactor` parser bug and makes the MPI
build usable when MUMPS is not installed.

## Command syntax

```tcl
partition \
  -objective cut|volume \
  -ncuts number \
  -niter number \
  -ufactor number \
  -seed number \
  -info
```

Unknown options and invalid objectives now produce Tcl errors. `-info` reports
the selected objective, objective value, number of parts, and tuning options.

## Partition correctness

- Retain element loads only on the rank that owns their element.
- Keep nodal mass on one owning rank instead of duplicating it on interface
  node copies.
- Retain floating fixed nodes, their SP constraints, and their nodal loads.
- Align ownership for `equalDOF`/MP-constrained nodes and keep each constraint
  complete wherever its mesh node is retained.

These fixes and the associated state regression were adapted from #1773 with
Gustavo A. Araújo R. credited as co-author.

## Build changes

- Require system METIS 5 for the MPI mesh-partition command.
- Enforce the requested METIS major version in `FindMETIS.cmake`.
- Include the selected system METIS 5 header explicitly, avoiding collisions
  with OpenSees' bundled METIS 4 headers on Linux.
- Compile the shared interpreter with the partition feature when MPI is found.
- Link OpenSeesMP to the selected METIS and Tcl libraries.
- Pass MPI C++ compile options as a list so multi-option MPICH configurations
  are handled correctly.
- Compile MUMPS sources only when a MUMPS installation is configured.
- Allow users and toolchains to override the macOS deployment target.
- Let CMake select compatible Fortran runtimes instead of injecting static GCC
  runtimes into every C++ target.
- Avoid exporting a `stat` data symbol from DistributedSuperLU, which can
  override the Linux C library's `stat()` function at runtime.
- Warn from rank zero when unsupported `EQ_Constraint` objects are present.\n
## Benchmark

The included benchmark constructs a 1,660-element 2D truss grid on every rank
and verifies conservation after partitioning.

| Ranks | Objective | METIS value | Elements per rank | Maximum imbalance |
|---:|---|---:|---|---:|
| 2 | volume | 42 | 832, 828 | 0.24% |
| 4 | volume | 112 | 410, 417, 416, 417 | 0.48% |
| 8 | volume | 186 | 209, 211, 208, 211, 211, 202, 211, 197 | 1.69% |
| 4 | cut | 65 | 408, 411, 421, 420 | 1.45% |

Repeating the four-rank volume test with seed 42 produces identical objective
and per-rank element counts.

## Verification

```text
macOS 26 / MPICH 5.0.1        OpenSeesMP build passed; pytest: 7 passed
Ubuntu 24.04 / Open MPI 4.1.6 OpenSeesMP build passed; pytest: 7 passed
Ubuntu 24.04 / MPICH 4.2.0    OpenSeesMP build passed; pytest: 7 passed
```

The Ubuntu MPICH-linked binary was run with a PMIx-aware launcher because the
ARM64 distribution's Hydra/PMIx combination created singleton communicators
even for a minimal MPI smoke test. `ldd` confirmed that OpenSeesMP loaded
MPICH, not Open MPI.

The pytest suite covers 2-, 4-, and 8-rank conservation and balance, fixed-seed
determinism, both METIS objectives, invalid-objective diagnostics, clean MPI
shutdown, element-load ownership, single-owner nodal mass, floating fixed-node
retention, nodal loads, and mesh/floating `equalDOF` ownership.
