### PR TITLE
Fix: Keep `Graph::getNumEdge` consistent with vertex adjacency lists.

### DIFF
--- a/SRC/analysis/model/AnalysisModel.cpp
+++ b/SRC/analysis/model/AnalysisModel.cpp
@@ -347,7 +347,7 @@ AnalysisModel::getDOFGraph(void)
 	if (eqn1 >=START_EQN_NUM) {
 	  for (int j=i+1; j<size; j++) {
 	    int eqn2 = id(j);
-	    if (eqn2 >=START_EQN_NUM)
+	    if (eqn2 >=START_EQN_NUM && eqn1 != eqn2)
 	      myDOFGraph->addEdgeFast(eqn1-START_EQN_NUM+START_VERTEX_NUM,
 				  eqn2-START_EQN_NUM+START_VERTEX_NUM);
 	  }

--- a/SRC/graph/graph/ArrayGraph.cpp
+++ b/SRC/graph/graph/ArrayGraph.cpp
@@ -208,6 +208,10 @@ ArrayGraph::getVertexPtr(int vertexTag)
 int 
 ArrayGraph::addEdge(int vertexTag, int otherVertexTag)
 {
+    // Self-loops are not stored in adjacency; do not inflate numEdge.
+    if (vertexTag == otherVertexTag)
+	return 0;
+
     // get pointers to the vertices, if one does not exist return
 
     Vertex *vertex1 = this->getVertexPtr(vertexTag);

--- a/SRC/graph/graph/DOF_Graph.cpp
+++ b/SRC/graph/graph/DOF_Graph.cpp
@@ -125,7 +125,7 @@ DOF_Graph::DOF_Graph(AnalysisModel &theModel)
       if (eqn1 >=START_EQN_NUM) {
 	for (int j=i+1; j<size; j++) {
 	  int eqn2 = id(j);
-	  if (eqn2 >=START_EQN_NUM)
+	  if (eqn2 >=START_EQN_NUM && eqn1 != eqn2)
 	    this->addEdge(eqn1-START_EQN_NUM+START_VERTEX_NUM,
 			  eqn2-START_EQN_NUM+START_VERTEX_NUM);
 	}

--- a/SRC/graph/graph/Graph.cpp
+++ b/SRC/graph/graph/Graph.cpp
@@ -184,6 +184,12 @@ Graph::addVertex(Vertex *vertexPtr, bool checkAdjacency)
 int 
 Graph::addEdge(int vertexTag, int otherVertexTag)
 {
+    // Self-loops are not stored in adjacency (Vertex::addEdge rejects them)
+    // but historically returned 0 ("added"), which inflated numEdge without
+    // growing either adjacency list. That broke nnz = V + 2E. Skip them.
+    if (vertexTag == otherVertexTag)
+	return 0;
+
     // get pointers to the vertices, if one does not exist return
 
     Vertex *vertex1 = this->getVertexPtr(vertexTag);
@@ -236,6 +242,10 @@ Graph::startAddEdge() {
 int 
 Graph::addEdgeFast(int vertexTag, int otherVertexTag)
 {
+    // See Graph::addEdge: self-loops must not inflate numEdge.
+    if (vertexTag == otherVertexTag)
+	return 0;
+
     // get pointers to the vertices, if one does not exist return
     if (vertices.size()<=vertexTag ||
     vertices.size()<=otherVertexTag) {

--- a/SRC/graph/graph/Vertex.cpp
+++ b/SRC/graph/graph/Vertex.cpp
@@ -101,9 +101,11 @@ Vertex::getTmp(void) const
 int 
 Vertex::addEdge(int otherTag)
 {
-    // don't allow itself to be added
+    // don't allow itself to be added. Return 1 ("already present") so
+    // Graph::addEdge does not treat this as a newly inserted edge and
+    // incorrectly increment numEdge.
     if (otherTag == this->getTag())
-      return 0;
+      return 1;
 
     // check the otherVertex has not already been added
     return myAdjacency.insert(otherTag);


### PR DESCRIPTION
`Vertex::addEdge` rejects self-loops but still returned `0` (i.e. “added”), so `Graph` increased `numEdge` without growing either adjacency list. That created a mismatch between the expected number of nonzeros from `nnz = numVertices + 2*numEdges` and the count from looping over the adjacency lists. Under the Transformation constraint handler this shows up when an element’s condensed IDs repeat an equation and the DOF graph asks for `addEdge(i,i)`.