### PR TITLE
Enable METIS 5 partitioning and parallel eigen analysis in OpenSeesMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,12 @@ else()
     include(OpenSeesFunctions) # Your custom logic
 endif()
 
+# Conan MSVC packages ship Release import libs only; map other optimized configs.
+if(CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
+  set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release)
+endif()
+
 find_package(ZLIB REQUIRED)
 find_package(HDF5 REQUIRED)
 find_package(TCL REQUIRED)
@@ -353,6 +359,47 @@ foreach(filepath ${ops_include_files})
 endforeach()
 list(REMOVE_DUPLICATES OPS_INCLUDE_DIRS)
 
+# Makefile.incl does not add OTHER/METIS to FE_INCLUDES; bundled headers belong only to the METIS
+# library target so <metis.h> resolves to system METIS 5 when installed (partition API).
+set(OPS_INCLUDE_DIRS_FILTERED "")
+foreach(_d IN LISTS OPS_INCLUDE_DIRS)
+  if(NOT _d STREQUAL "${PROJECT_SOURCE_DIR}/OTHER/METIS")
+    list(APPEND OPS_INCLUDE_DIRS_FILTERED "${_d}")
+  endif()
+endforeach()
+set(OPS_INCLUDE_DIRS "${OPS_INCLUDE_DIRS_FILTERED}")
+
+# METIS 5 for OPS_partition(). Bundled OTHER/METIS is METIS 4 — do not use it.
+# Pass -DMETIS5_DIR=... (same style as MUMPS_DIR) or set env METIS5_DIR.
+# Defaults: /usr on Linux; ../metis-5.1.0/install on Windows (see README-Windows-METIS5.md).
+set(METIS5_DIR "" CACHE PATH "METIS 5 install prefix (include/metis.h + lib)")
+if(NOT METIS5_DIR AND DEFINED ENV{METIS5_DIR} AND NOT "$ENV{METIS5_DIR}" STREQUAL "")
+  set(METIS5_DIR "$ENV{METIS5_DIR}")
+endif()
+if(NOT METIS5_DIR)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(METIS5_DIR "/usr")
+  elseif(WIN32)
+    set(METIS5_DIR "${PROJECT_SOURCE_DIR}/../metis-5.1.0/install")
+  endif()
+endif()
+
+set(OPENSEES_HAVE_METIS5_HEADER FALSE)
+set(OPENSEES_METIS5_INCLUDE_DIR "")
+if(METIS5_DIR AND EXISTS "${METIS5_DIR}/include/metis.h")
+  # Ubuntu's metis.h puts METIS_VER_* after a long banner; keep enough of the file.
+  file(READ "${METIS5_DIR}/include/metis.h" _opensees_metis_hdr LIMIT 12000)
+  if(_opensees_metis_hdr MATCHES "METIS_VER_MAJOR")
+    set(OPENSEES_HAVE_METIS5_HEADER TRUE)
+    set(OPENSEES_METIS5_INCLUDE_DIR "${METIS5_DIR}/include")
+  endif()
+endif()
+
+message(
+  STATUS
+  "METIS 5 (partition / OpenSeesMP): METIS5_DIR=${METIS5_DIR}, HAVE_METIS5_HEADER=${OPENSEES_HAVE_METIS5_HEADER}"
+)
+
 include_directories(${OPS_INCLUDE_DIRS})
 # end TODO
 
@@ -448,7 +495,11 @@ if(MPI_FOUND)
   else()
      set (MUMPS_FLAG -D_MUMPS)
      if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-       set (MUMPS_LIBRARIES "${MUMPS_DIR}/dmumps;${MUMPS_DIR}/mumps_common;${MUMPS_DIR}/pord")
+       get_filename_component(MUMPS_DIR "${MUMPS_DIR}" ABSOLUTE)
+       set (MUMPS_LIBRARIES
+         "${MUMPS_DIR}/dmumps.lib"
+         "${MUMPS_DIR}/mumps_common.lib"
+         "${MUMPS_DIR}/pord.lib")
      else()
        set (MUMPS_LIBRARIES "${MUMPS_DIR}/libdmumps.a;${MUMPS_DIR}/libmumps_common.a;${MUMPS_DIR}/libpord.a")
      endif()
@@ -457,8 +508,46 @@ if(MPI_FOUND)
 
   add_subdirectory("${PROJECT_SOURCE_DIR}/OTHER/SuperLU_DIST_4.3/SRC")
   add_subdirectory("${PROJECT_SOURCE_DIR}/OTHER/METIS")
+
+  # Bundled METIS target is METIS 4. partition() / system <metis.h> use METIS 5.
+  # Link libmetis when METIS 5 headers were detected; otherwise keep bundled METIS.
+  set(OPENSEES_METIS_LINK_LIB "METIS")
+  if(OPENSEES_HAVE_METIS5_HEADER)
+    find_library(
+      OPENSEES_METIS5_LIBRARY
+      NAMES metis
+      HINTS
+        "${METIS5_DIR}/lib"
+        "${METIS5_DIR}/lib64"
+      PATHS
+        /usr/lib/x86_64-linux-gnu
+        /usr/lib/aarch64-linux-gnu
+        /usr/lib64
+        /usr/lib
+      DOC "METIS 5 (libmetis) for partition() and MetisWrapper with system metis.h"
+    )
+    if(OPENSEES_METIS5_LIBRARY)
+      set(OPENSEES_METIS_LINK_LIB "${OPENSEES_METIS5_LIBRARY}")
+      message(STATUS "MPI executables: linking METIS 5 at ${OPENSEES_METIS5_LIBRARY}")
+    else()
+      message(
+        WARNING
+        "METIS 5 headers were found at ${OPENSEES_METIS5_INCLUDE_DIR} but libmetis was not found. "
+        "Falling back to bundled METIS 4; OpenSeesMP partition() will remain a stub. "
+        "Install libmetis (e.g. apt install libmetis-dev) or set METIS5_DIR."
+      )
+      set(OPENSEES_HAVE_METIS5_HEADER FALSE)
+    endif()
+  else()
+    message(
+      WARNING
+      "METIS 5 headers not found; OpenSeesMP partition() will remain a stub. "
+      "Install METIS development files (e.g. libmetis-dev) or set -DMETIS5_DIR=/path."
+    )
+  endif()
 else()
   message(STATUS "MPI was NOT found.")
+  set(OPENSEES_METIS_LINK_LIB "METIS")
 endif()
 
 
@@ -468,15 +557,15 @@ if(MKL_FOUND)
      set (SCALAPACK_LIBRARIES ${MKL_LIBRARIES})
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-     if(EXISTS "${MKL_ROOT}/lib/mkl_core.lib")
-      set(MKL_LPATH "${MKL_ROOT}/lib")
-    elseif(EXISTS "${MKL_ROOT}/lib/intel64/mkl_core.lib")
+    if(EXISTS "${MKL_ROOT}/lib/intel64/mkl_scalapack_lp64.lib")
       set(MKL_LPATH "${MKL_ROOT}/lib/intel64")
+    elseif(EXISTS "${MKL_ROOT}/lib/mkl_scalapack_lp64.lib")
+      set(MKL_LPATH "${MKL_ROOT}/lib")
     else()
-      message(FATAL_ERROR "MKL libraries not found in expected locations")
+      message(FATAL_ERROR "MKL lp64 ScaLAPACK libraries not found under ${MKL_ROOT}")
     endif()
 
-    set (SCALAPACK_LIBRARIES "${MKL_LPATH}/mkl_scalapack_ilp64.lib;${MKL_LPATH}/mkl_intel_ilp64.lib;${MKL_LPATH}/mkl_sequential.lib;${MKL_LPATH}/mkl_core.lib;${MKL_LPATH}/mkl_blacs_intelmpi_ilp64.lib")
+    set (SCALAPACK_LIBRARIES "${MKL_LPATH}/mkl_scalapack_lp64.lib;${MKL_LPATH}/mkl_intel_lp64.lib;${MKL_LPATH}/mkl_sequential.lib;${MKL_LPATH}/mkl_core.lib;${MKL_LPATH}/mkl_blacs_intelmpi_lp64.lib")
   endif()
 
 else()
@@ -515,6 +604,10 @@ set(TCL_LIBRARIES ${TCL_LIBRARY})
 #
 # OpenSees OBJECT LIBRARIES
 #
+
+# _PARALLEL_PROCESSING (OpenSeesSP) and _PARALLEL_INTERPRETERS (OpenSeesMP) are
+# mutually exclusive per executable. Do not use a global compile definition here;
+# SP object libraries and OpenSeesSP get _PARALLEL_PROCESSING when PARALLEL_PROCESSING=ON.
 
 add_library(OPS_Matrix             OBJECT)
 add_library(OPS_Actor              OBJECT)
@@ -755,7 +848,7 @@ if(MPI_FOUND)
        OPS_Reliability
        OPS_ReliabilityTcl
        OPS_Recorder
-       METIS
+       ${OPENSEES_METIS_LINK_LIB}
        SUPERLU_DIST
        OPS_Numerics
        ${MUMPS_LIBRARIES}
@@ -798,6 +891,18 @@ if(MPI_FOUND)
       ${OPS_SRC_DIR}/domain/subdomain/ShadowSubdomain.cpp
     )
 
+    # Compile OpenSeesMiscCommands with _PARALLEL_INTERPRETERS so OPS_partition
+    # (and other MPI misc commands) get real bodies. The stub archive member in
+    # OpenSeesLIB is not pulled when this TU is present on the executable.
+    if(OPENSEES_HAVE_METIS5_HEADER)
+      target_sources(OpenSeesMP PRIVATE
+        ${OPS_SRC_DIR}/interpreter/OpenSeesMiscCommands.cpp
+      )
+      target_include_directories(OpenSeesMP BEFORE PRIVATE
+        "${OPENSEES_METIS5_INCLUDE_DIR}"
+      )
+    endif()
+
     target_include_directories(OpenSeesMP PRIVATE ${MUMPS_DIR}/_deps/mumps-src/include ${MPI_CXX_INCLUDE_DIRS})
 
     target_compile_options(OpenSeesMP PRIVATE ${MPI_CXX_COMPILE_FLAGS})
@@ -820,7 +925,7 @@ if(MPI_FOUND)
        OPS_Reliability
        OPS_ReliabilityTcl
        OPS_Recorder
-       METIS
+       ${OPENSEES_METIS_LINK_LIB}
        SUPERLU_DIST
        OPS_Numerics
        ${MUMPS_LIBRARIES}
@@ -905,6 +1010,47 @@ add_subdirectory(${OPS_SRC_DIR})
 #                            Apply Options
 #
 #==============================================================================
+#----------------------------
+# PARALLEL_PROCESSING (OpenSeesSP object libraries + OPS_InterpTcl)
+#----------------------------
+if(PARALLEL_PROCESSING)
+  message(STATUS "PARALLEL_PROCESSING: applying _PARALLEL_PROCESSING to object libraries for OpenSeesSP")
+
+  function(ops_apply_parallel_processing_to_object_libs dir)
+    get_property(_ops_targets DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(_ops_tgt IN LISTS _ops_targets)
+      if(NOT TARGET "${_ops_tgt}")
+        continue()
+      endif()
+      get_target_property(_ops_type "${_ops_tgt}" TYPE)
+      if(_ops_type STREQUAL "OBJECT_LIBRARY")
+        target_compile_definitions("${_ops_tgt}" PRIVATE _PARALLEL_PROCESSING)
+      endif()
+    endforeach()
+    get_property(_ops_subdirs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+    foreach(_ops_subdir IN LISTS _ops_subdirs)
+      ops_apply_parallel_processing_to_object_libs("${_ops_subdir}")
+    endforeach()
+  endfunction()
+
+  foreach(_ops_tgt
+      OPS_Matrix OPS_Actor OPS_ObjectBroker OPS_Handler OPS_Recorder
+      OPS_Reliability OPS_Tagged OPS_Utilities OPS_ModelBuilder OPS_Domain
+      OPS_SysOfEqn OPS_Analysis OPS_ConvergenceTest OPS_Thermal OPS_Element
+      OPS_ElementFortran OPS_Material OPS_MaterialFortran OPS_Damage
+      OPS_Database OPS_INTERPRETER OPS_Paraview OPS_Renderer OPS_Graphics
+      OPS_Graphics_Default OPS_Graphics_GL OPS_PFEM OpenSeesLIB OPS_InterpTcl)
+    if(TARGET "${_ops_tgt}")
+      get_target_property(_ops_type "${_ops_tgt}" TYPE)
+      if(_ops_type STREQUAL "OBJECT_LIBRARY" OR _ops_tgt STREQUAL "OPS_InterpTcl")
+        target_compile_definitions("${_ops_tgt}" PRIVATE _PARALLEL_PROCESSING)
+      endif()
+    endif()
+  endforeach()
+
+  ops_apply_parallel_processing_to_object_libs("${PROJECT_SOURCE_DIR}/SRC")
+endif()
+
 #----------------------------
 # FMK
 #----------------------------

--- a/EXAMPLES/Partition/Example.tcl
+++ b/EXAMPLES/Partition/Example.tcl
@@ -1,0 +1,183 @@
+# OpenSeesMP partition example: serial, METIS, custom, and samePart.
+#
+# A small 3D solid pier is solved four ways. Each run prints element ownership,
+# the first three eigenvalues, and top-node displacement after gravity and after
+# a short transient pulse. The numerical results should agree independent of
+# how the mesh is partitioned.
+#
+# Run from this directory (any process count from 2 to 8 works for the
+# parallel modes):
+#   OpenSees Example.tcl serial
+#   mpiexec -n 4 OpenSeesMP Example.tcl metis
+#   mpiexec -n 4 OpenSeesMP Example.tcl custom
+#   mpiexec -n 4 OpenSeesMP Example.tcl samePart
+#
+# Optional smaller mesh for a quick run:
+#   OpenSees Example.tcl serial 4 4 20
+#   mpiexec -n 4 OpenSeesMP Example.tcl metis 4 4 20
+
+wipe
+
+set pid [getPID]
+set np  [getNP]
+set mode [expr {$argc > 0 ? [string tolower [lindex $argv 0]] : "serial"}]
+
+set nx 10
+set ny 10
+set nz 100
+if {$argc == 4} {
+    foreach {nx ny nz} [lrange $argv 1 3] break
+    foreach n [list $nx $ny $nz] {
+        if {![string is integer -strict $n] || $n < 1} {
+            puts "ERROR: nx, ny, and nz must be positive integers"
+            exit 1
+        }
+    }
+} elseif {$argc != 1} {
+    puts "usage: Example.tcl serial|metis|custom|samePart ?nx ny nz?"
+    exit 1
+}
+
+if {$mode ni {serial metis custom samepart}} {
+    puts "usage: Example.tcl serial|metis|custom|samePart ?nx ny nz?"
+    exit 1
+}
+if {$mode eq "serial" && $np != 1} {
+    puts "ERROR: serial mode requires one process"
+    exit 1
+}
+if {$mode ne "serial" && $np < 2} {
+    puts "ERROR: parallel modes in this example require at least 2 MPI processes"
+    exit 1
+}
+
+# Same concrete-like 2 m x 2 m x 10 m pier as EXAMPLES/LargeMP.
+set nn [expr {($nx + 1)*($ny + 1)*($nz + 1)}]
+set ne [expr {$nx*$ny*$nz}]
+set topNode $nn
+
+model BasicBuilder -ndm 3 -ndf 3
+set rho 2.4
+nDMaterial ElasticIsotropic 1 2.5e7 0.20 $rho
+
+block3D $nx $ny $nz 1 1 stdBrick 1 {
+    1  -1.0  -1.0   0.0
+    2   1.0  -1.0   0.0
+    3   1.0   1.0   0.0
+    4  -1.0   1.0   0.0
+    5  -1.0  -1.0  10.0
+    6   1.0  -1.0  10.0
+    7   1.0   1.0  10.0
+    8  -1.0   1.0  10.0
+}
+
+# Element mass comes from material rho. Add 50% extra nonstructural mass,
+# distributed uniformly over all nodes, to exercise nodal-mass ownership too.
+set structuralMass [expr {$rho*2.0*2.0*10.0}]
+set nodalMass [expr {0.5*$structuralMass/double($nn)}]
+for {set i 1} {$i <= $nn} {incr i} {
+    mass $i $nodalMass $nodalMass $nodalMass
+}
+fixZ 0.0 1 1 1
+
+# Mesh-independent gravity from all element + nodal mass. UniformExcitation
+# applies F = -M*ugddot, so positive g acts downward in global Z (direction 3).
+timeSeries Constant 1
+pattern UniformExcitation 1 3 -accel 1 -fact 9.81
+
+if {$mode eq "metis"} {
+    partition
+} elseif {$mode eq "custom"} {
+    # Explicit element -> part map: contiguous, balanced blocks over all ranks.
+    set customPairs {}
+    for {set e 1} {$e <= $ne} {incr e} {
+        lappend customPairs $e [expr {($e - 1)*$np/$ne}]
+    }
+    partition -customPartition $ne {*}$customPairs
+} elseif {$mode eq "samepart"} {
+    # METIS still partitions, but first/last (nonadjacent) elements stay together.
+    partition -samePart 2 1 $ne
+}
+
+set localEles [lsort -integer [getEleTags]]
+set eleSample [lrange $localEles 0 11]
+puts "PARTITION mode=$mode rank=$pid count=[llength $localEles] sample=$eleSample"
+
+if {$mode eq "samepart"} {
+    set hasFirst [expr {[lsearch -exact $localEles 1] >= 0}]
+    set hasLast [expr {[lsearch -exact $localEles $ne] >= 0}]
+    if {$hasFirst != $hasLast} {
+        puts "ERROR: -samePart failed: elements 1 and $ne are split on rank $pid"
+        exit 1
+    }
+}
+
+if {$np > 1} {
+    set numbererType ParallelPlain
+    set systemType Mumps
+} else {
+    set numbererType Plain
+    set systemType UmfPack
+}
+
+constraints Plain
+numberer $numbererType
+system $systemType
+test NormUnbalance 1.0e-10 20
+algorithm Newton
+integrator LoadControl 0.1
+analysis Static
+
+set ok [analyze 10]
+if {$ok != 0} {
+    puts "ERROR: gravity analysis failed on rank $pid, code=$ok"
+    exit 1
+}
+
+# Only the rank retaining the top node prints its displacement.
+set ownsTop [expr {[lsearch -exact [getNodeTags] $topNode] >= 0}]
+if {$ownsTop} {
+    puts [format "RESULT mode=%s stage=gravity node=%d disp={%.16e %.16e %.16e}" \
+        $mode $topNode [nodeDisp $topNode 1] [nodeDisp $topNode 2] \
+        [nodeDisp $topNode 3]]
+}
+
+# All MPI ranks participate in eigen and receive the same eigenvalues.
+set lambdas [eigen 3]
+if {$pid == 0} {
+    puts "RESULT mode=$mode stage=eigen lambda=$lambdas"
+}
+
+# Hold gravity constant and apply a one-step horizontal pulse at the top.
+set period1 [expr {2.0*acos(-1.0)/sqrt([lindex $lambdas 0])}]
+set dt [expr {$period1/20.0}]
+loadConst -time 0.0
+timeSeries Path 2 -dt $dt -values {0.0 1.0 0.0} -factor 100.0
+pattern Plain 2 2 {
+    if {$ownsTop} {
+        load $topNode 1.0 0.0 0.0
+    }
+}
+
+wipeAnalysis
+constraints Plain
+numberer $numbererType
+system $systemType
+test EnergyIncr 1.0e-10 20
+algorithm Newton
+integrator Newmark 0.5 0.25
+analysis Transient
+
+set ok [analyze 40 $dt]
+if {$ok != 0} {
+    puts "ERROR: transient analysis failed on rank $pid, code=$ok"
+    exit 1
+}
+if {$ownsTop} {
+    puts [format "RESULT mode=%s stage=transient node=%d disp={%.16e %.16e %.16e}" \
+        $mode $topNode [nodeDisp $topNode 1] [nodeDisp $topNode 2] \
+        [nodeDisp $topNode 3]]
+}
+
+wipe
+exit 0

--- a/OTHER/METIS/CMakeLists.txt
+++ b/OTHER/METIS/CMakeLists.txt
@@ -12,7 +12,15 @@
 
 add_library(METIS)
 
-target_sources(METIS PUBLIC
+# Sources use #include "metis.h"; metis.h includes local headers with "" so they stay in this tree.
+target_include_directories(
+  METIS
+  BEFORE
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(METIS PRIVATE
   coarsen.c
   fm.c
   initpart.c

--- a/README-Windows-METIS5.md
+++ b/README-Windows-METIS5.md
@@ -1,0 +1,144 @@
+# METIS 5 for OpenSeesMP
+
+OpenSeesMP's Tcl `partition` command requires the METIS 5 headers and library.
+The copy under `OTHER/METIS` is METIS 4 and is retained only for legacy graph
+code. If METIS 5 is unavailable, OpenSeesMP can still build, but CMake warns
+that `partition` will remain a stub.
+
+## Ubuntu
+
+Install the METIS 5 development package:
+
+```bash
+sudo apt update
+sudo apt install libmetis-dev
+```
+
+The default `makeOpenSeesMP_Ubuntu.sh` configuration uses `/usr` as the METIS
+prefix. For a nonstandard installation, set `METIS5_DIR`:
+
+```bash
+METIS5_DIR=/path/to/metis/install ./makeOpenSeesMP_Ubuntu.sh
+```
+
+The prefix must contain:
+
+```text
+include/metis.h
+lib/libmetis.so (or the platform-specific library directory)
+```
+
+## Windows
+
+There is no official Windows METIS binary. Build METIS 5.1.0 from source and
+point OpenSees to its installation prefix. A convenient layout is:
+
+```text
+...\OpenSees
+...\mumps\build          <- MUMPS_DIR
+...\metis-5.1.0\install  <- METIS5_DIR
+```
+
+### Obtain METIS 5.1.0
+
+Use the classic 5.1.0 release with bundled GKlib. This fork includes Windows
+build support:
+
+```bat
+cd ..
+git clone --depth 1 https://github.com/eric2003/METIS-5.1.0-Modified.git metis-5.1.0
+cd metis-5.1.0
+```
+
+Do not substitute the KarypisLab `master` branch (METIS 5.2.x) for this build.
+OpenSees's `partition` implementation targets the METIS 5.1 API, and
+`METIS_PartMeshNodal` from 5.2.x has caused access violations with MSVC.
+
+### Build with Visual Studio 2022
+
+The OpenSees Windows script uses the static MSVC runtime (`/MT`). Build METIS
+the same way. Keep 32-bit `idx_t` because OpenSeesMP communicates these arrays
+using `MPI_INT`.
+
+From the `metis-5.1.0` directory:
+
+```bat
+set CMAKE=C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe
+set PREFIX=%CD%\install
+
+"%CMAKE%" -S . -B build -G "Visual Studio 17 2022" -A x64 ^
+  -DMETIS_ENABLE_64BIT=OFF ^
+  -DSHARED=FALSE ^
+  -DCMAKE_INSTALL_PREFIX="%PREFIX%" ^
+  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW ^
+  -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+
+"%CMAKE%" --build build --config Release --target metis --parallel 8
+```
+
+Only the `metis` library target is needed. Assemble the installation prefix:
+
+```bat
+mkdir install\include install\lib
+copy include\metis.h install\include\
+copy build\libmetis\Release\metis.lib install\lib\
+```
+
+The result should be:
+
+```text
+metis-5.1.0\install\include\metis.h
+metis-5.1.0\install\lib\metis.lib
+```
+
+GKlib is included in `metis.lib`; it does not require a separate link step.
+
+### Build OpenSeesMP
+
+`makeOpenSeesMP_WIN.bat` defaults to the sibling directory shown above. Edit
+`METIS5_DIR` near the top of the script if METIS is installed elsewhere, then
+run:
+
+```bat
+makeOpenSeesMP_WIN.bat
+```
+
+The executable is written to:
+
+```text
+build-mp\Release\OpenSeesMP.exe
+```
+
+## Confirm METIS was detected
+
+A successful CMake configuration includes messages similar to:
+
+```text
+-- METIS 5 (partition / OpenSeesMP): ... HAVE_METIS5_HEADER=TRUE
+-- MPI executables: linking METIS 5 at .../libmetis...
+```
+
+If the configuration instead reports:
+
+```text
+METIS 5 headers not found; OpenSeesMP partition() will remain a stub
+```
+
+check `METIS5_DIR`, `include/metis.h`, and the library path. If the prefix was
+changed after an earlier configuration, remove the stale CMake cache entry or
+pass `-UOPENSEES_METIS5_LIBRARY`; the Windows build script already does this.
+
+## Quick partition check
+
+From `EXAMPLES/Partition`, use a smaller mesh for a fast check:
+
+```bash
+OpenSees Example.tcl serial 4 4 20
+mpiexec -n 4 OpenSeesMP Example.tcl metis 4 4 20
+mpiexec -n 4 OpenSeesMP Example.tcl custom 4 4 20
+mpiexec -n 4 OpenSeesMP Example.tcl samePart 4 4 20
+```
+
+The gravity displacement, eigenvalues, and transient displacement should agree
+between serial, METIS, custom, and `samePart` runs up to normal floating-point
+roundoff.

--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -30,6 +30,7 @@
 #include <ElementalLoadIter.h>
 #include <Element.h>
 #include <ElementIter.h>
+#include <algorithm>
 #include <Parameter.h>
 #include <RandomVariable.h>
 #include <Node.h>
@@ -40,6 +41,7 @@
 #include <SP_ConstraintIter.h>
 #include <MP_Constraint.h>
 #include <MP_ConstraintIter.h>
+#include <EQ_Constraint.h>
 #include <NodalLoad.h>
 #include <NodalLoadIter.h>
 #include <Matrix.h>
@@ -1962,6 +1964,7 @@ int OPS_setStartNodeTag() {
     return 0;
 }
 
+
 int OPS_partition() {
 #ifdef _PARALLEL_INTERPRETERS
     // domain
@@ -1977,11 +1980,24 @@ int OPS_partition() {
 
     if (np == 1) return 0;
 
+    // equationConstraint / EQ_Constraint is not cleaned or co-located yet;
+    // nodes involved may be dropped while the EQ remains (or vice versa).
+    if (pid == 0 && domain->getNumEQs() > 0) {
+        opserr << "WARNING: partition detected " << domain->getNumEQs()
+               << " equationConstraint(s); EQ_Constraint handling is not "
+                  "implemented correctly yet — results may be wrong or "
+                  "unstable under MPI\n";
+    }
+
     // parameters
     int ncuts = 1;
     int niter = 10;
     int ufactor = 30;
     int info = 0;
+    bool useCustomPartition = false;
+    std::map<int, idx_t> customElementParts;
+    // Groups of element tags that must share a METIS part (must-link).
+    std::vector<std::vector<int>> samePartGroups;
     while (OPS_GetNumRemainingInputArgs() > 0) {
         int num = 1;
         auto opt = OPS_GetString();
@@ -2005,7 +2021,7 @@ int OPS_partition() {
             }
         } else if (strcmp(opt, "-ufactor") == 0) {
             if (OPS_GetNumRemainingInputArgs() > 0 &&
-                OPS_GetIntInput(&num, &ncuts) < 0) {
+                OPS_GetIntInput(&num, &ufactor) < 0) {
                 opserr << "WARNING: failed to get ufactor\n";
                 return -1;
             }
@@ -2014,7 +2030,70 @@ int OPS_partition() {
             }
         } else if (strcmp(opt, "-info") == 0) {
             info = METIS_DBG_INFO;
+        } else if (strcmp(opt, "-customPartition") == 0) {
+            // Tcl:   partition -customPartition $count {*}$tagPartPairs
+            // Python: ops.partition("-customPartition", count, *tagPartPairs)
+            int count = 0;
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
+                OPS_GetIntInput(&num, &count) < 0 || count < 1) {
+                opserr << "WARNING: partition -customPartition requires a "
+                          "positive number of element-tag/part pairs\n";
+                return -1;
+            }
+            if (OPS_GetNumRemainingInputArgs() < 2 * count) {
+                opserr << "WARNING: partition -customPartition expected "
+                       << count << " element-tag/part pairs\n";
+                return -1;
+            }
+
+            std::vector<int> assignments(2 * count);
+            int numAssignments = 2 * count;
+            if (OPS_GetIntInput(&numAssignments, assignments.data()) < 0) {
+                opserr << "WARNING: failed to read custom element partition\n";
+                return -1;
+            }
+
+            useCustomPartition = true;
+            for (int i = 0; i < count; ++i) {
+                int elementTag = assignments[2 * i];
+                idx_t part = assignments[2 * i + 1];
+                if (!customElementParts.emplace(elementTag, part).second) {
+                    opserr << "WARNING: duplicate element tag " << elementTag
+                           << " in custom partition\n";
+                    return -1;
+                }
+            }
+        } else if (strcmp(opt, "-samePart") == 0) {
+            // Tcl: partition -samePart $n $e1 $e2 ...  (repeatable)
+            // Force those elements onto the same METIS part via dual-graph
+            // contraction (must-link). Ignored with -customPartition.
+            int count = 0;
+            if (OPS_GetNumRemainingInputArgs() < 1 ||
+                OPS_GetIntInput(&num, &count) < 0 || count < 2) {
+                opserr << "WARNING: partition -samePart requires a count >= 2 "
+                          "followed by that many element tags\n";
+                return -1;
+            }
+            if (OPS_GetNumRemainingInputArgs() < count) {
+                opserr << "WARNING: partition -samePart expected " << count
+                       << " element tags\n";
+                return -1;
+            }
+            std::vector<int> tags(count);
+            int numTags = count;
+            if (OPS_GetIntInput(&numTags, tags.data()) < 0) {
+                opserr << "WARNING: failed to read -samePart element tags\n";
+                return -1;
+            }
+            samePartGroups.push_back(std::move(tags));
+        } else {
+            opserr << "WARNING: unknown partition option " << opt << endln;
+            return -1;
         }
+    }
+
+    if (useCustomPartition && !samePartGroups.empty() && pid == 0) {
+        opserr << "WARNING: -samePart ignored when -customPartition is used\n";
     }
 
 
@@ -2107,9 +2186,81 @@ int OPS_partition() {
     // partition for nodes
     std::vector<idx_t> npart(nn);
 
-    // do partition on P0
-    if (pid == 0) {
+    // A custom partition supplies element ownership directly on every rank;
+    // node ownership is derived deterministically from adjacent element parts.
+    // METIS partitioning remains a rank-0 operation followed by broadcasts.
+    if (useCustomPartition) {
+        // Catch assignments for tags not present in this domain.
+        for (const auto& assignment : customElementParts) {
+            if (eindex.find(assignment.first) == eindex.end()) {
+                opserr << "WARNING: custom partition references unknown "
+                          "element "
+                       << assignment.first << endln;
+                return -1;
+            }
+        }
 
+        std::vector<int> elementsPerPart(np, 0);
+        std::vector<int> autoAssignedTags;
+        for (idx_t i = 0; i < ne; ++i) {
+            auto assignment = customElementParts.find(etag[i]);
+            if (assignment == customElementParts.end()) {
+                // Missing by accident: park on part 0 and warn below.
+                epart[i] = 0;
+                autoAssignedTags.push_back(etag[i]);
+            } else {
+                if (assignment->second < 0 || assignment->second >= np) {
+                    opserr << "WARNING: custom partition part "
+                           << assignment->second << " for element "
+                           << etag[i] << " is outside [0, " << np - 1
+                           << "]\n";
+                    return -1;
+                }
+                epart[i] = assignment->second;
+            }
+            ++elementsPerPart[epart[i]];
+        }
+
+        if (pid == 0 && !autoAssignedTags.empty()) {
+            const int nAuto = static_cast<int>(autoAssignedTags.size());
+            opserr << "WARNING: custom partition auto-assigned " << nAuto
+                   << " unlisted element(s) to part 0:";
+            const int maxList = 20;
+            const int nList = (nAuto < maxList) ? nAuto : maxList;
+            for (int i = 0; i < nList; ++i) {
+                opserr << " " << autoAssignedTags[i];
+            }
+            if (nAuto > maxList) {
+                opserr << " ...";
+            }
+            opserr << endln;
+        }
+
+        // A shared node is owned by the lowest adjacent element part.
+        // Ownership only controls unique nodal mass/load placement; copies
+        // are retained on every rank with an adjacent local element.
+        std::fill(npart.begin(), npart.end(), static_cast<idx_t>(np));
+        for (idx_t i = 0; i < ne; ++i) {
+            for (idx_t j = eptr[i]; j < eptr[i + 1]; ++j) {
+                idx_t node = eind[j];
+                if (epart[i] < npart[node]) {
+                    npart[node] = epart[i];
+                }
+            }
+        }
+        for (idx_t i = 0; i < nn; ++i) {
+            if (npart[i] == np) {
+                npart[i] = 0;  // isolated node: deterministic owner
+            }
+        }
+        for (int part = 0; pid == 0 && part < np; ++part) {
+            if (elementsPerPart[part] == 0) {
+                opserr << "WARNING: custom partition assigns no elements to "
+                          "part "
+                       << part << endln;
+            }
+        }
+    } else if (pid == 0) {
         // options
         idx_t options[METIS_NOPTIONS];
         METIS_SetDefaultOptions(options);
@@ -2124,16 +2275,182 @@ int OPS_partition() {
         // number of parts to partition
         idx_t nparts = np;
 
-        // total communications volume
-        idx_t objval;
+        // total communications volume / edgecut
+        idx_t objval = 0;
+        int res = METIS_OK;
 
-        // call metis
-        auto res = METIS_PartMeshNodal(
-            &ne, &nn, &eptr[0], &eind[0], NULL, NULL, &nparts,
-            NULL, options, &objval, &epart[0], &npart[0]);
+        if (samePartGroups.empty()) {
+            // Default: nodal-graph mesh partition (no must-link constraints).
+            res = METIS_PartMeshNodal(
+                &ne, &nn, &eptr[0], &eind[0], NULL, NULL, &nparts,
+                NULL, options, &objval, &epart[0], &npart[0]);
+        } else {
+            // Must-link: contract samePart groups on the element dual graph,
+            // partition with PartGraphKway, then expand and derive npart.
+            std::vector<idx_t> parent(static_cast<size_t>(ne));
+            for (idx_t i = 0; i < ne; ++i) {
+                parent[static_cast<size_t>(i)] = i;
+            }
+            auto findRoot = [&parent](idx_t x) -> idx_t {
+                idx_t r = x;
+                while (parent[static_cast<size_t>(r)] != r) {
+                    r = parent[static_cast<size_t>(r)];
+                }
+                while (parent[static_cast<size_t>(x)] != x) {
+                    const idx_t next = parent[static_cast<size_t>(x)];
+                    parent[static_cast<size_t>(x)] = r;
+                    x = next;
+                }
+                return r;
+            };
+            auto unite = [&findRoot, &parent](idx_t a, idx_t b) {
+                a = findRoot(a);
+                b = findRoot(b);
+                if (a != b) {
+                    parent[static_cast<size_t>(b)] = a;
+                }
+            };
 
+            for (const auto& group : samePartGroups) {
+                idx_t first = -1;
+                for (int tag : group) {
+                    auto it = eindex.find(tag);
+                    if (it == eindex.end()) {
+                        opserr << "WARNING: -samePart references unknown "
+                                  "element "
+                               << tag << endln;
+                        return -1;
+                    }
+                    if (first < 0) {
+                        first = it->second;
+                    } else {
+                        unite(first, it->second);
+                    }
+                }
+            }
 
-        // check errors 
+            idx_t ncommon = 1;
+            idx_t numflag = 0;
+            idx_t *xadj = 0;
+            idx_t *adjncy = 0;
+            res = METIS_MeshToDual(&ne, &nn, &eptr[0], &eind[0], &ncommon,
+                                   &numflag, &xadj, &adjncy);
+            if (res != METIS_OK) {
+                opserr << "WARNING: METIS_MeshToDual failed for -samePart\n";
+                return -1;
+            }
+
+            std::map<idx_t, idx_t> rootToSuper;
+            std::vector<idx_t> eleToSuper(static_cast<size_t>(ne));
+            std::vector<idx_t> vwgt;
+            for (idx_t i = 0; i < ne; ++i) {
+                const idx_t root = findRoot(i);
+                auto it = rootToSuper.find(root);
+                if (it == rootToSuper.end()) {
+                    const idx_t sid = static_cast<idx_t>(rootToSuper.size());
+                    rootToSuper[root] = sid;
+                    vwgt.push_back(0);
+                    it = rootToSuper.find(root);
+                }
+                eleToSuper[static_cast<size_t>(i)] = it->second;
+                vwgt[static_cast<size_t>(it->second)] += 1;
+            }
+
+            idx_t nsuper = static_cast<idx_t>(rootToSuper.size());
+            std::vector<std::map<idx_t, idx_t>> superAdj(
+                static_cast<size_t>(nsuper));
+            for (idx_t u = 0; u < ne; ++u) {
+                const idx_t su = eleToSuper[static_cast<size_t>(u)];
+                for (idx_t j = xadj[u]; j < xadj[u + 1]; ++j) {
+                    const idx_t v = adjncy[j];
+                    const idx_t sv = eleToSuper[static_cast<size_t>(v)];
+                    if (su == sv) {
+                        continue;
+                    }
+                    superAdj[static_cast<size_t>(su)][sv] += 1;
+                }
+            }
+
+            std::vector<idx_t> cxadj(static_cast<size_t>(nsuper) + 1);
+            std::vector<idx_t> cadjncy;
+            std::vector<idx_t> cadjwgt;
+            for (idx_t i = 0; i < nsuper; ++i) {
+                cxadj[static_cast<size_t>(i)] =
+                    static_cast<idx_t>(cadjncy.size());
+                for (const auto& edge : superAdj[static_cast<size_t>(i)]) {
+                    cadjncy.push_back(edge.first);
+                    cadjwgt.push_back(edge.second);
+                }
+            }
+            cxadj[static_cast<size_t>(nsuper)] =
+                static_cast<idx_t>(cadjncy.size());
+
+            METIS_Free(xadj);
+            METIS_Free(adjncy);
+            xadj = 0;
+            adjncy = 0;
+
+            if (nsuper < nparts) {
+                opserr << "WARNING: -samePart contraction left only " << nsuper
+                       << " supervertices for " << nparts
+                       << " parts; METIS may fail or imbalance\n";
+            }
+
+            std::vector<idx_t> cpart(static_cast<size_t>(nsuper), 0);
+            idx_t ncon = 1;
+            idx_t *adjwgtPtr = cadjwgt.empty() ? NULL : cadjwgt.data();
+            idx_t *adjncyPtr = cadjncy.empty() ? NULL : cadjncy.data();
+            // OBJTYPE_VOL uses vsize for communication volume; use CUT for
+            // contracted dual with explicit edge weights.
+            options[METIS_OPTION_OBJTYPE] = METIS_OBJTYPE_CUT;
+            res = METIS_PartGraphKway(
+                &nsuper, &ncon, cxadj.data(), adjncyPtr, vwgt.data(), NULL,
+                adjwgtPtr, &nparts, NULL, NULL, options, &objval, cpart.data());
+
+            if (res == METIS_OK) {
+                for (idx_t i = 0; i < ne; ++i) {
+                    epart[static_cast<size_t>(i)] =
+                        cpart[static_cast<size_t>(
+                            eleToSuper[static_cast<size_t>(i)])];
+                }
+                // Node ownership: lowest adjacent element part (same as custom).
+                std::fill(npart.begin(), npart.end(), static_cast<idx_t>(np));
+                for (idx_t i = 0; i < ne; ++i) {
+                    for (idx_t j = eptr[static_cast<size_t>(i)];
+                         j < eptr[static_cast<size_t>(i) + 1]; ++j) {
+                        const idx_t node = eind[static_cast<size_t>(j)];
+                        if (epart[static_cast<size_t>(i)] <
+                            npart[static_cast<size_t>(node)]) {
+                            npart[static_cast<size_t>(node)] =
+                                epart[static_cast<size_t>(i)];
+                        }
+                    }
+                }
+                for (idx_t i = 0; i < nn; ++i) {
+                    if (npart[static_cast<size_t>(i)] == np) {
+                        npart[static_cast<size_t>(i)] = 0;
+                    }
+                }
+
+                // Sanity: each samePart group shares one part.
+                for (const auto& group : samePartGroups) {
+                    idx_t part = -1;
+                    for (int tag : group) {
+                        const idx_t e = eindex[tag];
+                        if (part < 0) {
+                            part = epart[static_cast<size_t>(e)];
+                        } else if (epart[static_cast<size_t>(e)] != part) {
+                            opserr << "WARNING: -samePart failed to co-locate "
+                                      "element "
+                                   << tag << endln;
+                            return -1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // check errors
         if (res == METIS_ERROR_INPUT) {
             opserr << "WARNING: metis input error\n";
             return -1;
@@ -2160,6 +2477,16 @@ int OPS_partition() {
         return -1;
     }
 
+    auto indexOf = [](idx_t id) -> idx_t {
+        return (id < 0) ? static_cast<idx_t>(-id - 1) : id;
+    };
+
+    // Nodes that appear in the mesh connectivity (same on every rank).
+    std::vector<char> inMesh(nn, 0);
+    for (idx_t j = 0; j < static_cast<idx_t>(eind.size()); ++j) {
+        inMesh[eind[j]] = 1;
+    }
+
     // get nodes in current processor and remove elements
     for (int i = 0; i < ne; ++i) {
 
@@ -2183,7 +2510,37 @@ int OPS_partition() {
         }
     }
 
-    // get nodes in current processor and remove mp
+    // Align npart for equalDOF/MP pairs identically on every rank (do not use
+    // local retention marks here — those differ across ranks).
+    {
+        auto &mps = domain->getMPs();
+        MP_Constraint *mp = 0;
+        while ((mp = mps()) != 0) {
+            const idx_t ir = indexOf(nind[mp->getNodeRetained()]);
+            const idx_t ic = indexOf(nind[mp->getNodeConstrained()]);
+            if (inMesh[ir] && !inMesh[ic]) {
+                npart[ic] = npart[ir];
+            } else if (inMesh[ic] && !inMesh[ir]) {
+                npart[ir] = npart[ic];
+            } else if (!inMesh[ir] && !inMesh[ic]) {
+                const idx_t owner =
+                    (npart[ir] < npart[ic]) ? npart[ir] : npart[ic];
+                npart[ir] = owner;
+                npart[ic] = owner;
+            }
+        }
+    }
+
+    // Orphans (no local element yet) stay on their npart owner so fixes /
+    // nodal mass / nodal loads are not dropped.
+    for (auto& item : nind) {
+        auto& id = item.second;
+        if (id >= 0 && npart[id] == pid) {
+            id = -id - 1;
+        }
+    }
+
+    // Keep MPs that touch a locally retained node; pull in the partner.
     auto &mps = domain->getMPs();
     MP_Constraint *mp = 0;
     while ((mp = mps()) != 0) {
@@ -2204,7 +2561,8 @@ int OPS_partition() {
         }
     }
 
-    // remove nodes
+    // remove nodes; for retained interface copies, keep nodal mass only on
+    // the npart owner rank (same ownership rule as nodal loads)
     for (const auto& item: nind) {
         int ndtag = item.first;
         auto id = item.second;
@@ -2216,6 +2574,21 @@ int OPS_partition() {
             auto pc = domain->removePressure_Constraint(ndtag);
             if (pc != 0) {
                 delete pc;
+            }
+        } else {
+            // retained node: decode original index and drop duplicate mass
+            id = -id - 1;
+            if (npart[id] != pid) {
+                Node *node = domain->getNode(ndtag);
+                if (node != 0) {
+                    Matrix zeroMass(node->getNumberDOF(), node->getNumberDOF());
+                    zeroMass.Zero();
+                    if (node->setMass(zeroMass) < 0) {
+                        opserr << "WARNING: failed to zero mass on node "
+                               << ndtag << " for partition ownership\n";
+                        return -1;
+                    }
+                }
             }
         }
     }
@@ -2255,13 +2628,13 @@ int OPS_partition() {
             }
         }
 
-        // remove elemental loads
+        // remove elemental loads for elements assigned to other ranks
+        // (epart holds METIS part ids 0..np-1, unlike the sign-encoded nind)
         auto& eloads = lp->getElementalLoads();
         ElementalLoad* eload = 0;
         while ((eload = eloads()) != 0) {
             int e = eload->getElementTag();
-            auto id = epart[eindex[e]];
-            if (id >= 0) {
+            if (epart[eindex[e]] != pid) {
                 lp->removeElementalLoad(eload->getTag());
                 delete eload;
             }

--- a/SRC/recorder/GmshRecorder.cpp
+++ b/SRC/recorder/GmshRecorder.cpp
@@ -25,6 +25,7 @@
 
 #include "GmshRecorder.h"
 #include <sstream>
+#include <vector>
 #include <elementAPI.h>
 #include <OPS_Globals.h>
 #include <Domain.h>
@@ -933,7 +934,7 @@ GmshRecorder::write_element_graph()
         theFile.precision(precision);
         theFile << std::scientific;
 
-        int numvertex_proc[nproc];
+        std::vector<int> numvertex_proc(nproc);
 
 
         int start_tag = maxvertextag;
@@ -954,7 +955,7 @@ GmshRecorder::write_element_graph()
             &numvertex,
             1,
             MPI_INT,
-            numvertex_proc,
+            numvertex_proc.data(),
             1,
             MPI_INT,
             MPI_COMM_WORLD);

--- a/SRC/system_of_eqn/eigenSOE/ArpackSOE.cpp
+++ b/SRC/system_of_eqn/eigenSOE/ArpackSOE.cpp
@@ -65,6 +65,22 @@ ArpackSOE::getNumEqn(void) const
 ArpackSOE::~ArpackSOE()
 {
   if (M != 0) delete [] M;
+
+  // Free only what this SOE owns: the per-SOE channel pointer array and the
+  // parallel bookkeeping. The Channel objects themselves are global (owned by
+  // the MachineBroker), so they are not deleted here (same rule as MumpsParallelSOE).
+  if (theChannels != 0)
+    delete [] theChannels;
+
+  if (localCol != 0) {
+    for (int i = 0; i < numChannels; i++)
+      if (localCol[i] != 0)
+	delete localCol[i];
+    delete [] localCol;
+  }
+
+  if (sizeLocal != 0)
+    delete sizeLocal;
 }
 
 int 
@@ -382,6 +398,40 @@ int
 ArpackSOE::setLinearSOE(LinearSOE &theLinearSOE)
 {
   theSOE = &theLinearSOE;
+  return 0;
+}
+
+int
+ArpackSOE::setProcessID(int dTag)
+{
+  processID = dTag;
+  return 0;
+}
+
+int
+ArpackSOE::setChannels(int nChannels, Channel **theC)
+{
+  numChannels = nChannels;
+
+  if (theChannels != 0)
+    delete [] theChannels;
+
+  theChannels = new Channel *[numChannels];
+  for (int i = 0; i < numChannels; i++)
+    theChannels[i] = theC[i];
+
+  if (localCol != 0)
+    delete [] localCol;
+
+  localCol = new ID *[numChannels];
+  for (int i = 0; i < numChannels; i++)
+    localCol[i] = 0;
+
+  if (sizeLocal != 0)
+    delete sizeLocal;
+
+  sizeLocal = new ID(numChannels);
+
   return 0;
 }
 

--- a/SRC/system_of_eqn/eigenSOE/ArpackSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/ArpackSOE.h
@@ -62,6 +62,10 @@ class ArpackSOE : public EigenSOE
     int sendSelf(int commitTag, Channel &theChannel);
     int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
 
+    // OpenSeesMP: same pattern as MumpsParallelSOE
+    int setProcessID(int processTag);
+    int setChannels(int nChannels, Channel **theChannels);
+
     friend class ArpackSolver;
 
 	int checkSameInt(int);

--- a/SRC/system_of_eqn/linearSOE/profileSPD/CMakeLists.txt
+++ b/SRC/system_of_eqn/linearSOE/profileSPD/CMakeLists.txt
@@ -34,7 +34,7 @@ target_sources(OPS_SysOfEqn
 
 if(PARALLEL_INTERPRETERS)
 
-elseif(PARALLEL)
+elseif(PARALLEL_PROCESSING)
 
 endif()
 

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/DistributedSuperLU.cpp
@@ -66,7 +66,7 @@
 
 #endif
 
-SuperLUStat_t stat;
+SuperLUStat_t slu_stat;
 SuperMatrix A;
 gridinfo_t grid;
 MPI_Comm comm_SuperLU;
@@ -188,7 +188,7 @@ DistributedSuperLU::solve(void)
     //
 
     pdgssvx_ABglobal(&options, &A, &ScalePermstruct, Xptr, ldb, nrhs, &grid,
-		     &LUstruct, berr, &stat, &info);
+		     &LUstruct, berr, &slu_stat, &info);
 
     if (theSOE->factored == false) {
       options.Fact = FACTORED;      
@@ -254,7 +254,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables.
   //
-  PStatInit(&stat);
+  PStatInit(&slu_stat);
   
   //
   // Create compressed column matrix for A. 
@@ -294,7 +294,7 @@ DistributedSuperLU::setSize()
   //
   // Initialize the statistics variables. 
   //
-  PStatInit(&stat);
+  PStatInit(&slu_stat);
 
   return 0;
 }

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -5607,7 +5607,20 @@ eigenAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 
       } else {
 
-	theEigenSOE = new ArpackSOE(shift);    
+	theEigenSOE = new ArpackSOE(shift);
+
+#ifdef _PARALLEL_INTERPRETERS
+	// OpenSeesMP: same pattern as MumpsParallelSOE
+	if (theSOE != 0) {
+	  int soeTag = theSOE->getClassTag();
+	  if (soeTag == LinSOE_TAGS_MumpsParallelSOE ||
+	      soeTag == LinSOE_TAGS_DistributedProfileSPDLinSOE) {
+	    ArpackSOE *theArpackSOE = (ArpackSOE *)theEigenSOE;
+	    theArpackSOE->setProcessID(OPS_rank);
+	    theArpackSOE->setChannels(numChannels, theChannels);
+	  }
+	}
+#endif
 
       }
       

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -95,6 +95,7 @@ OPS_Stream *opserrPtr = &sserr;
 
 #include <elementAPI.h>
 extern "C" int         OPS_ResetInputNoBuilder(ClientData clientData, Tcl_Interp * interp, int cArg, int mArg, TCL_Char * *argv, Domain * domain);
+extern int OPS_partition();
 
 #include <packages.h>
 
@@ -1903,7 +1904,14 @@ partitionModel(int eleTag)
 int 
 opsPartition(ClientData clientData, Tcl_Interp *interp, int argc, TCL_Char **argv)
 {
-#ifdef _PARALLEL_PROCESSING
+#ifdef _PARALLEL_INTERPRETERS
+  // METIS mesh partition (same algorithm as OpenSeesPy OPS_partition).
+  // cArg=1 skips argv[0]=="partition" so -ncuts/-niter/-ufactor/-info parse.
+  OPS_ResetInputNoBuilder(clientData, interp, 1, argc, argv, &theDomain);
+  if (OPS_partition() < 0)
+    return TCL_ERROR;
+  return TCL_OK;
+#elif defined(_PARALLEL_PROCESSING)
   int eleTag;
   if (argc == 2) {
     if (Tcl_GetInt(interp, argv[1], &eleTag) != TCL_OK) {

--- a/makeOpenSeesMP_Ubuntu.sh
+++ b/makeOpenSeesMP_Ubuntu.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# OpenSeesMP Ubuntu build (Ninja + Conan + Intel MPI/MKL).
+# Edit these paths for your machine or override them in the environment:
+#   IMPI_ROOT=/opt/intel/oneapi/mpi/latest \
+#   MUMPS_DIR=/path/to/mumps/build ./makeOpenSeesMP_Ubuntu.sh
+# ---------------------------------------------------------------------------
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${BUILD_DIR:-${ROOT_DIR}/build-mp}"
+MUMPS_DIR="${MUMPS_DIR:-${ROOT_DIR}/../mumps/build}"
+METIS5_DIR="${METIS5_DIR:-/usr}"
+IMPI_ROOT="${IMPI_ROOT:-/opt/intel/oneapi/mpi/2021.16}"
+MKL_LIB="${MKL_LIB:-/opt/intel/oneapi/mkl/2025.2/lib}"
+JOBS="${JOBS:-$(nproc)}"
+
+cd "${ROOT_DIR}"
+
+if [[ -f /opt/intel/oneapi/setvars.sh ]]; then
+  set +u
+  # shellcheck source=/dev/null
+  source /opt/intel/oneapi/setvars.sh --force
+  set -u
+fi
+
+if [[ ! -x "${IMPI_ROOT}/bin/mpigcc" ]]; then
+  echo "ERROR: Intel MPI not found under: ${IMPI_ROOT}" >&2
+  exit 1
+fi
+if [[ ! -f "${MUMPS_DIR}/libdmumps.a" ]]; then
+  echo "ERROR: MUMPS libraries not found under: ${MUMPS_DIR}" >&2
+  exit 1
+fi
+if [[ ! -f "${METIS5_DIR}/include/metis.h" ]]; then
+  echo "ERROR: METIS 5 headers not found under: ${METIS5_DIR}" >&2
+  echo "Install libmetis-dev or set METIS5_DIR." >&2
+  exit 1
+fi
+
+# MUMPS was built against Intel MPI and LP64 MKL ScaLAPACK.
+SCALAPACK_LIBRARIES="${SCALAPACK_LIBRARIES:-\
+${MKL_LIB}/libmkl_scalapack_lp64.so;\
+${MKL_LIB}/libmkl_gf_lp64.so;\
+${MKL_LIB}/libmkl_gnu_thread.so;\
+${MKL_LIB}/libmkl_core.so;\
+${MKL_LIB}/libmkl_blacs_intelmpi_lp64.so}"
+
+# Conan provides Tcl, HDF5, Eigen and zlib.
+conan install . -of "${BUILD_DIR}" \
+  -s build_type=Release \
+  -s arch=x86_64 \
+  --build=missing \
+  -c tools.cmake.cmaketoolchain:generator=Ninja
+
+# Conan 2 layouts can place the toolchain in either location.
+TOOLCHAIN="${BUILD_DIR}/build/Release/generators/conan_toolchain.cmake"
+if [[ ! -f "${TOOLCHAIN}" ]]; then
+  TOOLCHAIN="${BUILD_DIR}/Release/generators/conan_toolchain.cmake"
+fi
+if [[ ! -f "${TOOLCHAIN}" ]]; then
+  echo "ERROR: Conan CMake toolchain was not generated." >&2
+  exit 1
+fi
+
+cmake -S . -B "${BUILD_DIR}/Release" -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMPI_C_COMPILER="${IMPI_ROOT}/bin/mpigcc" \
+  -DMPI_CXX_COMPILER="${IMPI_ROOT}/bin/mpigxx" \
+  -DMPI_Fortran_COMPILER="${IMPI_ROOT}/bin/mpif90" \
+  -DMUMPS_DIR="${MUMPS_DIR}" \
+  -DMETIS5_DIR="${METIS5_DIR}" \
+  -DSCALAPACK_LIBRARIES="${SCALAPACK_LIBRARIES}" \
+  -UOPENMPI \
+  -DPARALLEL_PROCESSING=OFF
+
+cmake --build "${BUILD_DIR}/Release" \
+  --target OpenSeesMP \
+  --parallel "${JOBS}"
+
+# OpenSeesMP looks for Tcl's init.tcl under build-mp/lib at runtime.
+# Must match conanfile.py tcl/8.6.11 (not an older cached tcl/8.6.10 package).
+TCL_VERSION="8.6.11"
+TCL_STAGED=0
+for TCL_PKG_LIB in "${HOME}/.conan2/p/b"/tcl*/p/lib; do
+  INIT_TCL="${TCL_PKG_LIB}/tcl8.6/init.tcl"
+  if [[ -f "${INIT_TCL}" ]] && grep -q "package require -exact Tcl ${TCL_VERSION}" "${INIT_TCL}"; then
+    mkdir -p "${BUILD_DIR}/lib"
+    cp -a "${TCL_PKG_LIB}/tcl8.6" "${TCL_PKG_LIB}/tcl8" "${BUILD_DIR}/lib/"
+    TCL_STAGED=1
+    break
+  fi
+done
+if [[ "${TCL_STAGED}" -ne 1 ]]; then
+  echo "ERROR: Conan Tcl ${TCL_VERSION} runtime was not found under ${HOME}/.conan2/p/b." >&2
+  exit 1
+fi
+
+echo
+echo "OpenSeesMP built successfully:"
+echo "  ${BUILD_DIR}/Release/OpenSeesMP"

--- a/makeOpenSeesMP_WIN.bat
+++ b/makeOpenSeesMP_WIN.bat
@@ -1,0 +1,101 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM ---------------------------------------------------------------------------
+REM OpenSeesMP Windows build (Ninja + Conan + Intel oneAPI).
+REM Edit these paths for your machine.
+REM ---------------------------------------------------------------------------
+set "BUILD_DIR=build-mp"
+set "MUMPS_DIR=%~dp0..\mumps\build"
+set "METIS5_DIR=%~dp0..\metis-5.1.0\install"
+set "ONEAPI_SETVARS=C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+set "JOBS=10"
+
+cd /d "%~dp0"
+
+if not exist "!ONEAPI_SETVARS!" (
+  echo ERROR: Intel oneAPI setvars.bat not found:
+  echo   !ONEAPI_SETVARS!
+  exit /b 1
+)
+if not exist "!MUMPS_DIR!\dmumps.lib" (
+  echo ERROR: MUMPS libraries not found under:
+  echo   !MUMPS_DIR!
+  exit /b 1
+)
+if not exist "!METIS5_DIR!\include\metis.h" (
+  echo ERROR: METIS 5 headers not found under:
+  echo   !METIS5_DIR!
+  exit /b 1
+)
+
+call "!ONEAPI_SETVARS!" intel64 mod
+if errorlevel 1 exit /b 1
+
+REM Conan provides Tcl, HDF5, Eigen and zlib.
+conan install . -of "!BUILD_DIR!" ^
+  -s build_type=Release ^
+  -s arch=x86_64 ^
+  -s compiler.runtime=static ^
+  --build=missing ^
+  -c tools.cmake.cmaketoolchain:generator=Ninja
+if errorlevel 1 exit /b 1
+
+REM Conan 2 layouts can place the toolchain in either location.
+set "TOOLCHAIN=!BUILD_DIR!\build\Release\generators\conan_toolchain.cmake"
+if not exist "!TOOLCHAIN!" set "TOOLCHAIN=!BUILD_DIR!\Release\generators\conan_toolchain.cmake"
+if not exist "!TOOLCHAIN!" (
+  echo ERROR: Conan CMake toolchain was not generated.
+  exit /b 1
+)
+
+cmake -S . -B "!BUILD_DIR!\Release" -G Ninja ^
+  -DCMAKE_TOOLCHAIN_FILE="!TOOLCHAIN!" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ^
+  -DCMAKE_EXE_LINKER_FLAGS="/FORCE:MULTIPLE" ^
+  -DCMAKE_SHARED_LINKER_FLAGS="/FORCE:MULTIPLE" ^
+  -DCMAKE_Fortran_COMPILER=ifx ^
+  -DBLA_STATIC=ON ^
+  -DMKL_LINK=static ^
+  -DMKL_INTERFACE_FULL=intel_lp64 ^
+  -DMUMPS_DIR="!MUMPS_DIR!" ^
+  -DMETIS5_DIR="!METIS5_DIR!" ^
+  -UOPENSEES_METIS5_LIBRARY ^
+  -UOPENMPI ^
+  -DPARALLEL_PROCESSING=OFF ^
+  -DCMAKE_NINJA_FORCE_RESPONSE_FILE=ON ^
+  -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS=ON ^
+  -DCMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS=ON
+if errorlevel 1 exit /b 1
+
+cmake --build "!BUILD_DIR!\Release" --target OpenSeesMP --parallel !JOBS!
+if errorlevel 1 exit /b 1
+
+REM OpenSeesMP.exe looks for Tcl's init.tcl under build-mp\lib at runtime.
+REM Must match conanfile.py tcl/8.6.11 (not an older cached tcl/8.6.10 package).
+set "TCL_VERSION=8.6.11"
+set "TCL_PKG_LIB="
+for /d %%d in ("%USERPROFILE%\.conan2\p\b\tcl*") do (
+  if exist "%%d\p\lib\tcl8.6\init.tcl" (
+    findstr /C:"package require -exact Tcl !TCL_VERSION!" "%%d\p\lib\tcl8.6\init.tcl" >nul 2>&1 && (
+      set "TCL_PKG_LIB=%%d\p\lib"
+      goto tcl_found
+    )
+  )
+)
+echo ERROR: Conan Tcl !TCL_VERSION! not found under %USERPROFILE%\.conan2\p\b.
+exit /b 1
+
+:tcl_found
+if not exist "!BUILD_DIR!\lib" mkdir "!BUILD_DIR!\lib"
+robocopy "!TCL_PKG_LIB!\tcl8.6" "!BUILD_DIR!\lib\tcl8.6" /E /NFL /NDL /NJH /NJS /NC /NS >nul
+if errorlevel 8 exit /b 1
+robocopy "!TCL_PKG_LIB!\tcl8" "!BUILD_DIR!\lib\tcl8" /E /NFL /NDL /NJH /NJS /NC /NS >nul
+if errorlevel 8 exit /b 1
+echo Tcl !TCL_VERSION! copied to !BUILD_DIR!\lib\
+
+echo.
+echo OpenSeesMP built successfully:
+echo   %CD%\!BUILD_DIR!\Release\OpenSeesMP.exe
+endlocal


### PR DESCRIPTION
## Summary

This PR enables model partitioning in `OpenSeesMP` through the existing `OPS_partition` implementation already used by `OpenSeesPy`. It also enables parallel ARPACK eigenvalue analysis with `system Mumps` and `numberer ParallelPlain`.

## Changes

- Exposes the existing [`partition`](https://openseespydoc.readthedocs.io/en/latest/src/partition.html) command in `OpenSeesMP`.

- Adds METIS 5 discovery and linking for Linux and Windows. OpenSees includes a bundled copy of METIS 4 for legacy graph partitioning, so the build configuration keeps the METIS 4 and METIS 5 headers and libraries separate.

- Fixes several correctness issues in `OPS_partition`, including:
  - retaining element loads only on the rank that owns the corresponding element;
  - assigning nodal mass to a single owning rank;
  - retaining fixed and constrained floating nodes appropriately; and
  - maintaining consistent ownership for `equalDOF`/MP-constrained nodes.

- Adds `-samePart`, which constrains groups of elements to the same METIS partition. This is useful for elements such as springs using [`PyLiq1`](https://openseespydoc.readthedocs.io/en/latest/src/PyLiq1.html), which obtain state information from other elements.

  Each group is specified by its element count followed by the element tags:

  ```tcl
  partition -samePart 3 101 102 103 \
            -samePart 2 201 202
  ```

- Adds `-customPartition`, allowing users to provide explicit element-to-part assignments instead of using METIS. Part IDs are zero-based.

  ```tcl
  partition -customPartition 4 \
      1 0 \
      2 0 \
      3 1 \
      4 1
  ```

  Unlisted elements are assigned to part 0 with a warning.

- Enables parallel ARPACK eigenvalue analysis by providing `ArpackSOE` with the MPI process ID and communication channels already used by the parallel system of equations. Eigenvalue analysis can therefore be performed both before and after partitioning.

- Emits a warning when equation constraints are present because their partitioning behavior is not yet fully supported.

## Example

A self-contained 3D brick example is provided at:

```text
EXAMPLES/Partition/Example.tcl
```

It compares serial execution with standard METIS partitioning, custom partitioning, and `-samePart`. The example prints gravity displacements, eigenvalues, and transient displacements for direct comparison.

For example:

```bash
OpenSees Example.tcl serial 4 4 20
mpiexec -n 4 OpenSeesMP Example.tcl metis 4 4 20
mpiexec -n 4 OpenSeesMP Example.tcl custom 4 4 20
mpiexec -n 4 OpenSeesMP Example.tcl samePart 4 4 20
```

The example was verified with 2–8 MPI processes.

## Build notes

METIS 5 is readily available through Linux package managers, but setting it up on Windows requires building it separately. Installation instructions are provided in:

```text
README-Windows-METIS5.md
```

Example `OpenSeesMP` build scripts are also included:

```text
makeOpenSeesMP_Ubuntu.sh
makeOpenSeesMP_WIN.bat
```

These changes allow models that previously relied on `OpenSeesSP` partitioning to run in `OpenSeesMP` with minimal script changes. Although the primary focus is `OpenSeesMP`, the fixes within `OPS_partition` also benefit `OpenSeesPy` users.