### PR TITLE
Handle Matrix and Vector otherFact special cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -899,6 +899,11 @@ set_target_properties(${OPS_FINAL_TARGET} PROPERTIES EXCLUDE_FROM_ALL OFF)
 # Add sources to targets
 add_subdirectory(${OPS_SRC_DIR})
 
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
+endif()
+
 
 
 

--- a/SRC/matrix/Matrix.cpp
+++ b/SRC/matrix/Matrix.cpp
@@ -44,6 +44,16 @@ using std::nothrow;
 
 #include <math.h>
 
+static inline double
+scaleWithFact(double value, double fact)
+{
+  if (fact == 1.0)
+    return value;
+  if (fact == -1.0)
+    return -value;
+  return value * fact;
+}
+
 int Matrix::sizeDoubleWork = MATRIX_WORK_AREA;
 int Matrix::sizeIntWork = INT_WORK_AREA;
 double Matrix::MATRIX_NOT_VALID_ENTRY =0.0;
@@ -650,8 +660,17 @@ Matrix::Invert(Matrix &theInverse) const
 int
 Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 {
-    if (factThis == 1.0 && factOther == 0.0)
+    if (factOther == 0.0) {
+      if (factThis == 1.0)
+        return 0;
+      if (factThis == 0.0) {
+        this->Zero();
+        return 0;
+      }
+      for (int i=0; i<dataSize; i++)
+        data[i] *= factThis;
       return 0;
+    }
 
 #ifdef _G3DEBUG
     if ((other.numRows != numRows) || (other.numCols != numCols)) {
@@ -672,7 +691,7 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
-	  *dataPtr++ += *otherDataPtr++ * factOther;
+	  *dataPtr++ += scaleWithFact(*otherDataPtr++, factOther);
       }
     } 
 
@@ -688,7 +707,7 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
-	  *dataPtr++ = *otherDataPtr++ * factOther;
+	  *dataPtr++ = scaleWithFact(*otherDataPtr++, factOther);
       }
     } 
 
@@ -706,7 +725,7 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++) {
-	  double value = *dataPtr * factThis + *otherDataPtr++ * factOther;
+	  double value = *dataPtr * factThis + scaleWithFact(*otherDataPtr++, factOther);
 	  *dataPtr++ = value;
 	}
       }
@@ -720,8 +739,17 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 int
 Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOther)
 {
-    if (factThis == 1.0 && factOther == 0.0)
+    if (factOther == 0.0) {
+      if (factThis == 1.0)
+        return 0;
+      if (factThis == 0.0) {
+        this->Zero();
+        return 0;
+      }
+      for (int i=0; i<dataSize; i++)
+        data[i] *= factThis;
       return 0;
+    }
 
 #ifdef _G3DEBUG
     if ((other.numRows != numCols) || (other.numCols != numRows)) {
@@ -742,8 +770,8 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
-      for (int i=0; i<numRows; i++)
-	    *dataPtr++ += (other.data)[j+i*numCols] * factOther;
+	for (int i=0; i<numRows; i++)
+	    *dataPtr++ += scaleWithFact((other.data)[j+i*numCols], factOther);
     }
       }
     } 
@@ -760,8 +788,8 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
-      for (int i=0; i<numRows; i++)
-	    *dataPtr++ = (other.data)[j+i*numCols] * factOther;
+	for (int i=0; i<numRows; i++)
+	    *dataPtr++ = scaleWithFact((other.data)[j+i*numCols], factOther);
     }
       }
     } 
@@ -780,8 +808,8 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
-      for (int i=0; i<numRows; i++) {
-	    double value = *dataPtr * factThis + (other.data)[j+i*numCols] * factOther;
+	for (int i=0; i<numRows; i++) {
+	    double value = *dataPtr * factThis + scaleWithFact((other.data)[j+i*numCols], factOther);
 	    *dataPtr++ = value;
       }
     }
@@ -799,8 +827,17 @@ Matrix::addMatrixProduct(double thisFact,
 			 const Matrix &C, 
 			 double otherFact)
 {
-    if (thisFact == 1.0 && otherFact == 0.0)
+    if (otherFact == 0.0) {
+      if (thisFact == 1.0)
+        return 0;
+      if (thisFact == 0.0) {
+        this->Zero();
+        return 0;
+      }
+      for (int i=0; i<dataSize; i++)
+        data[i] *= thisFact;
       return 0;
+    }
 #ifdef _G3DEBUG
     if ((B.numRows != numRows) || (C.numCols != numCols) || (B.numCols != C.numRows)) {
       opserr << "Matrix::addMatrixProduct(): incompatible matrices, this\n";
@@ -816,7 +853,7 @@ Matrix::addMatrixProduct(double thisFact,
       for (int j=0; j<numCols; j++) {
 	double *aijPtrA = &data[j*numRows];
 	for (int k=0; k<numColB; k++) {
-	  double tmp = *ckjPtr++ * otherFact;
+	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
 	  double *aijPtr = aijPtrA;
 	  double *bikPtr = &(B.data)[k*numRows];
 	  for (int i=0; i<numRows; i++)
@@ -836,7 +873,7 @@ Matrix::addMatrixProduct(double thisFact,
       for (int j=0; j<numCols; j++) {
 	double *aijPtrA = &data[j*numRows];
 	for (int k=0; k<numColB; k++) {
-	  double tmp = *ckjPtr++ * otherFact;
+	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
 	  double *aijPtr = aijPtrA;
 	  double *bikPtr = &(B.data)[k*numRows];
 	  for (int i=0; i<numRows; i++)
@@ -855,7 +892,7 @@ Matrix::addMatrixProduct(double thisFact,
       for (int j=0; j<numCols; j++) {
 	double *aijPtrA = &data[j*numRows];
 	for (int k=0; k<numColB; k++) {
-	  double tmp = *ckjPtr++ * otherFact;
+	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
 	  double *aijPtr = aijPtrA;
 	  double *bikPtr = &(B.data)[k*numRows];
 	  for (int i=0; i<numRows; i++)
@@ -873,8 +910,17 @@ Matrix::addMatrixTransposeProduct(double thisFact,
 				  const Matrix &C, 
 				  double otherFact)
 {
-  if (thisFact == 1.0 && otherFact == 0.0)
+  if (otherFact == 0.0) {
+    if (thisFact == 1.0)
+      return 0;
+    if (thisFact == 0.0) {
+      this->Zero();
+      return 0;
+    }
+    for (int i=0; i<dataSize; i++)
+      data[i] *= thisFact;
     return 0;
+  }
 
 #ifdef _G3DEBUG
   if ((B.numCols != numRows) || (C.numCols != numCols) || (B.numRows != C.numRows)) {
@@ -894,7 +940,7 @@ Matrix::addMatrixTransposeProduct(double thisFact,
 	for (int k=0; k<numMults; k++) {
 	  sum += *bkiPtr++ * *cjkPtr++;
 	}
-	*aijPtr++ += sum * otherFact;
+	*aijPtr++ += scaleWithFact(sum, otherFact);
       }
     } 
   } else if (thisFact == 0.0) {
@@ -908,7 +954,7 @@ Matrix::addMatrixTransposeProduct(double thisFact,
 	for (int k=0; k<numMults; k++) {
 	  sum += *bkiPtr++ * *cjkPtr++;
 	}
-	*aijPtr++ = sum * otherFact;
+	*aijPtr++ = scaleWithFact(sum, otherFact);
       }
     } 
   } else {
@@ -922,7 +968,7 @@ Matrix::addMatrixTransposeProduct(double thisFact,
 	for (int k=0; k<numMults; k++) {
 	  sum += *bkiPtr++ * *cjkPtr++;
 	}
-	*aijPtr = *aijPtr * thisFact + sum * otherFact;
+	*aijPtr = *aijPtr * thisFact + scaleWithFact(sum, otherFact);
 	aijPtr++;
       }
     } 
@@ -939,8 +985,17 @@ Matrix::addMatrixTripleProduct(double thisFact,
 			       const Matrix &B, 
 			       double otherFact)
 {
-    if (thisFact == 1.0 && otherFact == 0.0)
+    if (otherFact == 0.0) {
+      if (thisFact == 1.0)
+        return 0;
+      if (thisFact == 0.0) {
+        this->Zero();
+        return 0;
+      }
+      for (int i=0; i<dataSize; i++)
+        data[i] *= thisFact;
       return 0;
+    }
 #ifdef _G3DEBUG
     if ((numCols != numRows) || (B.numCols != B.numRows) || (T.numCols != numRows) ||
 	(T.numRows != B.numCols)) {
@@ -970,7 +1025,7 @@ Matrix::addMatrixTripleProduct(double thisFact,
     for (int j=0; j<numCols; j++) {
       double *aijPtrA = &matrixWork[j*dimB];
       for (int k=0; k<dimB; k++) {
-	double tmp = *tkjPtr++ * otherFact;
+	double tmp = scaleWithFact(*tkjPtr++, otherFact);
 	double *aijPtr = aijPtrA;
 	double *bikPtr = &(B.data)[k*dimB];
 	for (int i=0; i<dimB; i++) 
@@ -1038,8 +1093,17 @@ Matrix::addMatrixTripleProduct(double thisFact,
 			       const Matrix &C,
 			       double otherFact)
 {
-    if (thisFact == 1.0 && otherFact == 0.0)
+    if (otherFact == 0.0) {
+      if (thisFact == 1.0)
+        return 0;
+      if (thisFact == 0.0) {
+        this->Zero();
+        return 0;
+      }
+      for (int i=0; i<dataSize; i++)
+        data[i] *= thisFact;
       return 0;
+    }
 #ifdef _G3DEBUG
     if ((numRows != A.numRows) || (A.numCols != B.numRows) || (B.numCols != C.numRows) ||
 	(C.numCols != numCols)) {
@@ -1069,7 +1133,7 @@ Matrix::addMatrixTripleProduct(double thisFact,
     for (int j=0; j<numCols; j++) {
       double *aijPtrA = &matrixWork[j*rowsB];
       for (int k=0; k<rowsB; k++) {
-	double tmp = *ckjPtr++ * otherFact;
+	double tmp = scaleWithFact(*ckjPtr++, otherFact);
 	double *aijPtr = aijPtrA;
 	double *bikPtr = &(B.data)[k*rowsB];
 	for (int i=0; i<rowsB; i++) 

--- a/SRC/matrix/Matrix.cpp
+++ b/SRC/matrix/Matrix.cpp
@@ -44,16 +44,6 @@ using std::nothrow;
 
 #include <math.h>
 
-static inline double
-scaleWithFact(double value, double fact)
-{
-  if (fact == 1.0)
-    return value;
-  if (fact == -1.0)
-    return -value;
-  return value * fact;
-}
-
 int Matrix::sizeDoubleWork = MATRIX_WORK_AREA;
 int Matrix::sizeIntWork = INT_WORK_AREA;
 double Matrix::MATRIX_NOT_VALID_ENTRY =0.0;
@@ -687,11 +677,16 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
 	  *dataPtr++ += *otherDataPtr++;
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+	double *otherDataPtr = other.data;
+	for (int i=0; i<dataSize; i++)
+	  *dataPtr++ -= *otherDataPtr++;
       } else {
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
-	  *dataPtr++ += scaleWithFact(*otherDataPtr++, factOther);
+	  *dataPtr++ += *otherDataPtr++ * factOther;
       }
     } 
 
@@ -703,11 +698,16 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
 	  *dataPtr++ = *otherDataPtr++;
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+	double *otherDataPtr = other.data;
+	for (int i=0; i<dataSize; i++)
+	  *dataPtr++ = -(*otherDataPtr++);
       } else {
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++)
-	  *dataPtr++ = scaleWithFact(*otherDataPtr++, factOther);
+	  *dataPtr++ = *otherDataPtr++ * factOther;
       }
     } 
 
@@ -721,11 +721,18 @@ Matrix::addMatrix(double factThis, const Matrix &other, double factOther)
 	  double value = *dataPtr * factThis + *otherDataPtr++;
 	  *dataPtr++ = value;
 	}
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+	double *otherDataPtr = other.data;
+	for (int i=0; i<dataSize; i++) {
+	  double value = *dataPtr * factThis - *otherDataPtr++;
+	  *dataPtr++ = value;
+	}
       } else {
 	double *dataPtr = data;
 	double *otherDataPtr = other.data;		    
 	for (int i=0; i<dataSize; i++) {
-	  double value = *dataPtr * factThis + scaleWithFact(*otherDataPtr++, factOther);
+	  double value = *dataPtr * factThis + *otherDataPtr++ * factOther;
 	  *dataPtr++ = value;
 	}
       }
@@ -762,16 +769,22 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
 
       // want: this += other^T * factOther
       if (factOther == 1.0) {
-    double *dataPtr = data;
+	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
       for (int i=0; i<numRows; i++)
 	    *dataPtr++ += (other.data)[j+i*numCols];
+    }
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+    for (int j=0; j<numCols; j++) {
+      for (int i=0; i<numRows; i++)
+	    *dataPtr++ -= (other.data)[j+i*numCols];
     }
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
 	for (int i=0; i<numRows; i++)
-	    *dataPtr++ += scaleWithFact((other.data)[j+i*numCols], factOther);
+	    *dataPtr++ += (other.data)[j+i*numCols] * factOther;
     }
       }
     } 
@@ -785,11 +798,17 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
       for (int i=0; i<numRows; i++)
 	    *dataPtr++ = (other.data)[j+i*numCols];
     }
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+    for (int j=0; j<numCols; j++) {
+      for (int i=0; i<numRows; i++)
+	    *dataPtr++ = -(other.data)[j+i*numCols];
+    }
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
 	for (int i=0; i<numRows; i++)
-	    *dataPtr++ = scaleWithFact((other.data)[j+i*numCols], factOther);
+	    *dataPtr++ = (other.data)[j+i*numCols] * factOther;
     }
       }
     } 
@@ -805,11 +824,19 @@ Matrix::addMatrixTranspose(double factThis, const Matrix &other, double factOthe
 	    *dataPtr++ = value;
       }
     }
+      } else if (factOther == -1.0) {
+	double *dataPtr = data;
+    for (int j=0; j<numCols; j++) {
+      for (int i=0; i<numRows; i++) {
+        double value = *dataPtr * factThis - (other.data)[j+i*numCols];
+	    *dataPtr++ = value;
+      }
+    }
       } else {
 	double *dataPtr = data;
     for (int j=0; j<numCols; j++) {
 	for (int i=0; i<numRows; i++) {
-	    double value = *dataPtr * factThis + scaleWithFact((other.data)[j+i*numCols], factOther);
+	    double value = *dataPtr * factThis + (other.data)[j+i*numCols] * factOther;
 	    *dataPtr++ = value;
       }
     }
@@ -844,16 +871,43 @@ Matrix::addMatrixProduct(double thisFact,
       return -1;
     }
 #endif
-    // NOTE: looping as per blas3 dgemm_: j,k,i
-    if (thisFact == 1.0) {
+    if (thisFact == 0.0) {
+      this->Zero();
+    } else if (thisFact != 1.0) {
+      for (int i=0; i<dataSize; i++)
+	data[i] *= thisFact;
+    }
 
-      // want: this += B * C  otherFact
-      int numColB = B.numCols;
-      double *ckjPtr  = &(C.data)[0];
+    // NOTE: looping as per blas3 dgemm_: j,k,i
+    int numColB = B.numCols;
+    double *ckjPtr = &(C.data)[0];
+    if (otherFact == 1.0) {
       for (int j=0; j<numCols; j++) {
 	double *aijPtrA = &data[j*numRows];
 	for (int k=0; k<numColB; k++) {
-	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
+	  double tmp = *ckjPtr++;
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*numRows];
+	  for (int i=0; i<numRows; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else if (otherFact == -1.0) {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &data[j*numRows];
+	for (int k=0; k<numColB; k++) {
+	  double tmp = -(*ckjPtr++);
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*numRows];
+	  for (int i=0; i<numRows; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &data[j*numRows];
+	for (int k=0; k<numColB; k++) {
+	  double tmp = *ckjPtr++ * otherFact;
 	  double *aijPtr = aijPtrA;
 	  double *bikPtr = &(B.data)[k*numRows];
 	  for (int i=0; i<numRows; i++)
@@ -861,45 +915,6 @@ Matrix::addMatrixProduct(double thisFact,
 	}
       }
     }
-
-    else if (thisFact == 0.0) {
-
-      // want: this = B * C  otherFact
-      double *dataPtr = data;
-      for (int i=0; i<dataSize; i++)
-	  *dataPtr++ = 0.0;
-      int numColB = B.numCols;
-      double *ckjPtr  = &(C.data)[0];
-      for (int j=0; j<numCols; j++) {
-	double *aijPtrA = &data[j*numRows];
-	for (int k=0; k<numColB; k++) {
-	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
-	  double *aijPtr = aijPtrA;
-	  double *bikPtr = &(B.data)[k*numRows];
-	  for (int i=0; i<numRows; i++)
-	    *aijPtr++ += *bikPtr++ * tmp;
-	}
-      }
-    } 
-
-    else {
-      // want: this = B * C  otherFact
-      double *dataPtr = data;
-      for (int i=0; i<dataSize; i++)
-	  *dataPtr++ *= thisFact;
-      int numColB = B.numCols;
-      double *ckjPtr  = &(C.data)[0];
-      for (int j=0; j<numCols; j++) {
-	double *aijPtrA = &data[j*numRows];
-	for (int k=0; k<numColB; k++) {
-	  double tmp = scaleWithFact(*ckjPtr++, otherFact);
-	  double *aijPtr = aijPtrA;
-	  double *bikPtr = &(B.data)[k*numRows];
-	  for (int i=0; i<numRows; i++)
-	    *aijPtr++ += *bikPtr++ * tmp;
-	}
-      }
-    } 
 
     return 0;
 }
@@ -929,49 +944,48 @@ Matrix::addMatrixTransposeProduct(double thisFact,
   }
 #endif
 
-  if (thisFact == 1.0) {
-    int numMults = C.numRows;
-    double *aijPtr = data;
+  if (thisFact == 0.0) {
+    this->Zero();
+  } else if (thisFact != 1.0) {
+    for (int i=0; i<dataSize; i++)
+      data[i] *= thisFact;
+  }
+
+  int numMults = C.numRows;
+  double *aijPtr = data;
+  if (otherFact == 1.0) {
     for (int j=0; j<numCols; j++) {
       for (int i=0; i<numRows; i++) {
-	double *bkiPtr  = &(B.data)[i*numMults];
-	double *cjkPtr  = &(C.data)[j*numMults];
+	double *bkiPtr = &(B.data)[i*numMults];
+	double *cjkPtr = &(C.data)[j*numMults];
 	double sum = 0.0;
-	for (int k=0; k<numMults; k++) {
+	for (int k=0; k<numMults; k++)
 	  sum += *bkiPtr++ * *cjkPtr++;
-	}
-	*aijPtr++ += scaleWithFact(sum, otherFact);
+	*aijPtr++ += sum;
       }
-    } 
-  } else if (thisFact == 0.0) {
-    int numMults = C.numRows;
-    double *aijPtr = data;
+    }
+  } else if (otherFact == -1.0) {
     for (int j=0; j<numCols; j++) {
       for (int i=0; i<numRows; i++) {
-	double *bkiPtr  = &(B.data)[i*numMults];
-	double *cjkPtr  = &(C.data)[j*numMults];
+	double *bkiPtr = &(B.data)[i*numMults];
+	double *cjkPtr = &(C.data)[j*numMults];
 	double sum = 0.0;
-	for (int k=0; k<numMults; k++) {
+	for (int k=0; k<numMults; k++)
 	  sum += *bkiPtr++ * *cjkPtr++;
-	}
-	*aijPtr++ = scaleWithFact(sum, otherFact);
+	*aijPtr++ -= sum;
       }
-    } 
+    }
   } else {
-    int numMults = C.numRows;
-    double *aijPtr = data;
     for (int j=0; j<numCols; j++) {
       for (int i=0; i<numRows; i++) {
-	double *bkiPtr  = &(B.data)[i*numMults];
-	double *cjkPtr  = &(C.data)[j*numMults];
+	double *bkiPtr = &(B.data)[i*numMults];
+	double *cjkPtr = &(C.data)[j*numMults];
 	double sum = 0.0;
-	for (int k=0; k<numMults; k++) {
+	for (int k=0; k<numMults; k++)
 	  sum += *bkiPtr++ * *cjkPtr++;
-	}
-	*aijPtr = *aijPtr * thisFact + scaleWithFact(sum, otherFact);
-	aijPtr++;
+	*aijPtr++ += sum * otherFact;
       }
-    } 
+    }
   }
 
   return 0;
@@ -1021,15 +1035,39 @@ Matrix::addMatrixTripleProduct(double thisFact,
     // now form B * T * fact store in matrixWork == A area
     // NOTE: looping as per blas3 dgemm_: j,k,i
 
-    double *tkjPtr  = &(T.data)[0];
-    for (int j=0; j<numCols; j++) {
-      double *aijPtrA = &matrixWork[j*dimB];
-      for (int k=0; k<dimB; k++) {
-	double tmp = scaleWithFact(*tkjPtr++, otherFact);
-	double *aijPtr = aijPtrA;
-	double *bikPtr = &(B.data)[k*dimB];
-	for (int i=0; i<dimB; i++) 
-	  *aijPtr++ += *bikPtr++ * tmp;
+    double *tkjPtr = &(T.data)[0];
+    if (otherFact == 1.0) {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*dimB];
+	for (int k=0; k<dimB; k++) {
+	  double tmp = *tkjPtr++;
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*dimB];
+	  for (int i=0; i<dimB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else if (otherFact == -1.0) {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*dimB];
+	for (int k=0; k<dimB; k++) {
+	  double tmp = -(*tkjPtr++);
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*dimB];
+	  for (int i=0; i<dimB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*dimB];
+	for (int k=0; k<dimB; k++) {
+	  double tmp = *tkjPtr++ * otherFact;
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*dimB];
+	  for (int i=0; i<dimB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
       }
     }
 
@@ -1129,15 +1167,39 @@ Matrix::addMatrixTripleProduct(double thisFact,
     // NOTE: looping as per blas3 dgemm_: j,k,i
     
     int rowsB = B.numRows;
-    double *ckjPtr  = &(C.data)[0];
-    for (int j=0; j<numCols; j++) {
-      double *aijPtrA = &matrixWork[j*rowsB];
-      for (int k=0; k<rowsB; k++) {
-	double tmp = scaleWithFact(*ckjPtr++, otherFact);
-	double *aijPtr = aijPtrA;
-	double *bikPtr = &(B.data)[k*rowsB];
-	for (int i=0; i<rowsB; i++) 
-	  *aijPtr++ += *bikPtr++ * tmp;
+    double *ckjPtr = &(C.data)[0];
+    if (otherFact == 1.0) {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*rowsB];
+	for (int k=0; k<rowsB; k++) {
+	  double tmp = *ckjPtr++;
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*rowsB];
+	  for (int i=0; i<rowsB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else if (otherFact == -1.0) {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*rowsB];
+	for (int k=0; k<rowsB; k++) {
+	  double tmp = -(*ckjPtr++);
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*rowsB];
+	  for (int i=0; i<rowsB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
+      }
+    } else {
+      for (int j=0; j<numCols; j++) {
+	double *aijPtrA = &matrixWork[j*rowsB];
+	for (int k=0; k<rowsB; k++) {
+	  double tmp = *ckjPtr++ * otherFact;
+	  double *aijPtr = aijPtrA;
+	  double *bikPtr = &(B.data)[k*rowsB];
+	  for (int i=0; i<rowsB; i++)
+	    *aijPtr++ += *bikPtr++ * tmp;
+	}
       }
     }
 

--- a/SRC/matrix/Vector.cpp
+++ b/SRC/matrix/Vector.cpp
@@ -41,16 +41,6 @@ using std::nothrow;
 
 double Vector::VECTOR_NOT_VALID_ENTRY =0.0;
 
-static inline double
-scaleWithFact(double value, double fact)
-{
-  if (fact == 1.0)
-    return value;
-  if (fact == -1.0)
-    return -value;
-  return value * fact;
-}
-
 // Vector():
 //	Standard constructor, sets size = 0;
 
@@ -297,7 +287,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
 	*dataPtr++ -= *otherDataPtr++;
     } else 
       for (int i=0; i<sz; i++) 
-	*dataPtr++ += scaleWithFact(*otherDataPtr++, otherFact);
+	*dataPtr++ += *otherDataPtr++ * otherFact;
   } 
 
   else if (thisFact == 0.0) {
@@ -313,7 +303,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
 	*dataPtr++ = -(*otherDataPtr++);
     } else 
       for (int i=0; i<sz; i++) 
-	*dataPtr++ = scaleWithFact(*otherDataPtr++, otherFact);
+	*dataPtr++ = *otherDataPtr++ * otherFact;
   }
 
   else {
@@ -333,7 +323,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
       }
     } else 
       for (int i=0; i<sz; i++) {
-	double value = *dataPtr * thisFact + scaleWithFact(*otherDataPtr++, otherFact);
+	double value = *dataPtr * thisFact + *otherDataPtr++ * otherFact;
 	*dataPtr++ = value;
       }
   } 
@@ -396,7 +386,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
+	double otherData = *otherDataPtr++ * otherFact;
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -433,7 +423,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
+	double otherData = *otherDataPtr++ * otherFact;
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -469,7 +459,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
+	double otherData = *otherDataPtr++ * otherFact;
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -543,7 +533,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	theData[i] += scaleWithFact(sum, otherFact);
+	theData[i] += sum * otherFact;
       }
     }
   }
@@ -582,7 +572,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	theData[i] = scaleWithFact(sum, otherFact);
+	theData[i] = sum * otherFact;
       }
     }
   } 
@@ -623,7 +613,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	double value = theData[i] * thisFact + scaleWithFact(sum, otherFact);
+	double value = theData[i] * thisFact + sum * otherFact;
 	theData[i] = value;
       }
     }

--- a/SRC/matrix/Vector.cpp
+++ b/SRC/matrix/Vector.cpp
@@ -41,6 +41,16 @@ using std::nothrow;
 
 double Vector::VECTOR_NOT_VALID_ENTRY =0.0;
 
+static inline double
+scaleWithFact(double value, double fact)
+{
+  if (fact == 1.0)
+    return value;
+  if (fact == -1.0)
+    return -value;
+  return value * fact;
+}
+
 // Vector():
 //	Standard constructor, sets size = 0;
 
@@ -252,9 +262,17 @@ Vector::Normalize(void)
 int
 Vector::addVector(double thisFact, const Vector &other, double otherFact )
 {
-  // check if quick return
-  if (otherFact == 0.0 && thisFact == 1.0)
-    return 0; 
+  if (otherFact == 0.0) {
+    if (thisFact == 1.0)
+      return 0;
+    if (thisFact == 0.0) {
+      this->Zero();
+      return 0;
+    }
+    for (int i=0; i<sz; i++)
+      theData[i] *= thisFact;
+    return 0;
+  }
 
   // if sizes are compatible add
 #ifdef _G3DEBUG
@@ -279,7 +297,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
 	*dataPtr++ -= *otherDataPtr++;
     } else 
       for (int i=0; i<sz; i++) 
-	*dataPtr++ += *otherDataPtr++ * otherFact;
+	*dataPtr++ += scaleWithFact(*otherDataPtr++, otherFact);
   } 
 
   else if (thisFact == 0.0) {
@@ -295,7 +313,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
 	*dataPtr++ = -(*otherDataPtr++);
     } else 
       for (int i=0; i<sz; i++) 
-	*dataPtr++ = *otherDataPtr++ * otherFact;
+	*dataPtr++ = scaleWithFact(*otherDataPtr++, otherFact);
   }
 
   else {
@@ -315,7 +333,7 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
       }
     } else 
       for (int i=0; i<sz; i++) {
-	double value = *dataPtr * thisFact + *otherDataPtr++ * otherFact;
+	double value = *dataPtr * thisFact + scaleWithFact(*otherDataPtr++, otherFact);
 	*dataPtr++ = value;
       }
   } 
@@ -328,9 +346,17 @@ Vector::addVector(double thisFact, const Vector &other, double otherFact )
 int
 Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, double otherFact )
 {
-  // see if quick return
-  if (thisFact == 1.0 && otherFact == 0.0)
+  if (otherFact == 0.0) {
+    if (thisFact == 1.0)
+      return 0;
+    if (thisFact == 0.0) {
+      this->Zero();
+      return 0;
+    }
+    for (int i=0; i<sz; i++)
+      theData[i] *= thisFact;
     return 0;
+  }
 
   // check the sizes are compatible
 #ifdef _G3DEBUG
@@ -370,7 +396,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = *otherDataPtr++ * otherFact;
+	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -407,7 +433,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = *otherDataPtr++ * otherFact;
+	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -443,7 +469,7 @@ Vector::addMatrixVector(double thisFact, const Matrix &m, const Vector &v, doubl
       double *matrixDataPtr = m.data;
       double *otherDataPtr = v.theData;
       for (int i=0; i<otherSize; i++) {
-	double otherData = *otherDataPtr++ * otherFact;
+	double otherData = scaleWithFact(*otherDataPtr++, otherFact);
 	for (int j=0; j<sz; j++)
 	  theData[j] += *matrixDataPtr++ * otherData;
       }
@@ -462,9 +488,17 @@ Vector::addMatrixTransposeVector(double thisFact,
 				 const Vector &v, 
 				 double otherFact )
 {
-  // see if quick return
-  if (otherFact == 0.0 && thisFact == 1.0)
+  if (otherFact == 0.0) {
+    if (thisFact == 1.0)
+      return 0;
+    if (thisFact == 0.0) {
+      this->Zero();
+      return 0;
+    }
+    for (int i=0; i<sz; i++)
+      theData[i] *= thisFact;
     return 0;
+  }
 
 #ifdef _G3DEBUG
   // check the sizes are compatible
@@ -509,7 +543,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	theData[i] += sum * otherFact;
+	theData[i] += scaleWithFact(sum, otherFact);
       }
     }
   }
@@ -548,7 +582,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	theData[i] = sum * otherFact;
+	theData[i] = scaleWithFact(sum, otherFact);
       }
     }
   } 
@@ -589,7 +623,7 @@ Vector::addMatrixTransposeVector(double thisFact,
 	double sum = 0.0;
 	for (int j=0; j<otherSize; j++)
 	  sum += *matrixDataPtr++ * *otherDataPtr++;
-	double value = theData[i] * thisFact + sum * otherFact;
+	double value = theData[i] * thisFact + scaleWithFact(sum, otherFact);
 	theData[i] = value;
       }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_executable(matrix-vector-otherfact-test
+  test_matrix_vector_otherfact.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/matrix/Matrix.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/matrix/Vector.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/matrix/ID.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/handler/OPS_Stream.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/handler/DummyStream.cpp
+  ${PROJECT_SOURCE_DIR}/SRC/actor/actor/MovableObject.cpp
+)
+
+target_include_directories(matrix-vector-otherfact-test PRIVATE
+  ${PROJECT_SOURCE_DIR}/SRC
+  ${PROJECT_SOURCE_DIR}/SRC/matrix
+  ${PROJECT_SOURCE_DIR}/SRC/handler
+  ${PROJECT_SOURCE_DIR}/SRC/actor/actor
+)
+
+target_link_libraries(matrix-vector-otherfact-test PRIVATE
+  ${LAPACK_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+)
+
+add_test(
+  NAME matrix-vector-otherfact
+  COMMAND matrix-vector-otherfact-test
+)

--- a/tests/test_matrix_vector_otherfact.cpp
+++ b/tests/test_matrix_vector_otherfact.cpp
@@ -111,6 +111,9 @@ int main()
   actual = A;
   actual.addMatrix(1.0, B, -1.0);
   requireMatrix(actual, add(A, B, -1.0), "addMatrix negative-one factor");
+  actual = A;
+  actual.addMatrix(2.0, B, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), B, 2.5), "addMatrix general factors");
 
   actual = A;
   actual.addMatrixTranspose(1.0, B, 0.0);
@@ -118,6 +121,9 @@ int main()
   actual = A;
   actual.addMatrixTranspose(1.0, B, -1.0);
   requireMatrix(actual, add(A, transpose(B), -1.0), "addMatrixTranspose negative-one factor");
+  actual = A;
+  actual.addMatrixTranspose(2.0, B, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), transpose(B), 2.5), "addMatrixTranspose general factors");
 
   const Matrix B23 = makeMatrix(2, 3, 1.0);
   const Matrix C32 = makeMatrix(3, 2, 2.0);
@@ -131,6 +137,9 @@ int main()
   actual = A;
   actual.addMatrixProduct(1.0, B23, C32, -1.0);
   requireMatrix(actual, add(A, product, -1.0), "addMatrixProduct negative-one factor");
+  actual = A;
+  actual.addMatrixProduct(2.0, B23, C32, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), product, 2.5), "addMatrixProduct general factors");
 
   const Matrix A32 = makeMatrix(3, 2, 3.0);
   const Matrix B32 = makeMatrix(3, 2, 4.0);
@@ -141,6 +150,9 @@ int main()
   actual = A;
   actual.addMatrixTransposeProduct(1.0, A32, B32, -1.0);
   requireMatrix(actual, add(A, transposeProduct, -1.0), "addMatrixTransposeProduct negative-one factor");
+  actual = A;
+  actual.addMatrixTransposeProduct(2.0, A32, B32, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), transposeProduct, 2.5), "addMatrixTransposeProduct general factors");
 
   const Matrix T32 = makeMatrix(3, 2, 5.0);
   const Matrix B33 = makeMatrix(3, 3, 6.0);
@@ -151,6 +163,9 @@ int main()
   actual = A;
   actual.addMatrixTripleProduct(1.0, T32, B33, -1.0);
   requireMatrix(actual, add(A, triple, -1.0), "addMatrixTripleProduct negative-one factor");
+  actual = A;
+  actual.addMatrixTripleProduct(2.0, T32, B33, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), triple, 2.5), "addMatrixTripleProduct general factors");
 
   const Matrix C32b = makeMatrix(3, 2, 7.0);
   const Matrix tripleGeneral = multiply(transpose(A32), multiply(B33, C32b));
@@ -160,6 +175,9 @@ int main()
   actual = A;
   actual.addMatrixTripleProduct(1.0, A32, B33, C32b, -1.0);
   requireMatrix(actual, add(A, tripleGeneral, -1.0), "general triple product negative-one factor");
+  actual = A;
+  actual.addMatrixTripleProduct(2.0, A32, B33, C32b, 2.5);
+  requireMatrix(actual, add(scaled(A, 2.0), tripleGeneral, 2.5), "general triple product general factors");
 
   const Vector v = makeVector(2, 8.0);
   const Vector w = makeVector(2, 9.0);
@@ -171,6 +189,11 @@ int main()
   Vector expectedVector = w;
   expectedVector *= -1.0;
   requireVector(vector, expectedVector, "addVector negative-one factor");
+  vector = v;
+  vector.addVector(2.0, w, 2.5);
+  for (int i = 0; i < expectedVector.Size(); ++i)
+    expectedVector(i) = 2.0 * v(i) + 2.5 * w(i);
+  requireVector(vector, expectedVector, "addVector general factors");
 
   const Matrix M23 = makeMatrix(2, 3, 11.0);
   const Vector x3 = makeVector(3, 12.0);
@@ -187,6 +210,12 @@ int main()
   matrixVector.addMatrixVector(0.0, M23, x3, -1.0);
   Mx *= -1.0;
   requireVector(matrixVector, Mx, "addMatrixVector negative-one factor");
+  Mx *= -1.0;
+  matrixVector = v;
+  matrixVector.addMatrixVector(2.0, M23, x3, 2.5);
+  for (int i = 0; i < expectedVector.Size(); ++i)
+    expectedVector(i) = 2.0 * v(i) + 2.5 * Mx(i);
+  requireVector(matrixVector, expectedVector, "addMatrixVector general factors");
 
   const Matrix M32 = makeMatrix(3, 2, 13.0);
   const Vector x3b = makeVector(3, 14.0);
@@ -203,6 +232,12 @@ int main()
   transposeVector.addMatrixTransposeVector(0.0, M32, x3b, -1.0);
   Mtx *= -1.0;
   requireVector(transposeVector, Mtx, "addMatrixTransposeVector negative-one factor");
+  Mtx *= -1.0;
+  transposeVector = v;
+  transposeVector.addMatrixTransposeVector(2.0, M32, x3b, 2.5);
+  for (int i = 0; i < expectedVector.Size(); ++i)
+    expectedVector(i) = 2.0 * v(i) + 2.5 * Mtx(i);
+  requireVector(transposeVector, expectedVector, "addMatrixTransposeVector general factors");
 
   std::cout << "matrix/vector otherFact regression tests passed\n";
   return EXIT_SUCCESS;

--- a/tests/test_matrix_vector_otherfact.cpp
+++ b/tests/test_matrix_vector_otherfact.cpp
@@ -1,0 +1,209 @@
+#include "DummyStream.h"
+#include "Matrix.h"
+#include "Vector.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+DummyStream testError;
+OPS_Stream *opserrPtr = &testError;
+
+namespace {
+
+bool nearlyEqual(double lhs, double rhs)
+{
+  const double scale = 1.0 + std::max(std::fabs(lhs), std::fabs(rhs));
+  return std::fabs(lhs - rhs) <= 1.0e-12 * scale;
+}
+
+void require(bool condition, const char *message)
+{
+  if (!condition) {
+    std::cerr << "FAIL: " << message << "\n";
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+Matrix makeMatrix(int rows, int cols, double offset)
+{
+  Matrix result(rows, cols);
+  for (int j = 0; j < cols; ++j)
+    for (int i = 0; i < rows; ++i)
+      result(i, j) = offset + 1.0 + 2.0 * i + 3.0 * j;
+  return result;
+}
+
+Vector makeVector(int size, double offset)
+{
+  Vector result(size);
+  for (int i = 0; i < size; ++i)
+    result(i) = offset + 1.0 + 2.0 * i;
+  return result;
+}
+
+Matrix scaled(const Matrix &value, double factor)
+{
+  Matrix result(value);
+  for (int j = 0; j < result.noCols(); ++j)
+    for (int i = 0; i < result.noRows(); ++i)
+      result(i, j) *= factor;
+  return result;
+}
+
+Matrix add(const Matrix &lhs, const Matrix &rhs, double rhsFactor)
+{
+  Matrix result(lhs);
+  for (int j = 0; j < result.noCols(); ++j)
+    for (int i = 0; i < result.noRows(); ++i)
+      result(i, j) += rhs(i, j) * rhsFactor;
+  return result;
+}
+
+Matrix multiply(const Matrix &lhs, const Matrix &rhs)
+{
+  Matrix result(lhs.noRows(), rhs.noCols());
+  for (int j = 0; j < rhs.noCols(); ++j)
+    for (int i = 0; i < lhs.noRows(); ++i)
+      for (int k = 0; k < lhs.noCols(); ++k)
+        result(i, j) += lhs(i, k) * rhs(k, j);
+  return result;
+}
+
+Matrix transpose(const Matrix &value)
+{
+  Matrix result(value.noCols(), value.noRows());
+  for (int j = 0; j < value.noCols(); ++j)
+    for (int i = 0; i < value.noRows(); ++i)
+      result(j, i) = value(i, j);
+  return result;
+}
+
+void requireMatrix(const Matrix &actual, const Matrix &expected, const char *message)
+{
+  require(actual.noRows() == expected.noRows() && actual.noCols() == expected.noCols(), message);
+  for (int j = 0; j < actual.noCols(); ++j)
+    for (int i = 0; i < actual.noRows(); ++i)
+      require(nearlyEqual(actual(i, j), expected(i, j)), message);
+}
+
+void requireVector(const Vector &actual, const Vector &expected, const char *message)
+{
+  require(actual.Size() == expected.Size(), message);
+  for (int i = 0; i < actual.Size(); ++i)
+    require(nearlyEqual(actual(i), expected(i)), message);
+}
+
+} // namespace
+
+int main()
+{
+  const Matrix A = makeMatrix(2, 2, 0.0);
+  const Matrix B = makeMatrix(2, 2, 10.0);
+
+  Matrix actual = A;
+  require(actual.addMatrix(1.0, B, 0.0) == 0, "addMatrix zero factor return");
+  requireMatrix(actual, A, "addMatrix zero factor preserves this");
+  actual = A;
+  actual.addMatrix(2.0, B, 0.0);
+  requireMatrix(actual, scaled(A, 2.0), "addMatrix zero factor scales this");
+  actual = A;
+  actual.addMatrix(1.0, B, -1.0);
+  requireMatrix(actual, add(A, B, -1.0), "addMatrix negative-one factor");
+
+  actual = A;
+  actual.addMatrixTranspose(1.0, B, 0.0);
+  requireMatrix(actual, A, "addMatrixTranspose zero factor");
+  actual = A;
+  actual.addMatrixTranspose(1.0, B, -1.0);
+  requireMatrix(actual, add(A, transpose(B), -1.0), "addMatrixTranspose negative-one factor");
+
+  const Matrix B23 = makeMatrix(2, 3, 1.0);
+  const Matrix C32 = makeMatrix(3, 2, 2.0);
+  const Matrix product = multiply(B23, C32);
+  actual = A;
+  actual.addMatrixProduct(1.0, B23, C32, 0.0);
+  requireMatrix(actual, A, "addMatrixProduct zero factor");
+  actual = A;
+  actual.addMatrixProduct(0.0, B23, C32, 1.0);
+  requireMatrix(actual, product, "addMatrixProduct positive-one factor");
+  actual = A;
+  actual.addMatrixProduct(1.0, B23, C32, -1.0);
+  requireMatrix(actual, add(A, product, -1.0), "addMatrixProduct negative-one factor");
+
+  const Matrix A32 = makeMatrix(3, 2, 3.0);
+  const Matrix B32 = makeMatrix(3, 2, 4.0);
+  const Matrix transposeProduct = multiply(transpose(A32), B32);
+  actual = A;
+  actual.addMatrixTransposeProduct(1.0, A32, B32, 0.0);
+  requireMatrix(actual, A, "addMatrixTransposeProduct zero factor");
+  actual = A;
+  actual.addMatrixTransposeProduct(1.0, A32, B32, -1.0);
+  requireMatrix(actual, add(A, transposeProduct, -1.0), "addMatrixTransposeProduct negative-one factor");
+
+  const Matrix T32 = makeMatrix(3, 2, 5.0);
+  const Matrix B33 = makeMatrix(3, 3, 6.0);
+  const Matrix triple = multiply(transpose(T32), multiply(B33, T32));
+  actual = A;
+  actual.addMatrixTripleProduct(1.0, T32, B33, 0.0);
+  requireMatrix(actual, A, "addMatrixTripleProduct zero factor");
+  actual = A;
+  actual.addMatrixTripleProduct(1.0, T32, B33, -1.0);
+  requireMatrix(actual, add(A, triple, -1.0), "addMatrixTripleProduct negative-one factor");
+
+  const Matrix C32b = makeMatrix(3, 2, 7.0);
+  const Matrix tripleGeneral = multiply(transpose(A32), multiply(B33, C32b));
+  actual = A;
+  actual.addMatrixTripleProduct(1.0, A32, B33, C32b, 0.0);
+  requireMatrix(actual, A, "general triple product zero factor");
+  actual = A;
+  actual.addMatrixTripleProduct(1.0, A32, B33, C32b, -1.0);
+  requireMatrix(actual, add(A, tripleGeneral, -1.0), "general triple product negative-one factor");
+
+  const Vector v = makeVector(2, 8.0);
+  const Vector w = makeVector(2, 9.0);
+  Vector vector = v;
+  vector.addVector(1.0, w, 0.0);
+  requireVector(vector, v, "addVector zero factor");
+  vector = v;
+  vector.addVector(0.0, w, -1.0);
+  Vector expectedVector = w;
+  expectedVector *= -1.0;
+  requireVector(vector, expectedVector, "addVector negative-one factor");
+
+  const Matrix M23 = makeMatrix(2, 3, 11.0);
+  const Vector x3 = makeVector(3, 12.0);
+  Vector matrixVector = v;
+  matrixVector.addMatrixVector(1.0, M23, x3, 0.0);
+  requireVector(matrixVector, v, "addMatrixVector zero factor");
+  Vector Mx = makeVector(2, 0.0);
+  for (int i = 0; i < M23.noRows(); ++i) {
+    Mx(i) = 0.0;
+    for (int j = 0; j < M23.noCols(); ++j)
+      Mx(i) += M23(i, j) * x3(j);
+  }
+  matrixVector = v;
+  matrixVector.addMatrixVector(0.0, M23, x3, -1.0);
+  Mx *= -1.0;
+  requireVector(matrixVector, Mx, "addMatrixVector negative-one factor");
+
+  const Matrix M32 = makeMatrix(3, 2, 13.0);
+  const Vector x3b = makeVector(3, 14.0);
+  Vector transposeVector = v;
+  transposeVector.addMatrixTransposeVector(1.0, M32, x3b, 0.0);
+  requireVector(transposeVector, v, "addMatrixTransposeVector zero factor");
+  Vector Mtx = makeVector(2, 0.0);
+  for (int j = 0; j < M32.noCols(); ++j) {
+    Mtx(j) = 0.0;
+    for (int i = 0; i < M32.noRows(); ++i)
+      Mtx(j) += M32(i, j) * x3b(i);
+  }
+  transposeVector = v;
+  transposeVector.addMatrixTransposeVector(0.0, M32, x3b, -1.0);
+  Mtx *= -1.0;
+  requireVector(transposeVector, Mtx, "addMatrixTransposeVector negative-one factor");
+
+  std::cout << "matrix/vector otherFact regression tests passed\n";
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Fixes #1687 by handling `otherFact` values of `0`, `1`, and `-1` consistently in Matrix and Vector algebra helpers.

The zero-factor path now avoids reading operand storage and correctly applies `thisFact` to the destination. The `+1` and `-1` paths avoid unnecessary multiplication while preserving the existing algebra. The affected Matrix methods include matrix addition, transpose addition, matrix products, transpose products, and both triple-product overloads. The affected Vector methods include vector addition, matrix-vector products, and transpose matrix-vector products.

The patch also adds a focused CTest executable covering all affected methods and the special-factor behavior.

## Verification

- `cmake --build build/regression --target matrix-vector-otherfact-test -j4`
- `ctest --test-dir build/regression --output-on-failure -R matrix-vector-otherfact`
- Result: `1/1` tests passed.
- `git diff --check`

An additional `_G3DEBUG` build was attempted. It is currently blocked by the pre-existing `Vector::operator%` error at `SRC/matrix/Vector.cpp:1237`, where the `Matrix`-returning function returns `-1`.

Submitted by **Musawer Ahmad Saqif** <saqif@umich.com>.
