### PR TITLE
Fix CreepShrinkageACI209 revertToLastCommit stale-time re-evaluation

### DIFF
--- a/SRC/material/uniaxial/CreepShrinkageACI209.cpp
+++ b/SRC/material/uniaxial/CreepShrinkageACI209.cpp
@@ -243,9 +243,9 @@ UniaxialMaterial* CreepShrinkageACI209::getCopy(void)
   theCopy->committedMechanicalStrain = committedMechanicalStrain;
   theCopy->committedTotalStrain = committedTotalStrain;
 
-  theCopy->iterationInStep = iterationInStep;
+  theCopy->creepComputedTime = creepComputedTime;
   theCopy->historyPointCount = historyPointCount;
-  
+
   // Ensure array capacity and copy history
   theCopy->maxSize = maxSize;
   theCopy->DSIG_i = new double[maxSize];
@@ -317,8 +317,7 @@ int
 CreepShrinkageACI209::setTrialStrain(double strain, double strainRate)
 {
   double t = getCurrentTime();
-  
-  
+
   // Enforce non-negative time only when creep is enabled.
   if (ops_Creep == 1 && t < 0.0) {
     opserr << "CreepShrinkageACI209::setTrialStrain - Negative time (" << t
@@ -327,18 +326,12 @@ CreepShrinkageACI209::setTrialStrain(double strain, double strainRate)
   }
 
   trialTotalStrain = strain;
-  
+
   if (ops_Creep == 1) {
-    if (fabs(t-TIME_i[historyPointCount]) <= 0.0001) {
-      trialCreepStrain = committedCreepStrain;
-      trialShrinkageStrain = committedShrinkageStrain;
-      iterationInStep = 0;
-    } else {
-      if (iterationInStep < 1) {
-        trialCreepStrain = setCreepStrain(t);
-        trialShrinkageStrain = setShrink(t);
-      }
-      iterationInStep ++;
+    if (fabs(t - creepComputedTime) > 1e-6) {
+      trialCreepStrain = setCreepStrain(t);
+      trialShrinkageStrain = setShrink(t);
+      creepComputedTime = t;
     }
   } else {
     trialCreepStrain = committedCreepStrain;
@@ -374,8 +367,6 @@ CreepShrinkageACI209::getTangent(void)
 
 int CreepShrinkageACI209::commitState(void)
 {
-  iterationInStep = 0;
-
   if (ops_Creep == 1 && fabs(trialStress - committedCreepStress) > 1e-12) {
     double dSig = trialStress - committedCreepStress;
     this->expandArrays();
@@ -398,10 +389,11 @@ int CreepShrinkageACI209::commitState(void)
 }
 
 
-int 
+int
   CreepShrinkageACI209::revertToLastCommit(void)
 {
-  iterationInStep = 0;
+  creepComputedTime = -1.0; // invalidate cache; -1 is safe, negative t is rejected when creep is on
+
   // Restore trial state to last committed state
   trialTotalStrain = committedTotalStrain;
   trialShrinkageStrain = committedShrinkageStrain;
@@ -410,38 +402,38 @@ int
 
   trialTangent = committedTangent;
   trialStress = committedStress;
-  
+
   wrappedMaterial->revertToLastCommit();
-  
+
   return 0;
 }
 
-int 
+int
 CreepShrinkageACI209::revertToStart(void)
 {
-  
+
   committedTangent     = Ec;
   committedStress      = 0.0;
   trialStress          = 0.0;
   committedCreepStress = 0.0;
   trialTangent         = Ec;
 
- 
+
   historyPointCount = 0;
 
-  
+
   trialTotalStrain          = 0.0;
   committedTotalStrain      = 0.0;
   trialCreepStrain          = 0.0;
   trialShrinkageStrain      = 0.0;
   trialMechanicalStrain     = 0.0;
   committedCreepStrain      = 0.0;
-  committedShrinkageStrain  = 0.0; 
+  committedShrinkageStrain  = 0.0;
   committedMechanicalStrain = 0.0;
 
-  iterationInStep = 0;
+  creepComputedTime = -1.0; // invalidate cache, see revertToLastCommit()
 
-  if (wrappedMaterial) 
+  if (wrappedMaterial)
     wrappedMaterial->revertToStart();
 
   return 0;
@@ -482,11 +474,11 @@ CreepShrinkageACI209::sendSelf(int commitTag, Channel &theChannel)
   data(i++) = epscru;
   data(i++) = epscrd;
   data(i++) = tcast;
-  
+
   data(i++) = committedStress;
   data(i++) = committedTangent;
   data(i++) = committedCreepStress;
-  
+
   data(i++) = historyPointCount;
   data(i++) = trialCreepStrain;
   data(i++) = trialShrinkageStrain;
@@ -496,7 +488,7 @@ CreepShrinkageACI209::sendSelf(int commitTag, Channel &theChannel)
   data(i++) = committedShrinkageStrain;
   data(i++) = trialTotalStrain;
   data(i++) = committedTotalStrain;
-  data(i++) = iterationInStep;
+  data(i++) = creepComputedTime;
 
   for (int j = 0; j < maxSize; j++, i++)
     data(i) = DSIG_i[j];
@@ -541,32 +533,32 @@ CreepShrinkageACI209::recvSelf(int commitTag, Channel &theChannel,
     opserr << "CreepShrinkageACI209::recvSelf() - failed to recvSelf\n";
     return -1;
   }
-  
+
   int i = 0;
-  tcr = data(i++);    
-  Ec = data(i++);     
-  age = data(i++);     
-  epsshu = data(i++); 
-  epssha = data(i++); 
-  epscra = data(i++); 
-  epscru = data(i++); 
-  epscrd = data(i++); 
-  tcast = data(i++); 
+  tcr = data(i++);
+  Ec = data(i++);
+  age = data(i++);
+  epsshu = data(i++);
+  epssha = data(i++);
+  epscra = data(i++);
+  epscru = data(i++);
+  epscrd = data(i++);
+  tcast = data(i++);
 
   committedStress = data(i++);
   committedTangent = data(i++);
   committedCreepStress = data(i++);
-  
-  historyPointCount = data(i++);        
-  trialCreepStrain = data(i++);         
-  trialShrinkageStrain = data(i++);     
-  trialMechanicalStrain = data(i++);    
+
+  historyPointCount = data(i++);
+  trialCreepStrain = data(i++);
+  trialShrinkageStrain = data(i++);
+  trialMechanicalStrain = data(i++);
   committedMechanicalStrain = data(i++);
-  committedCreepStrain = data(i++);     
-  committedShrinkageStrain = data(i++); 
-  trialTotalStrain = data(i++);         
-  committedTotalStrain = data(i++);     
-  iterationInStep = data(i++);          
+  committedCreepStrain = data(i++);
+  committedShrinkageStrain = data(i++);
+  trialTotalStrain = data(i++);
+  committedTotalStrain = data(i++);
+  creepComputedTime = data(i++);
 
   if (DSIG_i != 0) delete [] DSIG_i;
   DSIG_i = new double [maxSize];
@@ -660,7 +652,7 @@ Response* CreepShrinkageACI209::setResponse(const char **argv, int argc,
     theOutput.tag("ResponseType", "C11");
     theResponse =  new MaterialResponse(this, 5, Vector(3));
   }
-  
+
   theOutput.endTag();
   return theResponse;
 }

--- a/SRC/material/uniaxial/CreepShrinkageACI209.h
+++ b/SRC/material/uniaxial/CreepShrinkageACI209.h
@@ -121,7 +121,7 @@ private:
   double committedTotalStrain;       // Last committed total strain
 
   int    historyPointCount;          // Number of points in stress-time history
-  int    iterationInStep;            // Iteration counter to avoid recomputing within same step 
+  double creepComputedTime;          // Time at which creep/shrinkage were last computed
 
   enum{startSize=500, growSize=200};
   int maxSize;                       // Current allocated size of history arrays


### PR DESCRIPTION
Drop iterationInStep in favor of creepComputedTime, set on every commit instead of relying on a creep-history slot that can go stale when stress stays flat for many steps.