### PR TITLE
Wire parallel Arpack eigen for OpenSeesMP.

### DIFF
--- a/SRC/interpreter/OpenSeesCommands.cpp
+++ b/SRC/interpreter/OpenSeesCommands.cpp
@@ -348,6 +348,23 @@ OpenSeesCommands::eigen(int typeSolver, double shift,
 
                 theEigenSOE = new ArpackSOE(shift);
 
+#ifdef _PARALLEL_INTERPRETERS
+                // OpenSeesMP / OpenSeesPy: same pattern as MumpsParallelSOE
+                if (theSOE != 0) {
+                    int soeTag = theSOE->getClassTag();
+                    if (soeTag == LinSOE_TAGS_MumpsParallelSOE ||
+                        soeTag == LinSOE_TAGS_DistributedProfileSPDLinSOE) {
+                        ArpackSOE *theArpackSOE = (ArpackSOE *)theEigenSOE;
+                        MachineBroker *theMachineBroker = this->getMachineBroker();
+                        if (theMachineBroker != 0) {
+                            theArpackSOE->setProcessID(theMachineBroker->getPID());
+                            theArpackSOE->setChannels(this->getNumChannels(),
+                                                      this->getChannels());
+                        }
+                    }
+                }
+#endif
+
             }
 
             eigenSOEUpdated = true;

--- a/SRC/system_of_eqn/eigenSOE/ArpackSOE.cpp
+++ b/SRC/system_of_eqn/eigenSOE/ArpackSOE.cpp
@@ -65,6 +65,22 @@ ArpackSOE::getNumEqn(void) const
 ArpackSOE::~ArpackSOE()
 {
   if (M != 0) delete [] M;
+
+  // Free only what this SOE owns: the per-SOE channel pointer array and the
+  // parallel bookkeeping. The Channel objects themselves are global (owned by
+  // the MachineBroker), so they are not deleted here (same rule as MumpsParallelSOE).
+  if (theChannels != 0)
+    delete [] theChannels;
+
+  if (localCol != 0) {
+    for (int i = 0; i < numChannels; i++)
+      if (localCol[i] != 0)
+	delete localCol[i];
+    delete [] localCol;
+  }
+
+  if (sizeLocal != 0)
+    delete sizeLocal;
 }
 
 int 
@@ -382,6 +398,40 @@ int
 ArpackSOE::setLinearSOE(LinearSOE &theLinearSOE)
 {
   theSOE = &theLinearSOE;
+  return 0;
+}
+
+int
+ArpackSOE::setProcessID(int dTag)
+{
+  processID = dTag;
+  return 0;
+}
+
+int
+ArpackSOE::setChannels(int nChannels, Channel **theC)
+{
+  numChannels = nChannels;
+
+  if (theChannels != 0)
+    delete [] theChannels;
+
+  theChannels = new Channel *[numChannels];
+  for (int i = 0; i < numChannels; i++)
+    theChannels[i] = theC[i];
+
+  if (localCol != 0)
+    delete [] localCol;
+
+  localCol = new ID *[numChannels];
+  for (int i = 0; i < numChannels; i++)
+    localCol[i] = 0;
+
+  if (sizeLocal != 0)
+    delete sizeLocal;
+
+  sizeLocal = new ID(numChannels);
+
   return 0;
 }
 

--- a/SRC/system_of_eqn/eigenSOE/ArpackSOE.h
+++ b/SRC/system_of_eqn/eigenSOE/ArpackSOE.h
@@ -62,6 +62,10 @@ class ArpackSOE : public EigenSOE
     int sendSelf(int commitTag, Channel &theChannel);
     int recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker);
 
+    // OpenSeesMP: same pattern as MumpsParallelSOE
+    int setProcessID(int processTag);
+    int setChannels(int nChannels, Channel **theChannels);
+
     friend class ArpackSolver;
 
 	int checkSameInt(int);

--- a/SRC/tcl/commands.cpp
+++ b/SRC/tcl/commands.cpp
@@ -5599,7 +5599,20 @@ eigenAnalysis(ClientData clientData, Tcl_Interp *interp, int argc,
 
       } else {
 
-	theEigenSOE = new ArpackSOE(shift);    
+	theEigenSOE = new ArpackSOE(shift);
+
+#ifdef _PARALLEL_INTERPRETERS
+	// OpenSeesMP: same pattern as MumpsParallelSOE
+	if (theSOE != 0) {
+	  int soeTag = theSOE->getClassTag();
+	  if (soeTag == LinSOE_TAGS_MumpsParallelSOE ||
+	      soeTag == LinSOE_TAGS_DistributedProfileSPDLinSOE) {
+	    ArpackSOE *theArpackSOE = (ArpackSOE *)theEigenSOE;
+	    theArpackSOE->setProcessID(OPS_rank);
+	    theArpackSOE->setChannels(numChannels, theChannels);
+	  }
+	}
+#endif
 
       }
       


### PR DESCRIPTION
## Summary

Propagate the MPI process ID and channels into `ArpackSOE` when the linear SOE is a parallel Mumps or distributed ProfileSPD system. This enables correct parallel ARPACK eigenvalue analysis in OpenSeesMP with `system Mumps` or `system ParallelProfileSPD`.

## Minimal Working Example

The following example creates a 2.0 × 1.5 × 10 m cantilever column with a `4 × 4 × 16` brick mesh. Each MPI rank creates a contiguous vertical segment of the global mesh.

For `np = 1`, the script uses serial `ProfileSPD`. For `np > 1`, it uses either `Mumps` + `ParallelPlain` or `ParallelProfileSPD` + `ParallelRCM`.

```tcl
# Filename: eigenTest.tcl
#
# Run:
#   OpenSees eigenTest.tcl
#   mpiexec -n 4 OpenSeesMP eigenTest.tcl mumps
#   mpiexec -n 4 OpenSeesMP eigenTest.tcl profilespd

wipe

set pid [getPID]
set np  [getNP]

set nx 4
set ny 4
set nz 16

if {$nz % $np != 0} {
    if {$pid == 0} {
        puts "ERROR: nz must be divisible by np"
    }
    exit 1
}

model BasicBuilder -ndm 3 -ndf 3
nDMaterial ElasticIsotropic 1 2.5e7 0.20 2.4

# Each rank creates one contiguous vertical segment of the global mesh.
set localNz    [expr {$nz/$np}]
set firstLayer [expr {$pid*$localNz}]
set z0         [expr {10.0*$firstLayer/$nz}]
set z1         [expr {10.0*($firstLayer+$localNz)/$nz}]

set nodesPerLayer [expr {($nx+1)*($ny+1)}]
set elesPerLayer  [expr {$nx*$ny}]
set startNode     [expr {$firstLayer*$nodesPerLayer + 1}]
set startEle      [expr {$firstLayer*$elesPerLayer + 1}]

# We can use block3D because it creates nodes and elements in a deterministic
# order. Computing startNode and startEle from the first global layer gives
# neighboring ranks identical node tags along their shared interface.
block3D $nx $ny $localNz $startNode $startEle stdBrick 1 [subst {
    1 -1.0 -0.75 $z0   2  1.0 -0.75 $z0
    3  1.0  0.75 $z0   4 -1.0  0.75 $z0
    5 -1.0 -0.75 $z1   6  1.0 -0.75 $z1
    7  1.0  0.75 $z1   8 -1.0  0.75 $z1
}]

# Fix the base of the cantilever.
if {$pid == 0} {
    for {set nodeTag 1} {$nodeTag <= $nodesPerLayer} {incr nodeTag} {
        fix $nodeTag 1 1 1
    }
}

# Optional argument for parallel runs: "mumps" or "profilespd".
set solver [expr {
    $argc > 0 ? [string tolower [lindex $argv 0]] : "mumps"
}]

if {$np == 1} {
    set numbererName RCM
    set systemName ProfileSPD
} elseif {$solver eq "profilespd"} {
    set numbererName ParallelRCM
    set systemName ParallelProfileSPD
} else {
    set numbererName ParallelPlain
    set systemName Mumps
}

constraints Plain
numberer $numbererName
system $systemName

set lambda [eigen 3]

if {$pid == 0} {
    puts [format \
        "RESULT np=%d numberer=%s system=%s lambda={%.16e %.16e %.16e}" \
        $np $numbererName $systemName \
        [lindex $lambda 0] \
        [lindex $lambda 1] \
        [lindex $lambda 2]]
}

wipe
exit 0
```

Run:

```bash
OpenSees eigenTest.tcl

mpiexec -n 2 OpenSeesMP eigenTest.tcl mumps
mpiexec -n 4 OpenSeesMP eigenTest.tcl mumps
mpiexec -n 8 OpenSeesMP eigenTest.tcl mumps

mpiexec -n 2 OpenSeesMP eigenTest.tcl profilespd
mpiexec -n 4 OpenSeesMP eigenTest.tcl profilespd
mpiexec -n 8 OpenSeesMP eigenTest.tcl profilespd
```

Without this PR, a distributed run aborts. For example:

```text
WARNING MumpsParallelSOE::setB() - incompatible sizes 1200 and 675
Vector::Assemble() ... out of range
double free or corruption (out)
KILLED BY SIGNAL: 6 (Aborted)
```

With this PR, serial and parallel runs agree to approximately 12–13 significant digits:

```text
RESULT np=1 numberer=RCM system=ProfileSPD lambda={2.5438823814805701e+03 4.2785593897652525e+03 8.5057954017445794e+04}

RESULT np=2 numberer=ParallelPlain system=Mumps lambda={2.5438823814859293e+03 4.2785593897645267e+03 8.5057954017455006e+04}
RESULT np=4 numberer=ParallelPlain system=Mumps lambda={2.5438823814908160e+03 4.2785593897622584e+03 8.5057954017456810e+04}
RESULT np=8 numberer=ParallelPlain system=Mumps lambda={2.5438823814891330e+03 4.2785593897619974e+03 8.5057954017455893e+04}

RESULT np=2 numberer=ParallelRCM system=ParallelProfileSPD lambda={2.5438823814806874e+03 4.2785593897649542e+03 8.5057954017446638e+04}
RESULT np=4 numberer=ParallelRCM system=ParallelProfileSPD lambda={2.5438823814812404e+03 4.2785593897632543e+03 8.5057954017446158e+04}
RESULT np=8 numberer=ParallelRCM system=ParallelProfileSPD lambda={2.5438823814819020e+03 4.2785593897604704e+03 8.5057954017445794e+04}
```

Note: This should work in OpenSeesPy too, but I haven't tested it!