### PR TITLE
Fix Conan 2 Linux CMake integration

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -30,6 +30,7 @@ jobs:
       - name: build OpenSees & OpenSeesPy
         run: |
           conan install . --build=missing
+          test -f build/Release/generators/conan_toolchain.cmake
           cmake -S . -B build/Release -DCMAKE_TOOLCHAIN_FILE=build/Release/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/bin
           cd build/Release
           cmake --build . --target OpenSees -j8
@@ -76,6 +77,7 @@ jobs:
           export FC=/opt/homebrew/bin/gfortran-13
           export LDFLAGS="-L/opt/homebrew/lib/gcc/current -lgfortran"
           conan install . --build=missing
+          test -f build/Release/generators/conan_toolchain.cmake
           cmake -S . -B build/Release -DCMAKE_TOOLCHAIN_FILE=build/Release/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/bin	
           cd build/Release
           cmake --build . --target OpenSees -j8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,12 +113,24 @@ add_library(OPS_OS_Specific_libs INTERFACE)
 MESSAGE("${CMAKE_BINARY_DIR}")
 
 
-if(CONAN_EXPORTED)
-    message(STATUS "USING CONAN (via Transparent Integration)")
+set(USING_CONAN FALSE)
+set(NOT_USING_CONAN TRUE)
+
+if(CONAN_EXPORTED OR (DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_TOOLCHAIN_FILE MATCHES "conan_toolchain\\.cmake$"))
+    message(STATUS "USING CONAN (via CMake toolchain)")
     set(USING_CONAN TRUE)
+    set(NOT_USING_CONAN FALSE)
 else()
     message(STATUS "NOT USING CONAN (System Search)")
     include(OpenSeesFunctions) # Your custom logic
+endif()
+
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.txt" AND NOT USING_CONAN)
+    message(FATAL_ERROR
+        "This build directory contains Conan 1 metadata (conanbuildinfo.txt), "
+        "but this project uses Conan 2. Run 'conan install . --build=missing' "
+        "and configure with -DCMAKE_TOOLCHAIN_FILE=build/Release/generators/conan_toolchain.cmake."
+    )
 endif()
 
 find_package(ZLIB REQUIRED)
@@ -561,7 +573,7 @@ add_library(OPS_PFEM               OBJECT EXCLUDE_FROM_ALL)
 add_library(OPS_InterpTcl          STATIC)
 
 target_compile_definitions(OPS_InterpTcl PUBLIC _TCL85)
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+if(NOT USING_CONAN)
   target_include_directories(OPS_InterpTcl PUBLIC ${TCL_INCLUDE_PATH})
   target_link_libraries(OPS_InterpTcl PRIVATE ${TCL_LIBRARIES})
 endif()
@@ -660,25 +672,23 @@ add_executable(OpenSees EXCLUDE_FROM_ALL
   ${OPS_SRC_DIR}/actor/objectBroker/FEM_ObjectBrokerAllClasses.cpp
 )
 
-if(TARGET TCL::TCL)
+if(TARGET TCL::TCL OR TARGET tcl::tcl)
     # --- CONAN 2 LOGIC ---
-    message(STATUS "Conan TCL found at: ${tcl_PACKAGE_FOLDER}")
-    
-    # In Conan 2, the library files are typically in the 'lib' subfolder of the package
-    set(CONAN_TCL_LIB_DIR "${tcl_PACKAGE_FOLDER}/lib")
+    message(STATUS "Conan TCL found")
 
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/tcl8.6)
-    
-    add_custom_command(
-        TARGET OpenSees POST_BUILD
-        COMMENT "Copying init.tcl from Conan TCL to binary directory"
-        COMMAND ${CMAKE_COMMAND} -E copy
-        "${CONAN_TCL_LIB_DIR}/tcl8.6/init.tcl"
-        "${CMAKE_CURRENT_BINARY_DIR}/lib/tcl8.6"
-    )
-    
-    # Note: You don't usually need target_include_directories here 
-    # because target_link_libraries(OpenSees PRIVATE TCL::TCL) handles it.
+
+    if(TCL_INIT_FILE)
+        add_custom_command(
+            TARGET OpenSees POST_BUILD
+            COMMENT "Copying init.tcl from Conan TCL to binary directory"
+            COMMAND ${CMAKE_COMMAND} -E copy
+            "${TCL_INIT_FILE}"
+            "${CMAKE_CURRENT_BINARY_DIR}/lib/tcl8.6"
+        )
+    else()
+        message(WARNING "Conan Tcl target found, but init.tcl was not located")
+    endif()
 
 else()
     # --- SYSTEM / NON-CONAN LOGIC ---

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ https://OpenSees.github.io/OpenSeesDocumentation
 Steps to build OpenSees on Windows, Linux, and Mac:
 https://opensees.github.io/OpenSeesDocumentation/developer/build.html
 
+### Linux with Conan 2
+
+The current CMake build uses Conan 2's generated toolchain. From the repository
+root, run:
+
+```bash
+python3 -m pip install --upgrade "conan>=2,<3"
+conan profile detect --force
+conan install . --build=missing
+cmake -S . -B build/Release \
+  -DCMAKE_TOOLCHAIN_FILE=build/Release/generators/conan_toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build/Release --target OpenSees -j$(nproc)
+```
+
+Do not run `cmake ..` against a directory containing Conan 1's
+`conanbuildinfo.txt`. Conan 1 metadata is not consumed by this Conan 2 CMake
+configuration; use the generated `conan_toolchain.cmake` as shown above.
+
 ## Modeling Questions
 Issues related to modeling questions will be closed. Instead, post your modeling questions on the OpenSees 
 message board or in the OpenSees Facebook group.

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy
 from conan.errors import ConanInvalidConfiguration
 import os
@@ -19,6 +19,11 @@ class OpenSeesDependencies(ConanFile):
     default_options = {}
 
     exports_sources = "CMakeLists.txt", "src/*", "applications/*", "LICENSE"
+
+    def layout(self):
+        # Keep Conan generators in build/<configuration>/generators, matching
+        # the CMake and CI entry points used by this repository.
+        cmake_layout(self)
 
     def requirements(self):
         self.requires("hdf5/1.14.6")


### PR DESCRIPTION
## Summary

- restore Conan 2 `cmake_layout()` so generated files land in the path used by CMake and CI
- detect the Conan 2 CMake toolchain and avoid accidentally mixing Conan and system dependency discovery
- provide a clear diagnostic for legacy Conan 1 metadata and correct Conan Tcl `init.tcl` handling
- document the supported Linux Conan 2 configure sequence and verify the generated toolchain in CI

This addresses #1778 by making the Linux dependency workflow explicit and by preventing `cmake ..` from silently ignoring Conan-generated dependencies.

## Verification

- Conan-toolchain CMake configure completed successfully with ZLIB, HDF5, Tcl, and Eigen package targets
- `cmake --build build/with-toolchain --target OpenSees -j4`
- result: `OpenSees` built successfully and copied Conan Tcl `init.tcl`
- simulated legacy `conanbuildinfo.txt` produced the new actionable configure error
- `git diff --check`

Contributor: Musawer Ahmad Saqif <saqif@umich.com>
