### PR TITLE
Account for shear stiffness in elastic beam column

### DIFF
--- a/SRC/element/elasticBeamColumn/CMakeLists.txt
+++ b/SRC/element/elasticBeamColumn/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(OPS_Element
     PRIVATE
       ElasticBeam2d.cpp
       ElasticBeam3d.cpp
+      ElasticBeamCommon.h
       ElasticBeamWarping3d.cpp      
       ElasticTimoshenkoBeam2d.cpp
       ElasticTimoshenkoBeam3d.cpp

--- a/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam2d.cpp
@@ -33,6 +33,7 @@
 // connect to a node with 6-dof. 
 
 #include <ElasticBeam2d.h>
+#include <ElasticBeamCommon.h>
 #include <ElementalLoad.h>
 
 #include <Domain.h>
@@ -921,20 +922,12 @@ ElasticBeam2d::addLoad(ElementalLoad *theLoad, double loadFactor)
 
     // Fixed end forces in basic system
     q0[0] -= 0.5*P;
-    if (release == 0) {
-      double M = V*L/6.0; // wt*L*L/12
-      q0[1] -= M;
-      q0[2] += M;
-    }
-    if (release == 1) {
-      q0[2] += wt*L*L/8;
-    }
-    if (release == 2) {
-      q0[1] -= wt*L*L/8;
-    }
-    if (release == 3) {
-      // Nothing to do
-    }
+    double M = V*L/6.0; // wt*L*L/12
+    double MI = -M;
+    double MJ = M;
+    elasticBeamEndMoments(MI, MJ, elasticBeamShearFactor(E, I, G, Av, L), release);
+    q0[1] += MI;
+    q0[2] += MJ;
   }
   else if (type == LOAD_TAG_BeamUniformMoment) {
     double mz = data(2)*loadFactor;  // About z
@@ -973,6 +966,7 @@ ElasticBeam2d::addLoad(ElementalLoad *theLoad, double loadFactor)
     double V1 = Fyt-V2;
     double M1 = (0.5*z1*ba2) + (wybma*ba3/(3.0*ba)) - (z1*ba3*2.0/(3.0*L)) - (wybma*ba4/(2.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wybma*ba5/(5.0*L2*ba));
     double M2 = (-1.0*z1*ba3/(3.0*L)) - (wybma*ba4/(4.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wybma*ba5/(5.0*L2*ba));
+    elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, I, G, Av, L), release);
     double P = waa*ba + 0.5*(wab-waa)*ba;
     double PJ = (1.0/L)*(waa*ba*(a+0.5*ba)+0.5*(wab-waa)*ba*(a+(2.0/3.0)*ba));
 
@@ -1011,21 +1005,11 @@ ElasticBeam2d::addLoad(ElementalLoad *theLoad, double loadFactor)
 
     // Fixed end forces in basic system
     q0[0] -= N*aOverL;
-    if (release == 0) {
-      double M1 = -a * b2 * P * L2;
-      double M2 = a2 * b * P * L2;
-      q0[1] += M1;
-      q0[2] += M2;
-    }
-    if (release == 1) {
-      q0[2] += 0.5*P*a*b*L2*(a+L);
-    }
-    if (release == 2) {
-      q0[1] -= 0.5*P*a*b*L2*(b+L);
-    }
-    if (release == 3) {
-      // Nothing to do
-    }    
+    double M1 = -a * b2 * P * L2;
+    double M2 = a2 * b * P * L2;
+    elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, I, G, Av, L), release);
+    q0[1] += M1;
+    q0[2] += M2;
   }
   
   else if (type == LOAD_TAG_Beam2dTempLoad) {

--- a/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
+++ b/SRC/element/elasticBeamColumn/ElasticBeam3d.cpp
@@ -33,6 +33,7 @@
 // connect to a node with 6-dof. 
 
 #include <ElasticBeam3d.h>
+#include <ElasticBeamCommon.h>
 #include <Domain.h>
 #include <Channel.h>
 #include <FEM_ObjectBroker.h>
@@ -953,36 +954,20 @@ ElasticBeam3d::addLoad(ElementalLoad *theLoad, double loadFactor)
 
     // Fixed end forces in basic system
     q0[0] -= 0.5*P;
-    if (releasez == 0) {
-      q0[1] -= Mz;
-      q0[2] += Mz;
-    }
-    if (releasez == 1) {
-      q0[2] += wy*L*L/8;
-    }
-    if (releasez == 2) {
-      q0[1] -= wy*L*L/8;
-    }
-    
-    if (releasey == 0) {
-      q0[3] += My;
-      q0[4] -= My;
-    }
-    if (releasey == 1) {
-      q0[4] -= wz*L*L/8;
-    }
-    if (releasey == 2) {
-      q0[3] += wz*L*L/8;
-    }
-    
+
+    double MI = -Mz;
+    double MJ = Mz;
+    elasticBeamEndMoments(MI, MJ, elasticBeamShearFactor(E, Iz, G, Avy, L), releasez);
+    q0[1] += MI;
+    q0[2] += MJ;
+
+    MI = My;
+    MJ = -My;
+    elasticBeamEndMoments(MI, MJ, elasticBeamShearFactor(E, Iy, G, Avz, L), releasey);
+    q0[3] += MI;
+    q0[4] += MJ;
   }
   else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
-    static bool errorReleasePartialUDL = false;
-    if ((releasey != 0 || releasez != 0) && errorReleasePartialUDL == false) {
-      opserr << "ElasticBeam3d::addLoad, element tag: " << this->getTag()
-	     << " - partial uniform load implementation assumes no releases" << endln;
-      errorReleasePartialUDL = true;
-    }
 	  double wa = data(2) * loadFactor;  // Axial
 	  double wy = data(0) * loadFactor;  // Transverse
 	  double wz = data(1) * loadFactor;  // Transverse
@@ -1010,6 +995,7 @@ ElasticBeam3d::addLoad(ElementalLoad *theLoad, double loadFactor)
 	  double V1 = Fyt-V2;
 	  double M1 = (0.5*z1*ba2) + (wybma*ba3/(3.0*ba)) - (z1*ba3*2.0/(3.0*L)) - (wybma*ba4/(2.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wybma*ba5/(5.0*L2*ba));
 	  double M2 = (-1.0*z1*ba3/(3.0*L)) - (wybma*ba4/(4.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wybma*ba5/(5.0*L2*ba));
+	  elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, Iz, G, Avy, L), releasez);
 	  double waa = wa;
 	  double P = waa*ba + 0.5*(wab-waa)*ba;
 	  double PJ = (1.0/L)*(waa*ba*(a+0.5*ba)+0.5*(wab-waa)*ba*(a+(2.0/3.0)*ba));
@@ -1032,6 +1018,7 @@ ElasticBeam3d::addLoad(ElementalLoad *theLoad, double loadFactor)
 	  V1 = Fzt-V2;
 	  M1 = (0.5*z1*ba2) + (wzbma*ba3/(3.0*ba)) - (z1*ba3*2.0/(3.0*L)) - (wzbma*ba4/(2.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wzbma*ba5/(5.0*L2*ba));
 	  M2 = (-1.0*z1*ba3/(3.0*L)) - (wzbma*ba4/(4.0*L*ba)) + (z1*ba4/(4.0*L2)) + (wzbma*ba5/(5.0*L2*ba));
+	  elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, Iy, G, Avz, L), releasey);
 	  q0[3] += M1;
 	  q0[4] += M2;	  
 
@@ -1069,12 +1056,16 @@ ElasticBeam3d::addLoad(ElementalLoad *theLoad, double loadFactor)
     // Fixed end forces in basic system
     q0[0] -= N*aOverL;
     double M1, M2;
+    // Bending about z (shear along y)
     M1 = -a * b2 * Py * L2;
     M2 = a2 * b * Py * L2;
+    elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, Iz, G, Avy, L), releasez);
     q0[1] += M1;
     q0[2] += M2;
+    // Bending about y (shear along z)
     M1 = -a * b2 * Pz * L2;
     M2 = a2 * b * Pz * L2;
+    elasticBeamEndMoments(M1, M2, elasticBeamShearFactor(E, Iy, G, Avz, L), releasey);
     q0[3] -= M1;
     q0[4] -= M2;
   }

--- a/SRC/element/elasticBeamColumn/ElasticBeamCommon.h
+++ b/SRC/element/elasticBeamColumn/ElasticBeamCommon.h
@@ -1,0 +1,62 @@
+/* ****************************************************************** **
+**    OpenSees - Open System for Earthquake Engineering Simulation    **
+**          Pacific Earthquake Engineering Research Center            **
+** ****************************************************************** */
+
+// Helpers shared by the elastic beam-column elements.
+
+#ifndef ElasticBeamCommon_h
+#define ElasticBeamCommon_h
+
+// Ratio of bending to shear flexibility, phi = 12EI/(G Av L^2).  Zero when the
+// section has no shear flexibility, which makes every formula below collapse
+// to its Euler-Bernoulli form.
+inline double
+elasticBeamShearFactor(double E, double I, double G, double Av, double L)
+{
+  if (G <= 0.0 || Av <= 0.0)
+    return 0.0;
+
+  return 12.0*E*I/(G*Av*L*L);
+}
+
+// Turns the Euler-Bernoulli fixed-end moments of a transverse load into the
+// shear-deformable ones and applies an end release, in place.
+//
+// The moment map is M_T = k_T * k_EB^-1 * M_EB, which is exact for an
+// arbitrary load, not just a uniform one: in the simply supported primary
+// system the shear strain integrates to M(L) - M(0) = 0, so shear leaves the
+// primary end rotations alone and only the stiffness changes.  Condensing out
+// a hinged end then uses the Timoshenko carry-over factor (2 - phi)/(4 + phi).
+//
+// Both maps are linear and odd, so callers may pass whichever sign convention
+// their fixed-end force expressions use, as long as MI is the node I end.
+inline void
+elasticBeamEndMoments(double &MI, double &MJ, double phi, int release)
+{
+  double MIe = MI;
+  double MJe = MJ;
+  MI = (MIe + 0.5*phi*(MIe - MJe))/(1.0 + phi);
+  MJ = (MJe + 0.5*phi*(MJe - MIe))/(1.0 + phi);
+
+  double carryOver = (2.0 - phi)/(4.0 + phi);
+
+  switch (release) {
+  case 1:
+    MJ -= carryOver*MI;
+    MI = 0.0;
+    break;
+  case 2:
+    MI -= carryOver*MJ;
+    MJ = 0.0;
+    break;
+  case 3:
+    MI = 0.0;
+    MJ = 0.0;
+    break;
+  default:
+    break;
+  }
+}
+
+#endif


### PR DESCRIPTION
Also fix/implement some other loading cases.

This was written entirely by Claude, however, it does now match the results of some hand calcs that led to this fix and further independent tests written by Claude.

> ElasticBeam2d/3d: shear-consistent fixed-end forces and end releases
> 
> These elements have always used a Timoshenko stiffness but Euler-Bernoulli
> fixed-end forces, so element loads produced end moments inconsistent with the
> stiffness resisting them. Map the fixed-end moments through
> M_T = k_T k_EB^-1 M_EB, which is exact for an arbitrary load distribution
> because shear leaves the simply supported primary end rotations alone.
> 
> Releases were wrong for the same reason: the branches hard-coded the
> Euler-Bernoulli carry-over of 1/2 rather than (2-phi)/(4+phi). This changes
> results even for a full-span uniform load, whose fixed-end moments are
> otherwise shear-invariant.
> 
> Also implement release handling that was simply missing:
>   - 2D partial uniform loads ignored -release silently
>   - 3D partial uniform loads ignored -releasey/-releasez (warned once)
>   - 3D point loads had no release handling at all
> 
> Factor the shared algebra into ElasticBeamCommon.h, replacing five
> copy-pasted correction blocks and nine ad-hoc release branches.
> 
> Elements defined without a shear area give phi = 0 and are unaffected.