### PR TITLE
Guard BandGeneral solver against invalid LAPACK inputs

### DIFF
--- a/SRC/system_of_eqn/linearSOE/bandGEN/BandGenLinLapackSolver.cpp
+++ b/SRC/system_of_eqn/linearSOE/bandGEN/BandGenLinLapackSolver.cpp
@@ -37,7 +37,7 @@
 
 #include <BandGenLinLapackSolver.h>
 #include <BandGenLinSOE.h>
-#include <math.h>
+#include <cmath>
 
 void* OPS_BandGenLinLapack()
 {
@@ -103,7 +103,23 @@ BandGenLinLapackSolver::solve(void)
 
     int kl = theSOE->numSubD;
     int ku = theSOE->numSuperD;
-    int ldA = 2*kl + ku +1;
+
+    // LAPACK requires non-negative bandwidths no larger than n - 1 and
+    // enough leading storage for the band matrix. Reject malformed state
+    // before it reaches the Fortran routine, which otherwise may crash the
+    // host process on some platforms.
+    if (kl < 0 || ku < 0 || kl >= n || ku >= n) {
+	opserr << "WARNING BandGenLinLapackSolver::solve() - invalid band dimensions" << endln;
+	return -1;
+    }
+
+    const long long ldAValue = 2LL * kl + ku + 1;
+    if (ldAValue <= 0 || ldAValue * n > theSOE->Asize) {
+	opserr << "WARNING BandGenLinLapackSolver::solve() - invalid leading dimension" << endln;
+	return -1;
+    }
+
+    int ldA = static_cast<int>(ldAValue);
     int nrhs = 1;
     int ldB = n;
     int info;
@@ -111,10 +127,26 @@ BandGenLinLapackSolver::solve(void)
     double *Xptr = theSOE->X;
     double *Bptr = theSOE->B;
     int    *iPIV = iPiv;
+
+    if (Aptr == 0 || Xptr == 0 || Bptr == 0 || iPIV == 0) {
+	opserr << "WARNING BandGenLinLapackSolver::solve() - incomplete solver storage" << endln;
+	return -1;
+    }
+
+    for (long long i = 0; i < static_cast<long long>(ldA) * n; ++i) {
+	if (!std::isfinite(Aptr[i])) {
+	    opserr << "WARNING BandGenLinLapackSolver::solve() - non-finite value in matrix A" << endln;
+	    return -1;
+	}
+    }
     
     // first copy B into X
     for (int i=0; i<n; i++) {
 	*(Xptr++) = *(Bptr++);
+	if (!std::isfinite(*(Xptr - 1))) {
+	    opserr << "WARNING BandGenLinLapackSolver::solve() - non-finite value in right-hand side" << endln;
+	    return -1;
+	}
     }
     Xptr = theSOE->X;
 

--- a/tests/test_bandgen_solver.py
+++ b/tests/test_bandgen_solver.py
@@ -1,0 +1,42 @@
+import math
+
+try:
+    import opensees as ops
+except ModuleNotFoundError:
+    import openseespy.opensees as ops
+
+
+def _build_static_system(material_modulus=1.0):
+    ops.wipe()
+    ops.model("basic", "-ndm", 1, "-ndf", 1)
+    ops.node(1, 0.0)
+    ops.node(2, 1.0)
+    ops.fix(1, 1)
+    ops.uniaxialMaterial("Elastic", 1, material_modulus)
+    ops.element("truss", 1, 1, 2, 1.0, 1)
+    ops.timeSeries("Constant", 1)
+    ops.pattern("Plain", 1, 1)
+    ops.system("BandGeneral")
+    ops.numberer("Plain")
+    ops.constraints("Plain")
+    ops.integrator("LoadControl", 1.0)
+    ops.algorithm("Linear")
+    ops.analysis("Static")
+
+
+def test_bandgeneral_rejects_nonfinite_rhs_without_crashing():
+    try:
+        _build_static_system()
+        ops.load(2, math.nan)
+        assert ops.analyze(1) != 0
+    finally:
+        ops.wipe()
+
+
+def test_bandgeneral_rejects_nonfinite_matrix_without_crashing():
+    try:
+        _build_static_system(math.nan)
+        ops.load(2, 1.0)
+        assert ops.analyze(1) != 0
+    finally:
+        ops.wipe()


### PR DESCRIPTION
## Summary

- validate BandGeneral bandwidth and LAPACK leading-dimension storage before calling DGBSV/DGBTRS
- reject incomplete solver storage and non-finite matrix or right-hand-side values with an OpenSees error
- add OpenSeesPy regressions covering non-finite matrix and right-hand-side input

This addresses the invalid-input failure mode reported in #1611 by preventing malformed data from reaching the Fortran LAPACK routine.

## Verification

- `cmake --build build/regression --target OpenSeesPy -j4`
- `python tests/run_pytest.py --module build/regression/OpenSeesPy.dylib --tests-dir tests/test_bandgen_solver.py`
- result: 2 passed

Contributor: Musawer Ahmad Saqif <saqif@umich.com>
