### PR TITLE
Return consistent tangent in Penalty and Lagrange constraints

### DIFF
--- a/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.cpp
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.cpp
@@ -17,12 +17,12 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.0 $
 // $Date: 2025-05-09$
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.cpp,v $
-                                                                        
-                                                                        
+
+
 // Written: Yuli Huang (yulee@berkeley.edu)
 // Created: 05/2020
 // Revision: A
@@ -47,41 +47,46 @@
 #include <DOF_Group.h>
 
 LagrangeEQ_FE::LagrangeEQ_FE(int tag, Domain &theDomain, EQ_Constraint &TheEQ,
-			     DOF_Group &theGroup, double Alpha)
-:FE_Element(tag, 2+(TheEQ.getRetainedDOFs()).Size(),
- 2+(TheEQ.getRetainedDOFs()).Size()),
- alpha(Alpha), theEQ(&TheEQ), 
- theConstrainedNode(0), theRetainedNode(0),
- theDofGroup(&theGroup), tang(0), resid(0)
+                             DOF_Group &theGroup, double Alpha)
+    : FE_Element(tag, 2 + (TheEQ.getRetainedDOFs()).Size(),
+                 2 + (TheEQ.getRetainedDOFs()).Size()),
+      theEQ(&TheEQ),
+      theConstrainedNode(0), theRetainedNode(0),
+      theDofGroup(&theGroup), tang(0), sysTang(0), resid(0),
+      timeVarying(TheEQ.isTimeVarying()), urLoaded(false),
+      alpha(Alpha),
+      numU(1 + (TheEQ.getRetainedDOFs()).Size())
 {
     int size = 2 + (theEQ->getRetainedDOFs()).Size();
-    
-    tang = new Matrix(size,size);
+
+    tang = new Matrix(size, size);
+    sysTang = new Matrix(size, size);
     resid = new Vector(size);
-    if (tang == 0 || resid == 0 || tang->noCols() == 0 || resid->Size() == 0) {
-	    opserr << "FATAL LagrangeEQ_FE::LagrangeEQ_FE() - out of memory\n";
-	    exit(-1);
+    if (tang == 0 || sysTang == 0 || resid == 0 ||
+        tang->noCols() == 0 || sysTang->noCols() == 0 || resid->Size() == 0) {
+        opserr << "FATAL LagrangeEQ_FE::LagrangeEQ_FE() - out of memory\n";
+        exit(-1);
     }
-    tang->Zero();	
+    tang->Zero();
+    sysTang->Zero();
     resid->Zero();
 
     theConstrainedNode = theDomain.getNode(theEQ->getNodeConstrained());
-
     if (theConstrainedNode == 0) {
-	    opserr << "FATAL LagrangeEQ_FE::LagrangeEQ_FE() - Constrained";
-	    opserr << " Node does not exist in Domain\n";
-	    opserr << theEQ->getNodeConstrained() << endln;
-	    exit(-1);
+        opserr << "FATAL LagrangeEQ_FE::LagrangeEQ_FE() - Constrained";
+        opserr << " Node does not exist in Domain\n";
+        opserr << theEQ->getNodeConstrained() << endln;
+        exit(-1);
     }
 
     DOF_Group *theConstrainedNodeDOFGrpPtr = theConstrainedNode->getDOF_GroupPtr();
-    if (theConstrainedNodeDOFGrpPtr != 0) 
-        myDOF_Groups(0) = theConstrainedNodeDOFGrpPtr->getTag();	        
+    if (theConstrainedNodeDOFGrpPtr != 0)
+        myDOF_Groups(0) = theConstrainedNodeDOFGrpPtr->getTag();
     else
-        opserr << "WARNING LagrangeEQ_FE::LagrangeEQ_FE() - no DOF_Group with Constrained Node\n"; 
+        opserr << "WARNING LagrangeEQ_FE::LagrangeEQ_FE() - no DOF_Group with Constrained Node\n";
 
     const ID &nodeRetained = theEQ->getNodeRetained();
-    theRetainedNode = new Node*[nodeRetained.Size()];
+    theRetainedNode = new Node *[nodeRetained.Size()];
     for (int i = 0; i < nodeRetained.Size(); ++i) {
         theRetainedNode[i] = theDomain.getNode(nodeRetained(i));
         if (theRetainedNode[i] == 0) {
@@ -91,40 +96,43 @@ LagrangeEQ_FE::LagrangeEQ_FE(int tag, Domain &theDomain, EQ_Constraint &TheEQ,
             exit(-1);
         }
         DOF_Group *theRetainedNodeDOFGrpPtr = theRetainedNode[i]->getDOF_GroupPtr();
-        if (theRetainedNodeDOFGrpPtr != 0) 
-            myDOF_Groups(i+1) = theRetainedNodeDOFGrpPtr->getTag();	    
-        else 
+        if (theRetainedNodeDOFGrpPtr != 0)
+            myDOF_Groups(i + 1) = theRetainedNodeDOFGrpPtr->getTag();
+        else
             opserr << "WARNING LagrangeEQ_FE::LagrangeEQ_FE() - no DOF_Group with Retained Node\n";
     }
 
     myDOF_Groups(nodeRetained.Size() + 1) = theDofGroup->getTag();
 
-    if (theEQ->isTimeVarying() == false) {
+    if (!timeVarying)
         this->determineTangent();
-    }
 }
 
 LagrangeEQ_FE::~LagrangeEQ_FE()
 {
+    if (theRetainedNode != 0)
+        delete[] theRetainedNode;
     if (tang != 0)
-	delete tang;
+        delete tang;
+    if (sysTang != 0)
+        delete sysTang;
     if (resid != 0)
-	delete resid;
-}    
+        delete resid;
+}
 
 // void setID(int index, int value);
-//	Method to set the corresponding index of the ID to value.
+//      Method to set the corresponding index of the ID to value.
 int
 LagrangeEQ_FE::setID(void)
 {
     int result = 0;
 
     // first determine the IDs in myID for those DOFs marked
-    // as constrainedDOF DOFs, this is obtained from the DOF_Group
-    // associated with the constrainedDOF node
+    // as constrained DOFs, this is obtained from the DOF_Group
+    // associated with the constrained node
     if (theConstrainedNode == 0) {
         opserr << "WARNING LagrangeEQ_FE::setID(void)";
-        opserr << "- no asscoiated Constrained Node\n";
+        opserr << "- no associated Constrained Node\n";
         return -1;
     }
     DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
@@ -132,31 +140,30 @@ LagrangeEQ_FE::setID(void)
         opserr << "WARNING LagrangeEQ_FE::setID(void)";
         opserr << " - no DOF_Group with Constrained Node\n";
         return -2;
-    }    
-    const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();    
+    }
+    const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();
 
     int constrainedDOF = theEQ->getConstrainedDOFs();
-	if (constrainedDOF < 0 || constrainedDOF >= theConstrainedNode->getNumberDOF()) {
-	    opserr << "WARNING LagrangeEQ_FE::setID(void) - unknown DOF ";
-	    opserr << constrainedDOF << " at Node\n";
-	    myID(0) = -1; // modify so nothing will be added to equations
-	    result = -3;
-	}    	
-	else {
-	    if (constrainedDOF >= theConstrainedNodesID.Size()) {
-		    opserr << "WARNING LagrangeEQ_FE::setID(void) - ";
-		    opserr << " Nodes DOF_Group too small\n";
-		    myID(0) = -1; // modify so nothing will be added to equations
-		    result = -4;
-	    }
-	    else
-		    myID(0) = theConstrainedNodesID(constrainedDOF);
-	}
-    
+    if (constrainedDOF < 0 || constrainedDOF >= theConstrainedNode->getNumberDOF()) {
+        opserr << "WARNING LagrangeEQ_FE::setID(void) - unknown DOF ";
+        opserr << constrainedDOF << " at Node\n";
+        myID(0) = -1;  // modify so nothing will be added to equations
+        result = -3;
+    } else {
+        if (constrainedDOF >= theConstrainedNodesID.Size()) {
+            opserr << "WARNING LagrangeEQ_FE::setID(void) - ";
+            opserr << " Nodes DOF_Group too small\n";
+            myID(0) = -1;  // modify so nothing will be added to equations
+            result = -4;
+        } else {
+            myID(0) = theConstrainedNodesID(constrainedDOF);
+        }
+    }
+
     // now determine the IDs for the retained dof's
     if (theRetainedNode == 0) {
         opserr << "WARNING LagrangeEQ_FE::setID(void)";
-        opserr << "- no asscoiated Retained Node\n";
+        opserr << "- no associated Retained Node\n";
         return -1;
     }
     const ID &nodeRetained = theEQ->getNodeRetained();
@@ -164,7 +171,7 @@ LagrangeEQ_FE::setID(void)
     for (int i = 0; i < nodeRetained.Size(); ++i) {
         if (theRetainedNode[i] == 0) {
             opserr << "WARNING LagrangeEQ_FE::setID(void)";
-            opserr << "- no asscoiated Retained Node\n";
+            opserr << "- no associated Retained Node\n";
             return -1;
         }
         DOF_Group *theRetainedNodesDOFs = theRetainedNode[i]->getDOF_GroupPtr();
@@ -172,140 +179,255 @@ LagrangeEQ_FE::setID(void)
             opserr << "WARNING LagrangeEQ_FE::setID(void)";
             opserr << " - no DOF_Group with Retained Node\n";
             return -2;
-        }    
-        const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();    
+        }
+        const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();
         int retained = RetainedDOFs(i);
         if (retained < 0 || retained >= theRetainedNode[i]->getNumberDOF()) {
             opserr << "WARNING LagrangeEQ_FE::setID(void) - unknown DOF ";
             opserr << retained << " at Node\n";
-            myID(i+1) = -1; // modify so nothing will be added
+            myID(i + 1) = -1;  // modify so nothing will be added
             result = -3;
-        }    	
-        else {
+        } else {
             if (retained >= theRetainedNodesID.Size()) {
                 opserr << "WARNING LagrangeEQ_FE::setID(void) - ";
                 opserr << " Nodes DOF_Group too small\n";
-                myID(i+1) = -1; // modify so nothing will be added 
+                myID(i + 1) = -1;  // modify so nothing will be added
                 result = -4;
+            } else {
+                myID(i + 1) = theRetainedNodesID(retained);
             }
-            else
-               myID(i+1) = theRetainedNodesID(retained);
         }
     }
 
     // finally set the ID corresponding to the ID's at the LagrangeDOF_Group
     const ID &theGroupsID = theDofGroup->getID();
-	myID(nodeRetained.Size() + 1) = theGroupsID(0);
-    
+    myID(nodeRetained.Size() + 1) = theGroupsID(0);
+
     return result;
 }
 
 const Matrix &
 LagrangeEQ_FE::getTangent(Integrator *theNewIntegrator)
 {
-    if (theEQ->isTimeVarying() == true)
-	this->determineTangent();
+    if (theNewIntegrator != 0) {
+        theNewIntegrator->formEleTangent(this);
+        return *sysTang;
+    }
+    return this->getStaticTangent();
+}
 
-    return *tang;
+void
+LagrangeEQ_FE::zeroTangent(void)
+{
+    sysTang->Zero();
+    urLoaded = false;
+}
+
+void
+LagrangeEQ_FE::addKtToTang(double fact)
+{
+    // Copy static coupling, then scale lower-left C by integrator fact (c1).
+    // Upper-right C^T stays unscaled. HALL_TANGENT may call addKi after addKt:
+    // the second call only accumulates the lower-left block.
+    if (fact == 0.0)
+        return;
+
+    const Matrix &Ks = this->getStaticTangent();
+    const int nLambda = Ks.noRows() - numU;
+
+    if (!urLoaded) {
+        *sysTang = Ks;
+        if (fact != 1.0) {
+            for (int i = 0; i < nLambda; i++)
+                for (int j = 0; j < numU; j++)
+                    (*sysTang)(numU + i, j) *= fact;
+        }
+        urLoaded = true;
+    } else {
+        for (int i = 0; i < nLambda; i++)
+            for (int j = 0; j < numU; j++)
+                (*sysTang)(numU + i, j) += Ks(numU + i, j) * fact;
+    }
+}
+
+void
+LagrangeEQ_FE::addKiToTang(double fact)
+{
+    this->addKtToTang(fact);
+}
+
+void
+LagrangeEQ_FE::addCtoTang(double fact)
+{
+    // no damping contribution from lagrange constraint
+}
+
+void
+LagrangeEQ_FE::addMtoTang(double fact)
+{
+    // no mass contribution from lagrange constraint
 }
 
 const Vector &
 LagrangeEQ_FE::getResidual(Integrator *theNewIntegrator)
 {
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return *resid;
+}
+
+void
+LagrangeEQ_FE::zeroResidual(void)
+{
+    resid->Zero();
+}
+
+void
+LagrangeEQ_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
+
     // get the solution vector [Uc Ur lambda]
     static Vector UU;
     const ID &RetainedDOFs = theEQ->getRetainedDOFs();
-    const ID& id2 = theEQ->getRetainedDOFs();
     int size = 2 + RetainedDOFs.Size();
     UU.resize(size);
-    const Vector& Uc = theConstrainedNode->getTrialDisp();
+
+    const Vector &Uc = theConstrainedNode->getTrialDisp();
     double Uc0 = theEQ->getConstrainedDOFsInitialDisplacement();
     int cdof = theEQ->getConstrainedDOFs();
     if (cdof < 0 || cdof >= Uc.Size()) {
-        opserr << "LagrangeEQ_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() - 1 << "]\n";
+        opserr << "LagrangeEQ_FE::addRtoResidual FATAL Error: Constrained DOF "
+               << cdof << " out of bounds [0-" << Uc.Size() - 1 << "]\n";
         exit(-1);
     }
     UU(0) = Uc(cdof) - Uc0;
 
-    const Vector& Ur0 = theEQ->getRetainedDOFsInitialDisplacement();
+    const Vector &Ur0 = theEQ->getRetainedDOFsInitialDisplacement();
     for (int i = 0; i < RetainedDOFs.Size(); ++i) {
         int rdof = RetainedDOFs(i);
-        const Vector& Ur = theRetainedNode[i]->getTrialDisp();
+        const Vector &Ur = theRetainedNode[i]->getTrialDisp();
         if (rdof < 0 || rdof >= Ur.Size()) {
-            opserr << "LagrangeEQ_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() - 1 << "]\n";
+            opserr << "LagrangeEQ_FE::addRtoResidual FATAL Error: Retained DOF "
+                   << rdof << " out of bounds [0-" << Ur.Size() - 1 << "]\n";
             exit(-1);
         }
-        UU(i+1) = Ur(rdof) - Ur0(i);
+        UU(i + 1) = Ur(rdof) - Ur0(i);
     }
 
-    const Vector& lambda = theDofGroup->getTrialDisp();
+    const Vector &lambda = theDofGroup->getTrialDisp();
     UU(RetainedDOFs.Size() + 1) = lambda(0);
 
-    // compute residual
-    const Matrix& KK = getTangent(theNewIntegrator);
-    resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-    // done
-    return *resid;
+    // compute residual from unscaled static coupling (no c1)
+    resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+void
+LagrangeEQ_FE::addRIncInertiaToResidual(double fact)
+{
+    this->addRtoResidual(fact);
+}
 
+void
+LagrangeEQ_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
+
+void
+LagrangeEQ_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
+}
 
 const Vector &
 LagrangeEQ_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeEQ_FE::getTangForce() - not yet implemented\n";
- return *resid;
-}
+    resid->Zero();
 
+    if (fact == 0.0)
+        return *resid;
+
+    // use last integrator's system tangent (includes c1 on lower-left)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+        opserr << "WARNING LagrangeEQ_FE::getTangForce() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
+}
 
 const Vector &
 LagrangeEQ_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeEQ_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+        opserr << "WARNING LagrangeEQ_FE::getK_Force() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 LagrangeEQ_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING LagrangeEQ_FE::getKi_Force() - not yet implemented\n";
- return *resid;
+    return this->getK_Force(disp, fact);
 }
 
 const Vector &
 LagrangeEQ_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeEQ_FE::getC_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 const Vector &
 LagrangeEQ_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeEQ_FE::getM_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
-void  
+void
 LagrangeEQ_FE::determineTangent(void)
 {
     const Vector &constraint = theEQ->getConstraint();
     int size = constraint.Size();
-    
-    tang->Zero();    
+
+    tang->Zero();
 
     (*tang)(size + 1, 0) = -alpha;
-    (*tang)(0, size + 1) = -alpha;	
-    
+    (*tang)(0, size + 1) = -alpha;
+
     for (int i = 0; i < size; i++) {
         double val = constraint(i) * alpha;
         (*tang)(size + 1, i + 1) = val;
         (*tang)(i + 1, size + 1) = val;
     }
 }
-
-
-
-
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.h
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.h
@@ -17,14 +17,14 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.0 $
 // $Date: 2025-05-09$
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeEQ_FE.h,v $
-                                                                        
-                                                                        
+
+
 // File: ~/analysis/fe_ele/lagrange/LagrangeEQ_FE.h
-// 
+//
 // Written: Yuli Huang (yulee@berkeley.edu)
 // Created: 05/2020
 // Revision: A
@@ -34,7 +34,6 @@
 // using the Lagrange method.
 //
 // What: "@(#) LagrangeEQ_FE.h, revA"
-
 
 #ifndef LagrangeEQ_FE_h
 #define LagrangeEQ_FE_h
@@ -52,39 +51,57 @@ class EQ_Constraint;
 class Node;
 class DOF_Group;
 
-class LagrangeEQ_FE: public FE_Element
+class LagrangeEQ_FE final : public FE_Element
 {
-  public:
-    LagrangeEQ_FE(int tag, Domain &theDomain, EQ_Constraint &theEQ, 
-		  DOF_Group &theDofGrp, double alpha = 1.0);
-    virtual ~LagrangeEQ_FE();    
+public:
+    LagrangeEQ_FE(int tag, Domain &theDomain, EQ_Constraint &theEQ,
+                  DOF_Group &theDofGrp, double alpha = 1.0);
+    ~LagrangeEQ_FE() override;
 
-    // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);    
-    virtual const Vector &getResidual(Integrator *theIntegrator);    
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);    
-    
-  protected:
-    
-  private:
-    double alpha;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent(void) override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual(void) override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
+private:
     void determineTangent(void);
-    
+
+    const Matrix &getStaticTangent(void)
+    {
+        if (timeVarying)
+            this->determineTangent();
+        return *tang;
+    }
+
     EQ_Constraint *theEQ;
     Node *theConstrainedNode;
-    Node **theRetainedNode;    
+    Node **theRetainedNode;
 
     DOF_Group *theDofGroup;
-    Matrix *tang;
+    Matrix *tang;     // unscaled static coupling
+    Matrix *sysTang;  // integrator-assembled system tangent
     Vector *resid;
+    const bool timeVarying;
+    bool urLoaded;  // true once upper-right C^T has been copied into sysTang
+    double alpha;
+    int numU;  // number of displacement dofs before lambda block
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.cpp
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.cpp
@@ -17,13 +17,13 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.5 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.cpp,v $
-                                                                        
-                                                                        
-// Written: fmk 
+
+
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -53,63 +53,67 @@
 //    CDOF = a1*RDOF1 + a2*RDOF2 + ... + an*RDOFn + beta
 
 LagrangeMP_FE::LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &TheMP,
-			     DOF_Group &theGroup, double Alpha)
-:FE_Element(tag, 3,(tag, TheMP.getConstrainedDOFs()).Size()+
-	      (TheMP.getRetainedDOFs()).Size() + 
-	      (TheMP.getConstrainedDOFs()).Size()), // *see note 1
- alpha(Alpha), theMP(&TheMP), 
- theConstrainedNode(0), theRetainedNode(0),
- theDofGroup(&theGroup), tang(0), resid(0)
+                             DOF_Group &theGroup, double Alpha)
+    : FE_Element(tag, 3, (tag, TheMP.getConstrainedDOFs()).Size() +
+                             (TheMP.getRetainedDOFs()).Size() +
+                             (TheMP.getConstrainedDOFs()).Size()),  // *see note 1
+      theMP(&TheMP),
+      theConstrainedNode(0), theRetainedNode(0),
+      theDofGroup(&theGroup), tang(0), sysTang(0), resid(0),
+      timeVarying(TheMP.isTimeVarying()), urLoaded(false),
+      alpha(Alpha),
+      numU(TheMP.getConstrainedDOFs().Size() + TheMP.getRetainedDOFs().Size())
 {
     const Matrix &constraint = theMP->getConstraint();
     int noRows = constraint.noRows();
     int noCols = constraint.noCols();
-    int size = 2*noRows+noCols;
-    
-    tang = new Matrix(size,size);
+    int size = 2 * noRows + noCols;
+
+    tang = new Matrix(size, size);
+    sysTang = new Matrix(size, size);
     resid = new Vector(size);
-    if (tang == 0 || resid == 0 || tang->noCols() == 0 || resid->Size() == 0) {
-	opserr << "FATAL LagrangeMP_FE::LagrangeMP_FE() - out of memory\n";
-	exit(-1);
+    if (tang == 0 || sysTang == 0 || resid == 0 ||
+        tang->noCols() == 0 || sysTang->noCols() == 0 || resid->Size() == 0) {
+        opserr << "FATAL LagrangeMP_FE::LagrangeMP_FE() - out of memory\n";
+        exit(-1);
     }
-    tang->Zero();	
+    tang->Zero();
+    sysTang->Zero();
     resid->Zero();
 
-    theRetainedNode = theDomain.getNode(theMP->getNodeRetained());    
+    theRetainedNode = theDomain.getNode(theMP->getNodeRetained());
     theConstrainedNode = theDomain.getNode(theMP->getNodeConstrained());
 
     if (theRetainedNode == 0) {
-	opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
-	opserr << "- no asscoiated Retained Node\n";
-	exit(-1);
+        opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
+        opserr << "- no associated Retained Node\n";
+        exit(-1);
     }
-    
+
     if (theConstrainedNode == 0) {
-	opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
-	opserr << "- no asscoiated Constrained Node\n";
-	exit(-1);
+        opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
+        opserr << "- no associated Constrained Node\n";
+        exit(-1);
     }
-    
-    if (theMP->isTimeVarying() == false) {
-	this->determineTangent();
-    }
-    
+
+    if (!timeVarying)
+        this->determineTangent();
+
     // set the myDOF_Groups tags indicating the attached id's of the
     // DOF_Group objects
     DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
     if (theConstrainedNodesDOFs == 0) {
-	opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
-	opserr << " - no DOF_Group with Constrained Node\n";
-	exit(-1);	
-    }    
+        opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
+        opserr << " - no DOF_Group with Constrained Node\n";
+        exit(-1);
+    }
 
     DOF_Group *theRetainedNodesDOFs = theRetainedNode->getDOF_GroupPtr();
     if (theRetainedNodesDOFs == 0) {
-	opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
-	opserr << " - no DOF_Group with Retained Node\n";
-	exit(-1);	
-    }            
-    
+        opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
+        opserr << " - no DOF_Group with Retained Node\n";
+        exit(-1);
+    }
 
     myDOF_Groups(0) = theConstrainedNodesDOFs->getTag();
     myDOF_Groups(1) = theRetainedNodesDOFs->getTag();
@@ -119,13 +123,15 @@ LagrangeMP_FE::LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &TheMP,
 LagrangeMP_FE::~LagrangeMP_FE()
 {
     if (tang != 0)
-	delete tang;
+        delete tang;
+    if (sysTang != 0)
+        delete sysTang;
     if (resid != 0)
-	delete resid;
-}    
+        delete resid;
+}
 
 // void setID(int index, int value);
-//	Method to set the correMPonding index of the ID to value.
+//      Method to set the corresponding index of the ID to value.
 int
 LagrangeMP_FE::setID(void)
 {
@@ -135,118 +141,187 @@ LagrangeMP_FE::setID(void)
     // as constrained DOFs, this is obtained from the DOF_Group
     // associated with the constrained node
     if (theConstrainedNode == 0) {
-	opserr << "WARNING LagrangeMP_FE::setID(void)";
-	opserr << "- no asscoiated Constrained Node\n";
-	return -1;
+        opserr << "WARNING LagrangeMP_FE::setID(void)";
+        opserr << "- no associated Constrained Node\n";
+        return -1;
     }
     DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
     if (theConstrainedNodesDOFs == 0) {
-	opserr << "WARNING LagrangeMP_FE::setID(void)";
-	opserr << " - no DOF_Group with Constrained Node\n";
-	return -2;
-    }    
+        opserr << "WARNING LagrangeMP_FE::setID(void)";
+        opserr << " - no DOF_Group with Constrained Node\n";
+        return -2;
+    }
 
     const ID &constrainedDOFs = theMP->getConstrainedDOFs();
-    const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();    
-    
+    const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();
+
     int size1 = constrainedDOFs.Size();
-    for (int i=0; i<size1; i++) {
-	int constrained = constrainedDOFs(i);
-	if (constrained < 0 || 
-	    constrained >= theConstrainedNode->getNumberDOF()) {
-	    
-	    opserr << "WARNING LagrangeMP_FE::setID(void) - unknown DOF ";
-	    opserr << constrained << " at Node\n";
-	    myID(i) = -1; // modify so nothing will be added to equations
-	    result = -3;
-	}    	
-	else {
-	    if (constrained >= theConstrainedNodesID.Size()) {
-		opserr << "WARNING LagrangeMP_FE::setID(void) - ";
-		opserr << " Nodes DOF_Group too small\n";
-		myID(i) = -1; // modify so nothing will be added to equations
-		result = -4;
-	    }
-	    else
-		myID(i) = theConstrainedNodesID(constrained);
-	}
+    for (int i = 0; i < size1; i++) {
+        int constrained = constrainedDOFs(i);
+        if (constrained < 0 ||
+            constrained >= theConstrainedNode->getNumberDOF()) {
+            opserr << "WARNING LagrangeMP_FE::setID(void) - unknown DOF ";
+            opserr << constrained << " at Node\n";
+            myID(i) = -1;  // modify so nothing will be added to equations
+            result = -3;
+        } else {
+            if (constrained >= theConstrainedNodesID.Size()) {
+                opserr << "WARNING LagrangeMP_FE::setID(void) - ";
+                opserr << " Nodes DOF_Group too small\n";
+                myID(i) = -1;  // modify so nothing will be added to equations
+                result = -4;
+            } else {
+                myID(i) = theConstrainedNodesID(constrained);
+            }
+        }
     }
-    
+
     // now determine the IDs for the retained dof's
     if (theRetainedNode == 0) {
-	opserr << "WARNING LagrangeMP_FE::setID(void)";
-	opserr << "- no asscoiated Retained Node\n";
-	return -1;
+        opserr << "WARNING LagrangeMP_FE::setID(void)";
+        opserr << "- no associated Retained Node\n";
+        return -1;
     }
     DOF_Group *theRetainedNodesDOFs = theRetainedNode->getDOF_GroupPtr();
     if (theRetainedNodesDOFs == 0) {
-	opserr << "WARNING LagrangeMP_FE::setID(void)";
-	opserr << " - no DOF_Group with Retained Node\n";
-	return -2;
-    }    
-    
+        opserr << "WARNING LagrangeMP_FE::setID(void)";
+        opserr << " - no DOF_Group with Retained Node\n";
+        return -2;
+    }
+
     const ID &RetainedDOFs = theMP->getRetainedDOFs();
-    const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();    
+    const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();
 
     int size2 = RetainedDOFs.Size();
-    for (int j=0; j<size2; j++) {
-	int retained = RetainedDOFs(j);
-	if (retained < 0 || retained >= theRetainedNode->getNumberDOF()) {
-	    opserr << "WARNING LagrangeMP_FE::setID(void) - unknown DOF ";
-	    opserr << retained << " at Node\n";
-	    myID(j+size1) = -1; // modify so nothing will be added
-	    result = -3;
-	}    	
-	else {
-	    if (retained >= theRetainedNodesID.Size()) {
-		opserr << "WARNING LagrangeMP_FE::setID(void) - ";
-		opserr << " Nodes DOF_Group too small\n";
-		myID(j+size1) = -1; // modify so nothing will be added 
-		result = -4;
-	    }
-	    else
-		myID(j+size1) = theRetainedNodesID(retained);
-	}
+    for (int j = 0; j < size2; j++) {
+        int retained = RetainedDOFs(j);
+        if (retained < 0 || retained >= theRetainedNode->getNumberDOF()) {
+            opserr << "WARNING LagrangeMP_FE::setID(void) - unknown DOF ";
+            opserr << retained << " at Node\n";
+            myID(j + size1) = -1;  // modify so nothing will be added
+            result = -3;
+        } else {
+            if (retained >= theRetainedNodesID.Size()) {
+                opserr << "WARNING LagrangeMP_FE::setID(void) - ";
+                opserr << " Nodes DOF_Group too small\n";
+                myID(j + size1) = -1;  // modify so nothing will be added
+                result = -4;
+            } else {
+                myID(j + size1) = theRetainedNodesID(retained);
+            }
+        }
     }
 
     // finally set the ID corresponding to the ID's at the LagrangeDOF_Group
     const ID &theGroupsID = theDofGroup->getID();
     int size3 = theGroupsID.Size();
-    for (int k=0; k<size3; k++) 
-	myID(k+size1+size2) = theGroupsID(k);
-    
-    
+    for (int k = 0; k < size3; k++)
+        myID(k + size1 + size2) = theGroupsID(k);
+
     return result;
 }
 
 const Matrix &
 LagrangeMP_FE::getTangent(Integrator *theNewIntegrator)
 {
-    if (theMP->isTimeVarying() == true)
-	this->determineTangent();
+    if (theNewIntegrator != 0) {
+        theNewIntegrator->formEleTangent(this);
+        return *sysTang;
+    }
+    return this->getStaticTangent();
+}
 
-    return *tang;
+void
+LagrangeMP_FE::zeroTangent(void)
+{
+    sysTang->Zero();
+    urLoaded = false;
+}
+
+void
+LagrangeMP_FE::addKtToTang(double fact)
+{
+    // Copy static coupling, then scale lower-left C by integrator fact (c1).
+    // Upper-right C^T stays unscaled. HALL_TANGENT may call addKi after addKt:
+    // the second call only accumulates the lower-left block.
+    if (fact == 0.0)
+        return;
+
+    const Matrix &Ks = this->getStaticTangent();
+    const int nLambda = Ks.noRows() - numU;
+
+    if (!urLoaded) {
+        *sysTang = Ks;
+        if (fact != 1.0) {
+            for (int i = 0; i < nLambda; i++)
+                for (int j = 0; j < numU; j++)
+                    (*sysTang)(numU + i, j) *= fact;
+        }
+        urLoaded = true;
+    } else {
+        for (int i = 0; i < nLambda; i++)
+            for (int j = 0; j < numU; j++)
+                (*sysTang)(numU + i, j) += Ks(numU + i, j) * fact;
+    }
+}
+
+void
+LagrangeMP_FE::addKiToTang(double fact)
+{
+    this->addKtToTang(fact);
+}
+
+void
+LagrangeMP_FE::addCtoTang(double fact)
+{
+    // no damping contribution from lagrange constraint
+}
+
+void
+LagrangeMP_FE::addMtoTang(double fact)
+{
+    // no mass contribution from lagrange constraint
 }
 
 const Vector &
 LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
 {
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return *resid;
+}
+
+void
+LagrangeMP_FE::zeroResidual(void)
+{
+    resid->Zero();
+}
+
+void
+LagrangeMP_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
+
     // get the solution vector [Uc Ur lambda]
     static Vector UU;
-    const ID& id1 = theMP->getConstrainedDOFs();
-    const ID& id2 = theMP->getRetainedDOFs();
-    const ID& id3 = theDofGroup->getID();
+    const ID &id1 = theMP->getConstrainedDOFs();
+    const ID &id2 = theMP->getRetainedDOFs();
+    const ID &id3 = theDofGroup->getID();
     int size = id1.Size() + id2.Size() + id3.Size();
     UU.resize(size);
-    const Vector& Uc = theConstrainedNode->getTrialDisp();
-    const Vector& Ur = theRetainedNode->getTrialDisp();
-    const Vector& Uc0 = theMP->getConstrainedDOFsInitialDisplacement();
-    const Vector& Ur0 = theMP->getRetainedDOFsInitialDisplacement();
-    const Vector& lambda = theDofGroup->getTrialDisp();
+
+    const Vector &Uc = theConstrainedNode->getTrialDisp();
+    const Vector &Ur = theRetainedNode->getTrialDisp();
+    const Vector &Uc0 = theMP->getConstrainedDOFsInitialDisplacement();
+    const Vector &Ur0 = theMP->getRetainedDOFsInitialDisplacement();
+    const Vector &lambda = theDofGroup->getTrialDisp();
+
     for (int i = 0; i < id1.Size(); ++i) {
         int cdof = id1(i);
         if (cdof < 0 || cdof >= Uc.Size()) {
-            opserr << "LagrangeMP_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
+            opserr << "LagrangeMP_FE::addRtoResidual FATAL Error: Constrained DOF "
+                   << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
             exit(-1);
         }
         UU(i) = Uc(cdof) - Uc0(i);
@@ -254,14 +329,14 @@ LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
     for (int i = 0; i < id2.Size(); ++i) {
         int rdof = id2(i);
         if (rdof < 0 || rdof >= Ur.Size()) {
-            opserr << "LagrangeMP_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
+            opserr << "LagrangeMP_FE::addRtoResidual FATAL Error: Retained DOF "
+                   << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
             exit(-1);
         }
         UU(i + id1.Size()) = Ur(rdof) - Ur0(i);
     }
-    for (int i = 0; i < id3.Size(); ++i) {
+    for (int i = 0; i < id3.Size(); ++i)
         UU(i + id1.Size() + id2.Size()) = lambda(i);
-    }
 
     /*
     R = -C*U + G
@@ -274,76 +349,120 @@ LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
     | Rl |    | A  0 | | l |   | g |
     */
 
-    // compute residual
-    const Matrix& KK = getTangent(theNewIntegrator);
-    resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-    // done
-    return *resid;
+    // compute residual from unscaled static coupling (no c1)
+    resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+void
+LagrangeMP_FE::addRIncInertiaToResidual(double fact)
+{
+    this->addRtoResidual(fact);
+}
 
+void
+LagrangeMP_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
+
+void
+LagrangeMP_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
+}
 
 const Vector &
 LagrangeMP_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getTangForce() - not yet implemented\n";
- return *resid;
-}
+    resid->Zero();
 
+    if (fact == 0.0)
+        return *resid;
+
+    // use last integrator's system tangent (includes c1 on lower-left)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+        opserr << "WARNING LagrangeMP_FE::getTangForce() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
+}
 
 const Vector &
 LagrangeMP_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+        opserr << "WARNING LagrangeMP_FE::getK_Force() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 LagrangeMP_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING LagrangeMP_FE::getKi_Force() - not yet implemented\n";
- return *resid;
+    return this->getK_Force(disp, fact);
 }
 
 const Vector &
 LagrangeMP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 const Vector &
 LagrangeMP_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
-void  
+void
 LagrangeMP_FE::determineTangent(void)
 {
     const Matrix &constraint = theMP->getConstraint();
     int noRows = constraint.noRows();
     int noCols = constraint.noCols();
-    int n = noRows+noCols;
-    
-    tang->Zero();    
+    int n = noRows + noCols;
 
-    for (int j=0; j<noRows; j++) {
-	(*tang)(n+j, j) = -alpha;
-	(*tang)(j, n+j) = -alpha;	
+    tang->Zero();
+
+    for (int j = 0; j < noRows; j++) {
+        (*tang)(n + j, j) = -alpha;
+        (*tang)(j, n + j) = -alpha;
     }
-    
-    for (int i=0; i<noRows; i++)
-	for (int j=0; j<noCols; j++) {
-	    double val = constraint(i,j) * alpha;
-	    (*tang)(n+i, j+noRows) = val;
-	    (*tang)(noRows+j, n+i) = val;
-	}
+
+    for (int i = 0; i < noRows; i++)
+        for (int j = 0; j < noCols; j++) {
+            double val = constraint(i, j) * alpha;
+            (*tang)(n + i, j + noRows) = val;
+            (*tang)(noRows + j, n + i) = val;
+        }
 }
-
-
-
-
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.h
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.h
@@ -17,15 +17,15 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.4 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.h,v $
-                                                                        
-                                                                        
+
+
 // File: ~/analysis/fe_ele/lagrange/LagrangeMP_FE.h
-// 
-// Written: fmk 
+//
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -34,7 +34,6 @@
 // using the Lagrange method.
 //
 // What: "@(#) LagrangeMP_FE.h, revA"
-
 
 #ifndef LagrangeMP_FE_h
 #define LagrangeMP_FE_h
@@ -52,39 +51,57 @@ class MP_Constraint;
 class Node;
 class DOF_Group;
 
-class LagrangeMP_FE: public FE_Element
+class LagrangeMP_FE final : public FE_Element
 {
-  public:
-    LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &theMP, 
-		  DOF_Group &theDofGrp, double alpha = 1.0);
-    virtual ~LagrangeMP_FE();    
+public:
+    LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &theMP,
+                  DOF_Group &theDofGrp, double alpha = 1.0);
+    ~LagrangeMP_FE() override;
 
-    // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);    
-    virtual const Vector &getResidual(Integrator *theIntegrator);    
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);    
-    
-  protected:
-    
-  private:
-    double alpha;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent(void) override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual(void) override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
+private:
     void determineTangent(void);
-    
+
+    const Matrix &getStaticTangent(void)
+    {
+        if (timeVarying)
+            this->determineTangent();
+        return *tang;
+    }
+
     MP_Constraint *theMP;
     Node *theConstrainedNode;
-    Node *theRetainedNode;    
+    Node *theRetainedNode;
 
     DOF_Group *theDofGroup;
-    Matrix *tang;
+    Matrix *tang;     // unscaled static coupling
+    Matrix *sysTang;  // integrator-assembled system tangent
     Vector *resid;
+    const bool timeVarying;
+    bool urLoaded;  // true once upper-right C^T has been copied into sysTang
+    double alpha;
+    int numU;  // number of displacement dofs before lambda block
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp
@@ -17,19 +17,17 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.5 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp,v $
-                                                                        
-// Written: fmk 
+
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
-// Purpose: This file contains the code for iSPlementing the methods
+// Purpose: This file contains the code for implementing the methods
 // of the LagrangeSP_FE class interface.
-//
-// the interface:
 
 #include <LagrangeSP_FE.h>
 #include <stdlib.h>
@@ -48,43 +46,47 @@
 #include <DOF_Group.h>
 
 LagrangeSP_FE::LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &TheSP,
-			     DOF_Group &theGroup, double Alpha)
-:FE_Element(tag, 2,2),
- alpha(Alpha), tang(0), resid(0), theSP(&TheSP), theDofGroup(&theGroup)
+                             DOF_Group &theGroup, double Alpha)
+    : FE_Element(tag, 2, 2),
+      alpha(Alpha), tang(0), sysTang(0), resid(0), urLoaded(false),
+      theSP(&TheSP), theNode(0), theDofGroup(&theGroup)
 {
     // create a Matrix and a Vector for the tangent and residual
-    tang = new Matrix(2,2);
+    tang = new Matrix(2, 2);
+    sysTang = new Matrix(2, 2);
     resid = new Vector(2);
-    if ((tang == 0) || (tang->noCols() == 0) || (resid == 0) ||
-	(resid->Size() == 0)) {
-	opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
-	opserr << "- ran out of memory\n";
-	exit(-1);
+    if (tang == 0 || tang->noCols() == 0 ||
+        sysTang == 0 || sysTang->noCols() == 0 ||
+        resid == 0 || resid->Size() == 0) {
+        opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
+        opserr << "- ran out of memory\n";
+        exit(-1);
     }
 
     // zero the Matrix and Vector
     resid->Zero();
     tang->Zero();
+    sysTang->Zero();
 
-    theNode = theDomain.getNode(theSP->getNodeTag());    
+    theNode = theDomain.getNode(theSP->getNodeTag());
     if (theNode == 0) {
-	opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
-	opserr << "- no asscoiated Node\n";
-	exit(-1);
+        opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
+        opserr << "- no associated Node\n";
+        exit(-1);
     }
 
-    // set the tangent
-    (*tang)(0,1) = alpha;
-    (*tang)(1,0) = alpha;
-    
+    // set the tangent: static coupling on [u, lambda] is [0, alpha; alpha, 0]
+    (*tang)(0, 1) = alpha;
+    (*tang)(1, 0) = alpha;
+
     // set the myDOF_Groups tags indicating the attached id's of the
     // DOF_Group objects
     DOF_Group *theNodesDOFs = theNode->getDOF_GroupPtr();
     if (theNodesDOFs == 0) {
-	opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
-	opserr << " - no DOF_Group with Constrained Node\n";
-	exit(-1);	
-    }    
+        opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
+        opserr << " - no DOF_Group with Constrained Node\n";
+        exit(-1);
+    }
 
     myDOF_Groups(0) = theNodesDOFs->getTag();
     myDOF_Groups(1) = theDofGroup->getTag();
@@ -93,71 +95,136 @@ LagrangeSP_FE::LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &TheSP,
 LagrangeSP_FE::~LagrangeSP_FE()
 {
     if (tang != 0)
-	delete tang;
+        delete tang;
+    if (sysTang != 0)
+        delete sysTang;
     if (resid != 0)
-	delete resid;
-}    
+        delete resid;
+}
 
 // void setID(int index, int value);
-//	Method to set the correSPonding index of the ID to value.
+//      Method to set the corresponding index of the ID to value.
 int
 LagrangeSP_FE::setID(void)
 {
-    int result = 0;
-
     // first determine the IDs in myID for those DOFs marked
     // as constrained DOFs, this is obtained from the DOF_Group
     // associated with the constrained node
     DOF_Group *theNodesDOFs = theNode->getDOF_GroupPtr();
     if (theNodesDOFs == 0) {
-	opserr << "WARNING LagrangeSP_FE::setID(void)";
-	opserr << " - no DOF_Group with Constrained Node\n";
-	return -1;
-    }    
+        opserr << "WARNING LagrangeSP_FE::setID(void)";
+        opserr << " - no DOF_Group with Constrained Node\n";
+        return -1;
+    }
 
     int restrainedDOF = theSP->getDOF_Number();
     const ID &theNodesID = theNodesDOFs->getID();
-    
+
     if (restrainedDOF < 0 || restrainedDOF >= theNodesID.Size()) {
-	opserr << "WARNING LagrangeSP_FE::setID(void)";
-	opserr << " - restrained DOF invalid\n";
-	return -2;
-    }    	
-    
+        opserr << "WARNING LagrangeSP_FE::setID(void)";
+        opserr << " - restrained DOF invalid\n";
+        return -2;
+    }
+
     myID(0) = theNodesID(restrainedDOF);
     myID(1) = (theDofGroup->getID())(0);
-    
-    return result;
+
+    return 0;
 }
 
 const Matrix &
 LagrangeSP_FE::getTangent(Integrator *theIntegrator)
 {
-    return *tang;
+    if (theIntegrator != 0) {
+        theIntegrator->formEleTangent(this);
+        return *sysTang;
+    }
+    return this->getStaticTangent();
+}
+
+void
+LagrangeSP_FE::zeroTangent(void)
+{
+    sysTang->Zero();
+    urLoaded = false;
+}
+
+void
+LagrangeSP_FE::addKtToTang(double fact)
+{
+    // Copy static coupling, then scale lower-left C by integrator fact (c1).
+    // Upper-right C^T stays unscaled. HALL_TANGENT may call addKi after addKt:
+    // the second call only accumulates the lower-left block.
+    if (fact == 0.0)
+        return;
+
+    const Matrix &Ks = this->getStaticTangent();
+
+    if (!urLoaded) {
+        *sysTang = Ks;
+        if (fact != 1.0)
+            (*sysTang)(1, 0) *= fact;
+        urLoaded = true;
+    } else {
+        (*sysTang)(1, 0) += Ks(1, 0) * fact;
+    }
+}
+
+void
+LagrangeSP_FE::addKiToTang(double fact)
+{
+    this->addKtToTang(fact);
+}
+
+void
+LagrangeSP_FE::addCtoTang(double fact)
+{
+    // no damping contribution from lagrange constraint
+}
+
+void
+LagrangeSP_FE::addMtoTang(double fact)
+{
+    // no mass contribution from lagrange constraint
 }
 
 const Vector &
 LagrangeSP_FE::getResidual(Integrator *theNewIntegrator)
 {
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return *resid;
+}
+
+void
+LagrangeSP_FE::zeroResidual(void)
+{
+    resid->Zero();
+}
+
+void
+LagrangeSP_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
+
     double constraint = theSP->getValue();
     double initialValue = theSP->getInitialValue();
     int constrainedDOF = theSP->getDOF_Number();
     const Vector &nodeDisp = theNode->getTrialDisp();
-    const Vector& lambda = theDofGroup->getTrialDisp();
+    const Vector &lambda = theDofGroup->getTrialDisp();
 
     if (constrainedDOF < 0 || constrainedDOF >= nodeDisp.Size()) {
-        opserr << "LagrangeSP_FE::getResidual() -";
+        opserr << "LagrangeSP_FE::addRtoResidual() -";
         opserr << " constrained DOF " << constrainedDOF << " outside range\n";
-        resid->Zero();
-        return *resid;
+        return;
     }
     if (lambda.Size() != 1) {
-        opserr << "LagrangeSP_FE::getResidual() -";
-        opserr << " Lambda.Size() = " << lambda.Size() << " != 1\n";
-        resid->Zero();
-        return *resid;
+        opserr << "LagrangeSP_FE::addRtoResidual() -";
+        opserr << " lambda.Size() = " << lambda.Size() << " != 1\n";
+        return;
     }
-    
+
     /*
     R = -C*U + G
        .R = generalized residual vector
@@ -168,54 +235,97 @@ LagrangeSP_FE::getResidual(Integrator *theNewIntegrator)
     |    | = -|      |*|   | + |   |
     | Rl |    | A  0 | | l |   | g |
     */
-    (*resid)(0) = alpha * (-lambda(0));
-    (*resid)(1) = alpha *(constraint - (nodeDisp(constrainedDOF) - initialValue));
-    return *resid;
+    (*resid)(0) += fact * alpha * (-lambda(0));
+    (*resid)(1) += fact * alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));
 }
 
+void
+LagrangeSP_FE::addRIncInertiaToResidual(double fact)
+{
+    this->addRtoResidual(fact);
+}
 
+void
+LagrangeSP_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
 
+void
+LagrangeSP_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
+}
 
 const Vector &
 LagrangeSP_FE::getTangForce(const Vector &disp, double fact)
 {
-    double constraint = theSP->getValue();
-    int constrainedID = myID(1);
-    if (constrainedID < 0 || constrainedID >= disp.Size()) {
-	opserr << "WARNING LagrangeSP_FE::getTangForce() - ";	
-	opserr << " constrained DOF " << constrainedID << " outside disp\n";
-	(*resid)(1) = constraint*alpha;
-	return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    // use last integrator's system tangent (includes c1 on lower-left)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
     }
-    (*resid)(1) = disp(constrainedID);
-    return *resid;    
+
+    if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+        opserr << "WARNING LagrangeSP_FE::getTangForce() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+        opserr << "WARNING LagrangeSP_FE::getK_Force() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getKi_Force() - not yet implemented\n";
- return *resid;
+    return this->getK_Force(disp, fact);
 }
 
 const Vector &
 LagrangeSP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h
@@ -17,16 +17,16 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.4 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h,v $
-                                                                        
-                                                                        
+
+
 #ifndef LagrangeSP_FE_h
 #define LagrangeSP_FE_h
 
-// Written: fmk 
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -49,36 +49,47 @@ class SP_Constraint;
 class Node;
 class DOF_Group;
 
-class LagrangeSP_FE: public FE_Element
+class LagrangeSP_FE final : public FE_Element
 {
-  public:
-    LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &theSP, 
-		  DOF_Group &theDofGrp, double alpha = 1.0);
-    virtual ~LagrangeSP_FE();    
+public:
+    LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &theSP,
+                  DOF_Group &theDofGrp, double alpha = 1.0);
+    ~LagrangeSP_FE() override;
 
-    // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);    
-    virtual const Vector &getResidual(Integrator *theIntegrator);    
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);        
-  protected:
-    
-  private:
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent(void) override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual(void) override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
+private:
+    const Matrix &getStaticTangent(void) { return *tang; }
+
     double alpha;
-    Matrix *tang;
+    Matrix *tang;     // unscaled static coupling [0, C^T; C, 0]
+    Matrix *sysTang;  // integrator-assembled system tangent
     Vector *resid;
-    
-    SP_Constraint *theSP;
-    Node *theNode;    
+    bool urLoaded;  // true once upper-right C^T has been copied into sysTang
 
+    SP_Constraint *theSP;
+    Node *theNode;
     DOF_Group *theDofGroup;
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyEQ_FE.cpp
+++ b/SRC/analysis/fe_ele/penalty/PenaltyEQ_FE.cpp
@@ -53,17 +53,19 @@ PenaltyEQ_FE::PenaltyEQ_FE(int tag, Domain &theDomain,
 :FE_Element(tag, 1+(TheEQ.getRetainedDOFs()).Size(),
  1+(TheEQ.getRetainedDOFs()).Size()),
  theEQ(&TheEQ), theConstrainedNode(0) , theRetainedNode(0),
- tang(0), resid(0), C(0), alpha(Alpha)
+ tang(0), sysTang(0), resid(0), C(0),
+ timeVarying(TheEQ.isTimeVarying()), alpha(Alpha)
 {
     int size = 1 + (theEQ->getRetainedDOFs()).Size();
 
     tang = new Matrix(size,size);
+    sysTang = new Matrix(size,size);
     resid = new Vector(size);
     C = new Vector(size);
 
-    if (tang == 0 || resid == 0 || C == 0 ||
-            tang->noCols() != size || C->Size() != size || 
-            resid->Size() != size) {
+    if (tang == 0 || sysTang == 0 || resid == 0 || C == 0 ||
+            tang->noCols() != size || sysTang->noCols() != size ||
+            C->Size() != size || resid->Size() != size) {
         opserr << "FATAL PenaltyEQ_FE::PenaltyEQ_FE() - out of memory\n";
         exit(-1);
     }
@@ -100,7 +102,7 @@ PenaltyEQ_FE::PenaltyEQ_FE(int tag, Domain &theDomain,
             opserr << "WARNING PenaltyEQ_FE::PenaltyEQ_FE() - node no Group yet?\n";
     }
     
-    if (theEQ->isTimeVarying() == false) {
+    if (!timeVarying) {
         this->determineTangent();
         // we can free up the space taken by C as it is no longer needed
         if (C != 0)
@@ -115,6 +117,8 @@ PenaltyEQ_FE::~PenaltyEQ_FE()
         delete theRetainedNode;
     if (tang != 0)
 	    delete tang;
+    if (sysTang != 0)
+	    delete sysTang;
     if (resid != 0)
 	    delete resid;
     if (C != 0)
@@ -208,15 +212,74 @@ PenaltyEQ_FE::setID(void)
 const Matrix &
 PenaltyEQ_FE::getTangent(Integrator *theNewIntegrator)
 {
-    if (theEQ->isTimeVarying() == true)
-	    this->determineTangent();    
-    return *tang;
+    if (theNewIntegrator != 0)
+	    theNewIntegrator->formEleTangent(this);
+    return *sysTang;
 }
+
+
+void
+PenaltyEQ_FE::zeroTangent(void)
+{
+    sysTang->Zero();
+}
+
+
+void
+PenaltyEQ_FE::addKtToTang(double fact)
+{
+    // Always accumulate: HALL_TANGENT calls both addKtToTang and
+    // addKiToTang, so fact==1.0 must not replace sysTang.
+    if (fact == 0.0)
+        return;
+
+    const Matrix &Ks = this->getStaticTangent();
+    sysTang->addMatrix(1.0, Ks, fact);
+}
+
+
+void
+PenaltyEQ_FE::addKiToTang(double fact)
+{
+    this->addKtToTang(fact);
+}
+
+
+void
+PenaltyEQ_FE::addCtoTang(double fact)
+{
+    // no damping contribution from penalty constraint
+}
+
+
+void
+PenaltyEQ_FE::addMtoTang(double fact)
+{
+    // no mass contribution from penalty constraint
+}
+
 
 const Vector &
 PenaltyEQ_FE::getResidual(Integrator *theNewIntegrator)
 {
-    // zero residual, CD = 0
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return *resid;
+}
+
+
+void
+PenaltyEQ_FE::zeroResidual(void)
+{
+    resid->Zero();
+}
+
+
+void
+PenaltyEQ_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
 
     // get the solution vector [Uc Ur]
     static Vector UU;
@@ -227,7 +290,7 @@ PenaltyEQ_FE::getResidual(Integrator *theNewIntegrator)
     double Uc0 = theEQ->getConstrainedDOFsInitialDisplacement();
     int cdof = theEQ->getConstrainedDOFs();
     if (cdof < 0 || cdof >= Uc.Size()) {
-        opserr << "PenaltyEQ_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() - 1 << "]\n";
+        opserr << "PenaltyEQ_FE::addRtoResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() - 1 << "]\n";
         exit(-1);
     }
     UU(0) = Uc(cdof) - Uc0;
@@ -237,55 +300,110 @@ PenaltyEQ_FE::getResidual(Integrator *theNewIntegrator)
         int rdof = RetainedDOFs(i);
         const Vector& Ur = theRetainedNode[i]->getTrialDisp();
         if (rdof < 0 || rdof >= Ur.Size()) {
-            opserr << "PenaltyEQ_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() - 1 << "]\n";
+            opserr << "PenaltyEQ_FE::addRtoResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() - 1 << "]\n";
             exit(-1);
         }
         UU(i + 1) = Ur(rdof) - Ur0(i);
     }
 
-    // compute residual
-    const Matrix& KK = getTangent(theNewIntegrator);
-    resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-    // done
-    return *resid;
+    // residual contribution = -R with R = K_static*U, same sign as before
+    resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+
+void
+PenaltyEQ_FE::addRIncInertiaToResidual(double fact)
+{
+    // no mass/damping on the constraint
+    this->addRtoResidual(fact);
+}
+
+
+void
+PenaltyEQ_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
+
+
+void
+PenaltyEQ_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
+}
 
 
 const Vector &
 PenaltyEQ_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyEQ_FE::getTangForce() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    // use last integrator's system tangent (includes c1)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+        opserr << "WARNING PenaltyEQ_FE::getTangForce() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 PenaltyEQ_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyEQ_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);  // Vector(int) zeros on construction
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+        opserr << "WARNING PenaltyEQ_FE::getK_Force() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 PenaltyEQ_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyEQ_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    return this->getK_Force(disp, fact);
 }
 
 const Vector &
 PenaltyEQ_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyEQ_FE::getC_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 const Vector &
 PenaltyEQ_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyEQ_FE::getM_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 void  
@@ -305,5 +423,3 @@ PenaltyEQ_FE::determineTangent(void)
     const Vector &Cref = *C;
     *tang = alpha * (Cref % Cref);
 }
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyEQ_FE.h
+++ b/SRC/analysis/fe_ele/penalty/PenaltyEQ_FE.h
@@ -48,40 +48,57 @@ class Domain;
 class EQ_Constraint;
 class Node;
 
-class PenaltyEQ_FE: public FE_Element
+class PenaltyEQ_FE final : public FE_Element
 {
   public:
     PenaltyEQ_FE(int tag, Domain &theDomain, EQ_Constraint &theEQ, double alpha);
-    virtual ~PenaltyEQ_FE();    
+    ~PenaltyEQ_FE() override;
 
     // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);
-    virtual const Vector &getResidual(Integrator *theIntegrator);
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);
-    
-  protected:
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    // methods to allow integrator to build tangent
+    void  zeroTangent(void) override;
+    void  addKtToTang(double fact = 1.0) override;
+    void  addKiToTang(double fact = 1.0) override;
+    void  addCtoTang(double fact = 1.0) override;
+    void  addMtoTang(double fact = 1.0) override;
+
+    // methods to allow integrator to build residual
+    void  zeroResidual(void) override;
+    void  addRtoResidual(double fact = 1.0) override;
+    void  addRIncInertiaToResidual(double fact = 1.0) override;
+    void  addM_Force(const Vector &accel, double fact = 1.0) override;
+    void  addD_Force(const Vector &vel, double fact = 1.0) override;
     
   private:
     void determineTangent(void);
+
+    const Matrix &getStaticTangent(void)
+    {
+        if (timeVarying)
+            this->determineTangent();
+        return *tang;
+    }
     
     EQ_Constraint *theEQ;
     Node *theConstrainedNode;
     Node **theRetainedNode;    
 
-    Matrix *tang;
+    Matrix *tang;      // unscaled static penalty stiffness
+    Matrix *sysTang;   // integrator-assembled system tangent
     Vector *resid;
     Vector *C;
+    const bool timeVarying;
     double alpha;
-	
-    
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.cpp
+++ b/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.cpp
@@ -53,7 +53,8 @@ PenaltyMP_FE::PenaltyMP_FE(int tag, Domain &theDomain,
 :FE_Element(tag, 2,(TheMP.getConstrainedDOFs()).Size()+
  (TheMP.getRetainedDOFs()).Size()),
  theMP(&TheMP), theConstrainedNode(0) , theRetainedNode(0),
- tang(0), resid(0), C(0), alpha(Alpha)
+ tang(0), sysTang(0), resid(0), C(0),
+ timeVarying(TheMP.isTimeVarying()), alpha(Alpha)
 {
     
     int size;
@@ -63,12 +64,13 @@ PenaltyMP_FE::PenaltyMP_FE(int tag, Domain &theDomain,
     size += id2.Size();
 
     tang = new Matrix(size,size);
+    sysTang = new Matrix(size,size);
     resid = new Vector(size);
     C = new Matrix(id1.Size(),size);
 
-    if (tang == 0 || resid == 0 || C == 0 ||
-	tang->noCols() != size || C->noCols() != size || 
-	resid->Size() != size) {
+    if (tang == 0 || sysTang == 0 || resid == 0 || C == 0 ||
+	tang->noCols() != size || sysTang->noCols() != size ||
+	C->noCols() != size || resid->Size() != size) {
 	opserr << "FATAL PenaltyMP_FE::PenaltyMP_FE() - out of memory\n";
 	exit(-1);
     }
@@ -98,7 +100,7 @@ PenaltyMP_FE::PenaltyMP_FE(int tag, Domain &theDomain,
 	opserr << "WARNING PenaltyMP_FE::PenaltyMP_FE() - node no Group yet?\n"; 
     
     
-    if (theMP->isTimeVarying() == false) {
+    if (!timeVarying) {
 	this->determineTangent();
 	// we can free up the space taken by C as it is no longer needed
 	if (C != 0)
@@ -111,6 +113,8 @@ PenaltyMP_FE::~PenaltyMP_FE()
 {
     if (tang != 0)
 	delete tang;
+    if (sysTang != 0)
+	delete sysTang;
     if (resid != 0)
 	delete resid;
     if (C != 0)
@@ -201,15 +205,74 @@ PenaltyMP_FE::setID(void)
 const Matrix &
 PenaltyMP_FE::getTangent(Integrator *theNewIntegrator)
 {
-    if (theMP->isTimeVarying() == true)
-	this->determineTangent();    
-    return *tang;
+    if (theNewIntegrator != 0)
+	theNewIntegrator->formEleTangent(this);
+    return *sysTang;
 }
+
+
+void
+PenaltyMP_FE::zeroTangent(void)
+{
+    sysTang->Zero();
+}
+
+
+void
+PenaltyMP_FE::addKtToTang(double fact)
+{
+    // Always accumulate: HALL_TANGENT calls both addKtToTang and
+    // addKiToTang, so fact==1.0 must not replace sysTang.
+    if (fact == 0.0)
+        return;
+
+    const Matrix &Ks = this->getStaticTangent();
+    sysTang->addMatrix(1.0, Ks, fact);
+}
+
+
+void
+PenaltyMP_FE::addKiToTang(double fact)
+{
+    this->addKtToTang(fact);
+}
+
+
+void
+PenaltyMP_FE::addCtoTang(double fact)
+{
+    // no damping contribution from penalty constraint
+}
+
+
+void
+PenaltyMP_FE::addMtoTang(double fact)
+{
+    // no mass contribution from penalty constraint
+}
+
 
 const Vector &
 PenaltyMP_FE::getResidual(Integrator *theNewIntegrator)
 {
-    // zero residual, CD = 0
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return *resid;
+}
+
+
+void
+PenaltyMP_FE::zeroResidual(void)
+{
+    resid->Zero();
+}
+
+
+void
+PenaltyMP_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
 
     // get the solution vector [Uc Ur]
     static Vector UU;
@@ -224,7 +287,7 @@ PenaltyMP_FE::getResidual(Integrator *theNewIntegrator)
     for (int i = 0; i < id1.Size(); ++i) {
         int cdof = id1(i);
         if (cdof < 0 || cdof >= Uc.Size()) {
-            opserr << "PenaltyMP_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
+            opserr << "PenaltyMP_FE::addRtoResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
             exit(-1);
         }
         UU(i) = Uc(cdof) - Uc0(i);
@@ -232,55 +295,110 @@ PenaltyMP_FE::getResidual(Integrator *theNewIntegrator)
     for (int i = 0; i < id2.Size(); ++i) {
         int rdof = id2(i);
         if (rdof < 0 || rdof >= Ur.Size()) {
-            opserr << "PenaltyMP_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
+            opserr << "PenaltyMP_FE::addRtoResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
             exit(-1);
         }
         UU(i+id1.Size()) = Ur(rdof) - Ur0(i);
     }
 
-    // compute residual
-    const Matrix& KK = getTangent(theNewIntegrator);
-    resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-    // done
-    return *resid;
+    // residual contribution = -R with R = K_static*U, same sign as before
+    resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+
+void
+PenaltyMP_FE::addRIncInertiaToResidual(double fact)
+{
+    // no mass/damping on the constraint
+    this->addRtoResidual(fact);
+}
+
+
+void
+PenaltyMP_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
+
+
+void
+PenaltyMP_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
+}
 
 
 const Vector &
 PenaltyMP_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getTangForce() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    // use last integrator's system tangent (includes c1)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+        opserr << "WARNING PenaltyMP_FE::getTangForce() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+
+    if (fact == 0.0)
+        return *resid;
+
+    const int size = resid->Size();
+    const int dispSize = disp.Size();
+    Vector tmp(size);  // Vector(int) zeros on construction
+    for (int i = 0; i < size; i++) {
+        int dof = myID(i);
+        if (dof >= 0 && dof < dispSize)
+            tmp(i) = disp(dof);
+    }
+
+    if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+        opserr << "WARNING PenaltyMP_FE::getK_Force() - ";
+        opserr << "- addMatrixVector returned error\n";
+    }
+
+    return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+    return this->getK_Force(disp, fact);
 }
 
 const Vector &
 PenaltyMP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getM_Force(const Vector &disp, double fact)
 {
-  // opserr << "WARNING PenaltyMP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+    resid->Zero();
+    return *resid;
 }
 
 void  
@@ -301,25 +419,6 @@ PenaltyMP_FE::determineTangent(void)
     
 
     // now form the tangent: [K] = alpha * [C]^t[C]
-    // *(tang) = (*C)^(*C);
-    // *(tang) *= alpha;
-    /*
-	// THIS IS A WORKAROUND UNTIL WE GET addMatrixTransposeProduct() IN
-	// THE Matrix CLASS OR UNROLL THIS COMPUTATION
-	int rows = C->noRows();
-	int cols = C->noCols();
-	Matrix CT(cols,rows);
-	const Matrix &Cref = *C;
-	// Fill in the transpose of C
-	for (int k = 0; k < cols; k++)
-		for (int l = 0; l < rows; l++)
-			CT(k,l) = Cref(l,k);
-	// Compute alpha*(C^*C)
-	tang->addMatrixProduct(0.0, CT, Cref, alpha);
-    */
-    // workaround no longer required
     const Matrix &Cref = *C;
     tang->addMatrixTransposeProduct(0.0, Cref, Cref, alpha);
 }
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.h
+++ b/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.h
@@ -48,40 +48,57 @@ class Domain;
 class MP_Constraint;
 class Node;
 
-class PenaltyMP_FE: public FE_Element
+class PenaltyMP_FE final : public FE_Element
 {
   public:
     PenaltyMP_FE(int tag, Domain &theDomain, MP_Constraint &theMP, double alpha);
-    virtual ~PenaltyMP_FE();    
+    ~PenaltyMP_FE() override;
 
     // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);
-    virtual const Vector &getResidual(Integrator *theIntegrator);
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);
-    
-  protected:
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    // methods to allow integrator to build tangent
+    void  zeroTangent(void) override;
+    void  addKtToTang(double fact = 1.0) override;
+    void  addKiToTang(double fact = 1.0) override;
+    void  addCtoTang(double fact = 1.0) override;
+    void  addMtoTang(double fact = 1.0) override;
+
+    // methods to allow integrator to build residual
+    void  zeroResidual(void) override;
+    void  addRtoResidual(double fact = 1.0) override;
+    void  addRIncInertiaToResidual(double fact = 1.0) override;
+    void  addM_Force(const Vector &accel, double fact = 1.0) override;
+    void  addD_Force(const Vector &vel, double fact = 1.0) override;
     
   private:
     void determineTangent(void);
+
+    const Matrix &getStaticTangent(void)
+    {
+        if (timeVarying)
+            this->determineTangent();
+        return *tang;
+    }
     
     MP_Constraint *theMP;
     Node *theConstrainedNode;
     Node *theRetainedNode;    
 
-    Matrix *tang;
+    Matrix *tang;      // unscaled static penalty stiffness
+    Matrix *sysTang;   // integrator-assembled system tangent
     Vector *resid;
     Matrix *C;    // to hold the C matrix
+    const bool timeVarying;
     double alpha;
-	
-    
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltySP_FE.cpp
+++ b/SRC/analysis/fe_ele/penalty/PenaltySP_FE.cpp
@@ -113,65 +113,157 @@ PenaltySP_FE::setID(void)
 const Matrix &
 PenaltySP_FE::getTangent(Integrator *theNewIntegrator)
 {
-  tang(0,0) = alpha;
+  if (theNewIntegrator != 0)
+    theNewIntegrator->formEleTangent(this);
+
   return tang;
+}
+
+
+void
+PenaltySP_FE::zeroTangent(void)
+{
+  tang.Zero();
+}
+
+
+void
+PenaltySP_FE::addKtToTang(double fact)
+{
+  if (fact == 0.0)
+    return;
+  tang(0,0) += alpha * fact;
+}
+
+
+void
+PenaltySP_FE::addKiToTang(double fact)
+{
+  this->addKtToTang(fact);
+}
+
+
+void
+PenaltySP_FE::addCtoTang(double fact)
+{
+  // no damping contribution from penalty constraint
+}
+
+
+void
+PenaltySP_FE::addMtoTang(double fact)
+{
+  // no mass contribution from penalty constraint
 }
 
 
 const Vector &
 PenaltySP_FE::getResidual(Integrator *theNewIntegrator)
 {
+    if (theNewIntegrator != 0)
+        theNewIntegrator->formEleResidual(this);
+    return resid;
+}
+
+
+void
+PenaltySP_FE::zeroResidual(void)
+{
+    resid.Zero();
+}
+
+
+void
+PenaltySP_FE::addRtoResidual(double fact)
+{
+    if (fact == 0.0)
+        return;
+
     double constraint = theSP->getValue();
     double initialValue = theSP->getInitialValue();
     int constrainedDOF = theSP->getDOF_Number();
     const Vector &nodeDisp = theNode->getTrialDisp();
-	
+
     if (constrainedDOF < 0 || constrainedDOF >= nodeDisp.Size()) {
-	opserr << "WARNING PenaltySP_FE::getTangForce() - ";	
-	opserr << " constrained DOF " << constrainedDOF << " outside disp\n";
-	resid(0) = 0;
+        opserr << "WARNING PenaltySP_FE::addRtoResidual() - ";
+        opserr << " constrained DOF " << constrainedDOF << " outside disp\n";
+        return;
     }
 
-    //    (*resid)(0) = alpha * (constraint - nodeDisp(constrainedDOF));    
-    // is replace with the following to remove possible problems with
-    // subtracting very small numbers
+    // residual contribution = -R with R = alpha*((u-u0) - g), same sign as before
+    resid(0) += fact * alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));
+}
 
-    resid(0) = alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));    
 
-    return resid;
+void
+PenaltySP_FE::addRIncInertiaToResidual(double fact)
+{
+    // no mass/damping on the constraint
+    this->addRtoResidual(fact);
+}
+
+
+void
+PenaltySP_FE::addM_Force(const Vector &accel, double fact)
+{
+    // no-op
+}
+
+
+void
+PenaltySP_FE::addD_Force(const Vector &vel, double fact)
+{
+    // no-op
 }
 
 
 const Vector &
 PenaltySP_FE::getTangForce(const Vector &disp, double fact)
 {
-    double constraint = theSP->getValue();
-    int constrainedID = myID(0);
-    if (constrainedID < 0 || constrainedID >= disp.Size()) {
-	opserr << "WARNING PenaltySP_FE::getTangForce() - ";	
-	opserr << " constrained DOF " << constrainedID << " outside disp\n";
-	resid(0) = 0.0;
-	return resid;
-    }
-    resid(0) = alpha * disp(constrainedID);
+    resid.Zero();
 
+    if (fact == 0.0)
+        return resid;
+
+    // use last integrator's system tangent (includes c1)
+    const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+    const int constrainedID = myID(0);
+    const int dispSize = disp.Size();
+    if (constrainedID < 0 || constrainedID >= dispSize) {
+        opserr << "WARNING PenaltySP_FE::getTangForce() - ";
+        opserr << " constrained DOF " << constrainedID << " outside disp\n";
+        return resid;
+    }
+
+    resid(0) = Kt(0, 0) * disp(constrainedID) * fact;
     return resid;
 }
 
 const Vector &
 PenaltySP_FE::getK_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltySP_FE::getK_Force() - not yet implemented\n";
-  resid(0) = 0.0;
-  return resid;
+    resid(0) = 0.0;
+
+    if (fact == 0.0)
+        return resid;
+
+    const int constrainedID = myID(0);
+    const int dispSize = disp.Size();
+    if (constrainedID < 0 || constrainedID >= dispSize) {
+        opserr << "WARNING PenaltySP_FE::getK_Force() - ";
+        opserr << " constrained DOF " << constrainedID << " outside disp\n";
+        return resid;
+    }
+
+    resid(0) = alpha * disp(constrainedID) * fact;
+    return resid;
 }
 
 const Vector &
 PenaltySP_FE::getKi_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltySP_FE::getKi_Force() - not yet implemented\n";
-  resid(0) = 0.0;
-  return resid;
+  return this->getK_Force(disp, fact);
 }
 
 
@@ -190,7 +282,3 @@ PenaltySP_FE::getM_Force(const Vector &disp, double fact)
   resid(0) = 0.0;
   return resid;
 }
-
-
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltySP_FE.h
+++ b/SRC/analysis/fe_ele/penalty/PenaltySP_FE.h
@@ -48,25 +48,37 @@ class Domain;
 class SP_Constraint;
 class Node;
 
-class PenaltySP_FE: public FE_Element
+class PenaltySP_FE final : public FE_Element
 {
   public:
     PenaltySP_FE(int tag, Domain &theDomain, SP_Constraint &theSP, double alpha=1.0e8);    
-    virtual ~PenaltySP_FE();    
+    ~PenaltySP_FE() override;
 
     // public methods
-    virtual int  setID(void);
-    virtual const Matrix &getTangent(Integrator *theIntegrator);
-    virtual const Vector &getResidual(Integrator *theIntegrator);
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(void) override;
+    const Matrix &getTangent(Integrator *theIntegrator) override;
+    const Vector &getResidual(Integrator *theIntegrator) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);    
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
 
-  protected:
-    
+    // methods to allow integrator to build tangent
+    void  zeroTangent(void) override;
+    void  addKtToTang(double fact = 1.0) override;
+    void  addKiToTang(double fact = 1.0) override;
+    void  addCtoTang(double fact = 1.0) override;
+    void  addMtoTang(double fact = 1.0) override;
+
+    // methods to allow integrator to build residual
+    void  zeroResidual(void) override;
+    void  addRtoResidual(double fact = 1.0) override;
+    void  addRIncInertiaToResidual(double fact = 1.0) override;
+    void  addM_Force(const Vector &accel, double fact = 1.0) override;
+    void  addD_Force(const Vector &vel, double fact = 1.0) override;
+
   private:
     double alpha;
     SP_Constraint *theSP;
@@ -76,5 +88,3 @@ class PenaltySP_FE: public FE_Element
 };
 
 #endif
-
-


### PR DESCRIPTION
**Issue**

`getTangent` in the Penalty and Lagrange FE elements bypassed the integrator. As a result:

1. Constraint terms could be incorrectly included in matrices intended to contain only mass contributions, such as through the eigenvalue assembly path `formM` → `getTangent` → `addM`, or in certain explicit integrators that assemble only mass on the left-hand side.
2. The assembled tangent could be inconsistent with the residual.

This PR routes the Penalty and Lagrange constraint FE tangents through the integrator and also implements previously missing methods, including `getK_Force` and `getTangForce`.
