### PR TITLE
Add TimberHoffman3D nonlinear orthotropic timber nDMaterial

### DIFF
--- a/SRC/classTags.h
+++ b/SRC/classTags.h
@@ -568,6 +568,7 @@
 #define ND_TAG_SmearedSteelDoubleLayerT2DMaterial01 7019		  // M. J. Nunez - UChile
 
 #define ND_TAG_InitStrainNDMaterial 7020 // Massimo Petracca ASDEA Software
+#define ND_TAG_TimberHoffman3D 7021
 #define ND_TAG_ASDPlasticMaterial3D 10000 // For ASDPlasticity-class material
 
 

--- a/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
+++ b/SRC/interpreter/OpenSeesNDMaterialCommands.cpp
@@ -86,6 +86,7 @@ void* OPS_ConcreteMcftNonlinear7();
 void* OPS_ASDConcrete3DMaterial();
 void* OPS_OrthotropicRotatingAngleConcreteT2DMaterial01();	// M. J. Nunez - UChile
 void* OPS_SmearedSteelDoubleLayerT2DMaterial01();			// M. J. Nunez - UChile
+void* OPS_TimberHoffman3D();
 #ifdef _EIGEN3
 void* OPS_AllASDPlasticMaterial3Ds();
 #endif // _EIGEN3
@@ -213,6 +214,7 @@ namespace {
 	nDMaterialsMap.insert(std::make_pair("ASDConcrete3D", &OPS_ASDConcrete3DMaterial));
 	nDMaterialsMap.insert(std::make_pair("OrthotropicRAConcrete", &OPS_OrthotropicRotatingAngleConcreteT2DMaterial01));
 	nDMaterialsMap.insert(std::make_pair("SmearedSteelDoubleLayer", &OPS_SmearedSteelDoubleLayerT2DMaterial01));
+	nDMaterialsMap.insert(std::make_pair("TimberHoffman3D", &OPS_TimberHoffman3D));
 #ifdef _EIGEN3
 	nDMaterialsMap.insert(std::make_pair("ASDPlasticMaterial", &OPS_AllASDPlasticMaterial3Ds));
 	nDMaterialsMap.insert(std::make_pair("ASDPlasticMaterial3D", &OPS_AllASDPlasticMaterial3Ds));

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -42,10 +42,35 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include "PythonWrapper.h"
 #include "OpenSeesCommands.h"
 #include <OPS_Globals.h>
+#include <NDMaterial.h>
+#include <elementAPI.h>
 
 #define OPS_PYVERSION "3.4.0.4"
 
 static PythonWrapper* wrapper = 0;
+static int testingNDMaterialTag = -1;
+
+static NDMaterial* getTestingNDMaterial()
+{
+    return testingNDMaterialTag >= 0 ? OPS_getNDMaterial(testingNDMaterialTag) : 0;
+}
+
+static PyObject* vectorToPythonList(const Vector& values)
+{
+    PyObject* result = PyList_New(values.Size());
+    if (result == 0)
+        return 0;
+
+    for (int i = 0; i < values.Size(); ++i) {
+        PyObject* value = PyFloat_FromDouble(values(i));
+        if (value == 0) {
+            Py_DECREF(result);
+            return 0;
+        }
+        PyList_SET_ITEM(result, i, value);
+    }
+    return result;
+}
 
 PythonWrapper::PythonWrapper()
     :currentArgv(0), currentArg(0), numberArgs(0),
@@ -335,6 +360,23 @@ static PyObject *Py_ops_setStrain(PyObject *self, PyObject *args)
 
 static PyObject* Py_ops_setTrialStrain(PyObject* self, PyObject* args)
 {
+    NDMaterial* material = getTestingNDMaterial();
+    if (material != 0) {
+        if (PyTuple_Size(args) != 6) {
+            PyErr_SetString(PyExc_TypeError, "setTrialStrain requires six strain components for an nD material");
+            return NULL;
+        }
+
+        Vector strain(6);
+        for (int i = 0; i < 6; ++i) {
+            strain(i) = PyFloat_AsDouble(PyTuple_GetItem(args, i));
+            if (PyErr_Occurred())
+                return NULL;
+        }
+        material->setTrialStrain(strain);
+        Py_RETURN_NONE;
+    }
+
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_setTrialStrain() < 0) {
@@ -347,6 +389,12 @@ static PyObject* Py_ops_setTrialStrain(PyObject* self, PyObject* args)
 
 static PyObject* Py_ops_commitState(PyObject* self, PyObject* args)
 {
+    NDMaterial* material = getTestingNDMaterial();
+    if (material != 0) {
+        material->commitState();
+        Py_RETURN_NONE;
+    }
+
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_commitState() < 0) {
@@ -359,6 +407,10 @@ static PyObject* Py_ops_commitState(PyObject* self, PyObject* args)
 
 static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 {
+    NDMaterial* material = getTestingNDMaterial();
+    if (material != 0)
+        return vectorToPythonList(material->getStrain());
+
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getStrain() < 0) {
@@ -371,6 +423,10 @@ static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_getStress(PyObject *self, PyObject *args)
 {
+    NDMaterial* material = getTestingNDMaterial();
+    if (material != 0)
+        return vectorToPythonList(material->getStress());
+
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getStress() < 0) {
@@ -383,6 +439,26 @@ static PyObject *Py_ops_getStress(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_getTangent(PyObject *self, PyObject *args)
 {
+    NDMaterial* material = getTestingNDMaterial();
+    if (material != 0) {
+        const Matrix& tangent = material->getTangent();
+        PyObject* result = PyList_New(36);
+        if (result == 0)
+            return NULL;
+
+        for (int i = 0; i < 6; ++i) {
+            for (int j = 0; j < 6; ++j) {
+                PyObject* value = PyFloat_FromDouble(tangent(i, j));
+                if (value == 0) {
+                    Py_DECREF(result);
+                    return NULL;
+                }
+                PyList_SET_ITEM(result, 6 * i + j, value);
+            }
+        }
+        return result;
+    }
+
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getTangent() < 0) {
@@ -407,6 +483,7 @@ static PyObject *Py_ops_getDampTangent(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_wipe(PyObject *self, PyObject *args)
 {
+    testingNDMaterialTag = -1;
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_wipe() < 0) {
@@ -3078,6 +3155,21 @@ static PyObject *Py_ops_NDTest(PyObject *self, PyObject *args) {
     return wrapper->getResults();
 }
 
+static PyObject* Py_ops_testNDMaterial(PyObject* self, PyObject* args)
+{
+    int tag = 0;
+    if (!PyArg_ParseTuple(args, "i", &tag))
+        return NULL;
+
+    if (OPS_getNDMaterial(tag) == 0) {
+        PyErr_Format(PyExc_RuntimeError, "nD material with tag %d does not exist", tag);
+        return NULL;
+    }
+
+    testingNDMaterialTag = tag;
+    Py_RETURN_NONE;
+}
+
 /////////////////////////////////////////////////
 ////////////// Add Python commands //////////////
 /////////////////////////////////////////////////
@@ -3086,9 +3178,11 @@ PythonWrapper::addOpenSeesCommands()
 {
     addCommand("uniaxialMaterial", &Py_ops_UniaxialMaterial);
     addCommand("testUniaxialMaterial", &Py_ops_testUniaxialMaterial);
+    addCommand("testNDMaterial", &Py_ops_testNDMaterial);
     addCommand("setStrain", &Py_ops_setStrain);
     addCommand("setTrialStrain", &Py_ops_setTrialStrain);
     addCommand("commitState", &Py_ops_commitState);
+    addCommand("commitStrain", &Py_ops_commitState);
     addCommand("getStrain", &Py_ops_getStrain);
     addCommand("getStress", &Py_ops_getStress);
     addCommand("getTangent", &Py_ops_getTangent);

--- a/SRC/interpreter/PythonWrapper.cpp
+++ b/SRC/interpreter/PythonWrapper.cpp
@@ -42,35 +42,10 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include "PythonWrapper.h"
 #include "OpenSeesCommands.h"
 #include <OPS_Globals.h>
-#include <NDMaterial.h>
-#include <elementAPI.h>
 
 #define OPS_PYVERSION "3.4.0.4"
 
 static PythonWrapper* wrapper = 0;
-static int testingNDMaterialTag = -1;
-
-static NDMaterial* getTestingNDMaterial()
-{
-    return testingNDMaterialTag >= 0 ? OPS_getNDMaterial(testingNDMaterialTag) : 0;
-}
-
-static PyObject* vectorToPythonList(const Vector& values)
-{
-    PyObject* result = PyList_New(values.Size());
-    if (result == 0)
-        return 0;
-
-    for (int i = 0; i < values.Size(); ++i) {
-        PyObject* value = PyFloat_FromDouble(values(i));
-        if (value == 0) {
-            Py_DECREF(result);
-            return 0;
-        }
-        PyList_SET_ITEM(result, i, value);
-    }
-    return result;
-}
 
 PythonWrapper::PythonWrapper()
     :currentArgv(0), currentArg(0), numberArgs(0),
@@ -360,23 +335,6 @@ static PyObject *Py_ops_setStrain(PyObject *self, PyObject *args)
 
 static PyObject* Py_ops_setTrialStrain(PyObject* self, PyObject* args)
 {
-    NDMaterial* material = getTestingNDMaterial();
-    if (material != 0) {
-        if (PyTuple_Size(args) != 6) {
-            PyErr_SetString(PyExc_TypeError, "setTrialStrain requires six strain components for an nD material");
-            return NULL;
-        }
-
-        Vector strain(6);
-        for (int i = 0; i < 6; ++i) {
-            strain(i) = PyFloat_AsDouble(PyTuple_GetItem(args, i));
-            if (PyErr_Occurred())
-                return NULL;
-        }
-        material->setTrialStrain(strain);
-        Py_RETURN_NONE;
-    }
-
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_setTrialStrain() < 0) {
@@ -389,12 +347,6 @@ static PyObject* Py_ops_setTrialStrain(PyObject* self, PyObject* args)
 
 static PyObject* Py_ops_commitState(PyObject* self, PyObject* args)
 {
-    NDMaterial* material = getTestingNDMaterial();
-    if (material != 0) {
-        material->commitState();
-        Py_RETURN_NONE;
-    }
-
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_commitState() < 0) {
@@ -407,10 +359,6 @@ static PyObject* Py_ops_commitState(PyObject* self, PyObject* args)
 
 static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 {
-    NDMaterial* material = getTestingNDMaterial();
-    if (material != 0)
-        return vectorToPythonList(material->getStrain());
-
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getStrain() < 0) {
@@ -423,10 +371,6 @@ static PyObject *Py_ops_getStrain(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_getStress(PyObject *self, PyObject *args)
 {
-    NDMaterial* material = getTestingNDMaterial();
-    if (material != 0)
-        return vectorToPythonList(material->getStress());
-
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getStress() < 0) {
@@ -439,26 +383,6 @@ static PyObject *Py_ops_getStress(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_getTangent(PyObject *self, PyObject *args)
 {
-    NDMaterial* material = getTestingNDMaterial();
-    if (material != 0) {
-        const Matrix& tangent = material->getTangent();
-        PyObject* result = PyList_New(36);
-        if (result == 0)
-            return NULL;
-
-        for (int i = 0; i < 6; ++i) {
-            for (int j = 0; j < 6; ++j) {
-                PyObject* value = PyFloat_FromDouble(tangent(i, j));
-                if (value == 0) {
-                    Py_DECREF(result);
-                    return NULL;
-                }
-                PyList_SET_ITEM(result, 6 * i + j, value);
-            }
-        }
-        return result;
-    }
-
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_getTangent() < 0) {
@@ -483,7 +407,6 @@ static PyObject *Py_ops_getDampTangent(PyObject *self, PyObject *args)
 
 static PyObject *Py_ops_wipe(PyObject *self, PyObject *args)
 {
-    testingNDMaterialTag = -1;
     wrapper->resetCommandLine(PyTuple_Size(args), 1, args);
 
     if (OPS_wipe() < 0) {
@@ -3155,21 +3078,6 @@ static PyObject *Py_ops_NDTest(PyObject *self, PyObject *args) {
     return wrapper->getResults();
 }
 
-static PyObject* Py_ops_testNDMaterial(PyObject* self, PyObject* args)
-{
-    int tag = 0;
-    if (!PyArg_ParseTuple(args, "i", &tag))
-        return NULL;
-
-    if (OPS_getNDMaterial(tag) == 0) {
-        PyErr_Format(PyExc_RuntimeError, "nD material with tag %d does not exist", tag);
-        return NULL;
-    }
-
-    testingNDMaterialTag = tag;
-    Py_RETURN_NONE;
-}
-
 /////////////////////////////////////////////////
 ////////////// Add Python commands //////////////
 /////////////////////////////////////////////////
@@ -3178,11 +3086,9 @@ PythonWrapper::addOpenSeesCommands()
 {
     addCommand("uniaxialMaterial", &Py_ops_UniaxialMaterial);
     addCommand("testUniaxialMaterial", &Py_ops_testUniaxialMaterial);
-    addCommand("testNDMaterial", &Py_ops_testNDMaterial);
     addCommand("setStrain", &Py_ops_setStrain);
     addCommand("setTrialStrain", &Py_ops_setTrialStrain);
     addCommand("commitState", &Py_ops_commitState);
-    addCommand("commitStrain", &Py_ops_commitState);
     addCommand("getStrain", &Py_ops_getStrain);
     addCommand("getStress", &Py_ops_getStress);
     addCommand("getTangent", &Py_ops_getTangent);

--- a/SRC/material/nD/CMakeLists.txt
+++ b/SRC/material/nD/CMakeLists.txt
@@ -6,6 +6,7 @@
 #==============================================================================
 target_sources(OPS_Material
   PRIVATE
+    TimberHoffman3D.cpp
     NDMaterial.cpp
     BeamFiberMaterial.cpp
     PlasticDamageConcretePlaneStress.cpp

--- a/SRC/material/nD/TclModelBuilderNDMaterialCommand.cpp
+++ b/SRC/material/nD/TclModelBuilderNDMaterialCommand.cpp
@@ -120,6 +120,7 @@ extern  void *OPS_SAniSandMSMaterial(void);
 extern void* OPS_OrthotropicMaterial(void);
 extern void* OPS_Series3DMaterial(void);
 extern void* OPS_Parallel3DMaterial(void);
+extern void* OPS_TimberHoffman3D(void);
 extern void* OPS_ASDConcrete3DMaterial(void);
 #ifdef _EIGEN3
 extern void* OPS_AllASDPlasticMaterial3Ds(void);
@@ -1260,6 +1261,15 @@ TclModelBuilderNDMaterialCommand (ClientData clientData, Tcl_Interp *interp, int
 			return TCL_ERROR;
 	}
 
+	else if(strcmp(argv[1], "TimberHoffman3D") == 0) {
+		void *theMat = OPS_TimberHoffman3D();
+		if (theMat != 0)  {
+			theMaterial = (NDMaterial *)theMat;
+		}
+		else
+			return TCL_ERROR;
+	}
+
 	else if(strcmp(argv[1], "ASDConcrete3D") == 0) {
 		void *theMat = OPS_ASDConcrete3DMaterial();
 		if (theMat != 0)  {
@@ -1715,5 +1725,3 @@ TclModelBuilderNDMaterialCommand (ClientData clientData, Tcl_Interp *interp, int
 
     return TCL_OK;
 }
-
-

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -65,6 +65,28 @@ void *OPS_TimberHoffman3D()
         }
     }
 
+    if (data[0] <= 0.0 || data[1] <= 0.0 || data[2] <= 0.0 ||
+        data[6] <= 0.0 || data[7] <= 0.0 || data[8] <= 0.0) {
+        opserr << "WARNING TimberHoffman3D elastic moduli must be positive\n";
+        return nullptr;
+    }
+
+    if (data[9] <= 0.0 || data[10] <= 0.0 || data[11] <= 0.0 ||
+        data[12] <= 0.0 || data[13] <= 0.0 || data[14] <= 0.0 ||
+        data[15] <= 0.0 || data[16] <= 0.0 || data[17] <= 0.0) {
+        opserr << "WARNING TimberHoffman3D strength parameters must be positive\n";
+        return nullptr;
+    }
+
+    if (data[22] <= 0.0 || data[23] <= 0.0 || data[24] <= 0.0) {
+        opserr << "WARNING TimberHoffman3D fracture energies must be positive\n";
+        return nullptr;
+    }
+
+    if (data[25] < 0.0 || data[26] <= 0.0 || dt <= 0.0) {
+        opserr << "WARNING TimberHoffman3D requires eta >= 0, Lc > 0, and dt > 0\n";
+        return nullptr;
+    }
     return new TimberHoffman3D(
         tag,
         data[0], data[1], data[2],

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -1,0 +1,709 @@
+
+#include "TimberHoffman3D.h"
+
+#include <elementAPI.h>
+#include <OPS_Globals.h>
+#include <Channel.h>
+#include <FEM_ObjectBroker.h>
+
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+
+namespace {
+
+double vecNormInf(const Vector &v)
+{
+    double m = 0.0;
+    for (int i = 0; i < v.Size(); ++i)
+        m = std::max(m, std::fabs(v(i)));
+    return m;
+}
+
+double quadForm(const Vector &v, const Matrix &A)
+{
+    Vector Av(v.Size());
+    Av.addMatrixVector(0.0, A, v, 1.0);
+    return v ^ Av;
+}
+
+}
+
+void *OPS_TimberHoffman3D()
+{
+    if (OPS_GetNumRemainingInputArgs() < 28) {
+        opserr
+            << "WARNING insufficient arguments for TimberHoffman3D\n"
+            << "Want: nDMaterial TimberHoffman3D tag "
+            << "E1 E2 E3 nu12 nu13 nu23 G12 G13 G23 "
+            << "fc1 fc2 fc3 ft1 ft2 ft3 f12 f13 f23 "
+            << "h sigmaE0 Acomp Bcomp Gf1t Gf2t Gf3t eta Lc <dt>\n";
+        return nullptr;
+    }
+
+    int tag;
+    int nInt = 1;
+    if (OPS_GetIntInput(&nInt, &tag) < 0) {
+        opserr << "WARNING invalid TimberHoffman3D tag\n";
+        return nullptr;
+    }
+
+    double data[27];
+    int nDouble = 27;
+
+    if (OPS_GetDoubleInput(&nDouble, data) < 0) {
+        opserr << "WARNING invalid TimberHoffman3D material parameters\n";
+        return nullptr;
+    }
+
+    double dt = 1.0;
+    if (OPS_GetNumRemainingInputArgs() > 0) {
+        int one = 1;
+        if (OPS_GetDoubleInput(&one, &dt) < 0) {
+            opserr << "WARNING invalid TimberHoffman3D dt\n";
+            return nullptr;
+        }
+    }
+
+    return new TimberHoffman3D(
+        tag,
+        data[0], data[1], data[2],
+        data[3], data[4], data[5],
+        data[6], data[7], data[8],
+        data[9], data[10], data[11],
+        data[12], data[13], data[14],
+        data[15], data[16], data[17],
+        data[18],
+        data[19],
+        data[20], data[21],
+        data[22], data[23], data[24],
+        data[25],
+        data[26],
+        dt
+    );
+}
+
+TimberHoffman3D::TimberHoffman3D()
+: NDMaterial(0, ND_TAG_TimberHoffman3D),
+  E1(0), E2(0), E3(0),
+  nu12(0), nu13(0), nu23(0),
+  G12(0), G13(0), G23(0),
+  fc1(0), fc2(0), fc3(0),
+  ft1(0), ft2(0), ft3(0),
+  f12(0), f13(0), f23(0),
+  hardeningModulus(0), sigmaE0(1.0),
+  Acomp(0), Bcomp(0),
+  Gf1t(0), Gf2t(0), Gf3t(0),
+  eta(1e-4), Lc(1.0), dt(1.0),
+  C0(6,6), Cdam(6,6), P(6,6), Q0(6), Z(6,6),
+  strainTrial(6), stressTrial(6), effectiveStressTrial(6),
+  plasticStrainTrial(6),
+  eqpTrial(0.0), damageTTrial(3), damageC1Trial(0.0),
+  damageVTrial(3), FmaxTTrial(3), FmaxC1Trial(1.0),
+  strainCommit(6), stressCommit(6), effectiveStressCommit(6),
+  plasticStrainCommit(6),
+  eqpCommit(0.0), damageTCommit(3), damageC1Commit(0.0),
+  damageVCommit(3), FmaxTCommit(3), FmaxC1Commit(1.0),
+  tol(1e-8), maxIter(60), innerTol(1e-10), innerMaxIter(30)
+{
+    revertToStart();
+}
+
+TimberHoffman3D::TimberHoffman3D(
+    int tag,
+    double E1_, double E2_, double E3_,
+    double nu12_, double nu13_, double nu23_,
+    double G12_, double G13_, double G23_,
+    double fc1_, double fc2_, double fc3_,
+    double ft1_, double ft2_, double ft3_,
+    double f12_, double f13_, double f23_,
+    double h_,
+    double sigmaE0_,
+    double Acomp_, double Bcomp_,
+    double Gf1t_, double Gf2t_, double Gf3t_,
+    double eta_,
+    double Lc_,
+    double dt_
+)
+: NDMaterial(tag, ND_TAG_TimberHoffman3D),
+  E1(E1_), E2(E2_), E3(E3_),
+  nu12(nu12_), nu13(nu13_), nu23(nu23_),
+  G12(G12_), G13(G13_), G23(G23_),
+  fc1(fc1_), fc2(fc2_), fc3(fc3_),
+  ft1(ft1_), ft2(ft2_), ft3(ft3_),
+  f12(f12_), f13(f13_), f23(f23_),
+  hardeningModulus(h_), sigmaE0(sigmaE0_),
+  Acomp(Acomp_), Bcomp(Bcomp_),
+  Gf1t(Gf1t_), Gf2t(Gf2t_), Gf3t(Gf3t_),
+  eta(eta_), Lc(Lc_), dt(dt_),
+  C0(6,6), Cdam(6,6), P(6,6), Q0(6), Z(6,6),
+  strainTrial(6), stressTrial(6), effectiveStressTrial(6),
+  plasticStrainTrial(6),
+  eqpTrial(0.0), damageTTrial(3), damageC1Trial(0.0),
+  damageVTrial(3), FmaxTTrial(3), FmaxC1Trial(1.0),
+  strainCommit(6), stressCommit(6), effectiveStressCommit(6),
+  plasticStrainCommit(6),
+  eqpCommit(0.0), damageTCommit(3), damageC1Commit(0.0),
+  damageVCommit(3), FmaxTCommit(3), FmaxC1Commit(1.0),
+  tol(1e-8), maxIter(60), innerTol(1e-10), innerMaxIter(30)
+{
+    buildElasticStiffness();
+    buildHoffmanPQ();
+
+    Z.Zero();
+    Z(0,0)=1.0; Z(1,1)=1.0; Z(2,2)=1.0;
+    Z(3,3)=0.5; Z(4,4)=0.5; Z(5,5)=0.5;
+
+    revertToStart();
+}
+
+TimberHoffman3D::~TimberHoffman3D() {}
+
+void TimberHoffman3D::buildElasticStiffness()
+{
+    Matrix S(6,6);
+    S.Zero();
+
+    const double nu21 = nu12 * E2 / E1;
+    const double nu31 = nu13 * E3 / E1;
+    const double nu32 = nu23 * E3 / E2;
+
+    S(0,0)=1.0/E1;
+    S(1,1)=1.0/E2;
+    S(2,2)=1.0/E3;
+
+    S(0,1)=-nu21/E2;
+    S(1,0)=-nu12/E1;
+
+    S(0,2)=-nu31/E3;
+    S(2,0)=-nu13/E1;
+
+    S(1,2)=-nu32/E3;
+    S(2,1)=-nu23/E2;
+
+    S(3,3)=1.0/G12;
+    S(4,4)=1.0/G13;
+    S(5,5)=1.0/G23;
+
+    S.Invert(C0);  // C0 = inv(S)
+    Cdam = C0;
+}
+
+void TimberHoffman3D::buildHoffmanPQ()
+{
+    const double se2 = sigmaE0*sigmaE0;
+
+    const double a12 =
+        0.5*se2*(1.0/(fc1*ft1) + 1.0/(fc2*ft2) - 1.0/(fc3*ft3));
+
+    const double a23 =
+        0.5*se2*(-1.0/(fc1*ft1) + 1.0/(fc2*ft2) + 1.0/(fc3*ft3));
+
+    const double a13 =
+        0.5*se2*(1.0/(fc1*ft1) - 1.0/(fc2*ft2) + 1.0/(fc3*ft3));
+
+    const double a11 = se2*(fc1-ft1)/(fc1*ft1);
+    const double a22 = se2*(fc2-ft2)/(fc2*ft2);
+    const double a33 = se2*(fc3-ft3)/(fc3*ft3);
+
+    const double a44 = se2/(3.0*f12*f12);
+    const double a55 = se2/(3.0*f13*f13);
+    const double a66 = se2/(3.0*f23*f23);
+
+    P.Zero();
+    P(0,0)=2.0*(a13+a12);
+    P(1,1)=2.0*(a23+a12);
+    P(2,2)=2.0*(a13+a23);
+
+    P(0,1)=P(1,0)=-2.0*a12;
+    P(0,2)=P(2,0)=-2.0*a13;
+    P(1,2)=P(2,1)=-2.0*a23;
+
+    P(3,3)=6.0*a44;
+    P(4,4)=6.0*a55;
+    P(5,5)=6.0*a66;
+
+    Q0.Zero();
+    Q0(0)=a11;
+    Q0(1)=a22;
+    Q0(2)=a33;
+}
+
+double TimberHoffman3D::sigmaEk(double eqp) const
+{
+    return sigmaE0 + hardeningModulus*eqp;
+}
+
+double TimberHoffman3D::yieldFunction(const Vector &s, double eqp) const
+{
+    const double sek = sigmaEk(eqp);
+    return 0.5*quadForm(s,P) + (s ^ Q0) - sek*sek;
+}
+
+void TimberHoffman3D::flowDirection(
+    const Vector &s, double eqp, Vector &g) const
+{
+    g.Zero();
+    g.addMatrixVector(0.0, P, s, 1.0);
+    g += Q0; // fixed-Q interpretation
+}
+
+double TimberHoffman3D::equivalentPlasticIncrement(
+    const Vector &depsP) const
+{
+    return std::sqrt(std::max(0.0, (2.0/3.0)*quadForm(depsP,Z)));
+}
+
+int TimberHoffman3D::stateForLambda(
+    const Vector &sigmaTrial,
+    double dLambda,
+    Vector &sigma,
+    double &eqp,
+    Vector &depsP
+)
+{
+    if (dLambda <= 0.0) {
+        sigma = sigmaTrial;
+        eqp = eqpCommit;
+        depsP.Zero();
+        return 0;
+    }
+
+    Matrix A(6,6);
+    A.Zero();
+    for (int i=0;i<6;++i) A(i,i)=1.0;
+
+    Matrix CP(6,6);
+    CP.addMatrixProduct(0.0, C0, P, 1.0);
+    A.addMatrix(1.0, CP, dLambda);
+
+    Vector CQ(6);
+    CQ.addMatrixVector(0.0, C0, Q0, 1.0);
+
+    Vector rhs(sigmaTrial);
+    rhs.addVector(1.0, CQ, -dLambda);
+
+    Matrix Ainv(6,6);
+    if (A.Invert(Ainv) < 0)
+        return -1;
+
+    sigma.addMatrixVector(0.0, Ainv, rhs, 1.0);
+
+    Vector g(6);
+    flowDirection(sigma, eqpCommit, g);
+
+    depsP = g;
+    depsP *= dLambda;
+
+    eqp = eqpCommit + equivalentPlasticIncrement(depsP);
+    return 0;
+}
+
+int TimberHoffman3D::returnMapHardening(
+    const Vector &sigmaTrial,
+    Vector &sigmaNew,
+    double &eqpNew,
+    Vector &depsP,
+    double &dLambda
+)
+{
+    bool anyCompression = false;
+    for (int i=0;i<3;++i)
+        if (sigmaTrial(i) < 0.0) anyCompression = true;
+
+    if (!anyCompression || yieldFunction(sigmaTrial,eqpCommit) <= tol) {
+        sigmaNew = sigmaTrial;
+        eqpNew = eqpCommit;
+        depsP.Zero();
+        dLambda = 0.0;
+        return 0;
+    }
+
+    double lo = 0.0;
+    double hi = 1.0e-12;
+
+    Vector sHi(6), dpHi(6);
+    double kHi = eqpCommit;
+
+    bool bracketed = false;
+    for (int i=0;i<140;++i) {
+        if (stateForLambda(sigmaTrial,hi,sHi,kHi,dpHi) < 0)
+            return -1;
+
+        if (yieldFunction(sHi,kHi) <= 0.0) {
+            bracketed = true;
+            break;
+        }
+        hi *= 10.0;
+    }
+
+    if (!bracketed) return -2;
+
+    Vector sMid(6), dpMid(6);
+    double kMid = eqpCommit;
+
+    for (int i=0;i<maxIter;++i) {
+        const double mid = 0.5*(lo+hi);
+
+        if (stateForLambda(sigmaTrial,mid,sMid,kMid,dpMid) < 0)
+            return -3;
+
+        const double f = yieldFunction(sMid,kMid);
+
+        if (std::fabs(f) <= tol) {
+            sigmaNew = sMid;
+            eqpNew = kMid;
+            depsP = dpMid;
+            dLambda = mid;
+            return 0;
+        }
+
+        if (f > 0.0) lo = mid;
+        else hi = mid;
+    }
+
+    dLambda = 0.5*(lo+hi);
+    if (stateForLambda(sigmaTrial,dLambda,sigmaNew,eqpNew,depsP) < 0)
+        return -4;
+
+    return 0;
+}
+
+void TimberHoffman3D::failureIndices(
+    const Vector &s,
+    Vector &Ft,
+    double &F1c
+) const
+{
+    Ft.Zero();
+
+    F1c = (s(0) < 0.0) ? (-s(0)/fc1) : 0.0;
+
+    Ft(0) = (s(0) > 0.0) ? (s(0)/ft1) : 0.0;
+
+    if (s(1) > 0.0) {
+        Ft(1) =
+            std::pow(s(1)/ft2,2.0) +
+            std::pow(s(3)/f12,2.0) +
+            std::pow(s(5)/f23,2.0);
+    }
+
+    if (s(2) > 0.0) {
+        Ft(2) =
+            std::pow(s(2)/ft3,2.0) +
+            std::pow(s(4)/f13,2.0) +
+            std::pow(s(5)/f23,2.0);
+    }
+}
+
+double TimberHoffman3D::tensileDamage(double F, int dir) const
+{
+    if (F <= 1.0) return 0.0;
+
+    double Ei=E1, ft=ft1, Gf=Gf1t;
+
+    if (dir==2) { Ei=E2; ft=ft2; Gf=Gf2t; }
+    if (dir==3) { Ei=E3; ft=ft3; Gf=Gf3t; }
+
+    const double exponent =
+        (1.0-F)*Lc*ft*ft/(Ei*Gf);
+
+    double d = 1.0 - (1.0/F)*std::exp(exponent);
+    return std::max(0.0,std::min(0.999999,d));
+}
+
+double TimberHoffman3D::compressionDamage(double F1c) const
+{
+    if (F1c <= 1.0) return 0.0;
+
+    const double d =
+        1.0
+        - (1.0/F1c)*(1.0-Acomp)
+        - Acomp*std::exp(Bcomp*(1.0-F1c));
+
+    return std::max(0.0,std::min(0.999999,d));
+}
+
+void TimberHoffman3D::updateDamage(const Vector &stressEff)
+{
+    Vector Ft(3);
+    double F1c = 0.0;
+    failureIndices(stressEff,Ft,F1c);
+
+    for (int i=0;i<3;++i)
+        FmaxTTrial(i)=std::max(FmaxTCommit(i),Ft(i));
+
+    FmaxC1Trial=std::max(FmaxC1Commit,F1c);
+
+    for (int i=0;i<3;++i)
+        damageTTrial(i)=std::max(
+            damageTCommit(i),
+            tensileDamage(FmaxTTrial(i),i+1)
+        );
+
+    damageC1Trial=std::max(
+        damageC1Commit,
+        compressionDamage(FmaxC1Trial)
+    );
+
+    Vector dRaw(3);
+    dRaw(0)=std::max(damageTTrial(0),damageC1Trial);
+    dRaw(1)=damageTTrial(1);
+    dRaw(2)=damageTTrial(2);
+
+    const double aOld=eta/(eta+dt);
+    const double aNew=dt/(eta+dt);
+
+    for (int i=0;i<3;++i) {
+        damageVTrial(i)=
+            aOld*damageVCommit(i)+aNew*dRaw(i);
+
+        damageVTrial(i)=std::max(
+            damageVCommit(i),
+            damageVTrial(i)
+        );
+
+        damageVTrial(i)=std::max(
+            0.0,
+            std::min(0.999999,damageVTrial(i))
+        );
+    }
+}
+
+void TimberHoffman3D::buildDamagedStiffness(const Vector &d)
+{
+    const double d1=d(0);
+    const double d2=d(1);
+    const double d3=d(2);
+
+    Cdam.Zero();
+
+    Cdam(0,0)=(1.0-d1)*C0(0,0);
+    Cdam(1,1)=(1.0-d2)*C0(1,1);
+    Cdam(2,2)=(1.0-d3)*C0(2,2);
+
+    Cdam(0,1)=Cdam(1,0)=(1.0-d1)*(1.0-d2)*C0(0,1);
+    Cdam(0,2)=Cdam(2,0)=(1.0-d1)*(1.0-d3)*C0(0,2);
+    Cdam(1,2)=Cdam(2,1)=(1.0-d2)*(1.0-d3)*C0(1,2);
+
+    Cdam(3,3)=(1.0-d1)*(1.0-d2)*C0(3,3);
+    Cdam(4,4)=(1.0-d1)*(1.0-d3)*C0(4,4);
+    Cdam(5,5)=(1.0-d2)*(1.0-d3)*C0(5,5);
+}
+
+int TimberHoffman3D::setTrialStrain(const Vector &strain)
+{
+    if (strain.Size()!=6) return -1;
+
+    strainTrial=strain;
+
+    Vector deps(6);
+    deps = strainTrial;
+    deps.addVector(1.0,strainCommit,-1.0);
+
+    Vector sigmaTrialEff(effectiveStressCommit);
+    sigmaTrialEff.addMatrixVector(
+        1.0,C0,deps,1.0
+    );
+
+    Vector depsP(6);
+    double dLambda=0.0;
+
+    if (returnMapHardening(
+        sigmaTrialEff,
+        effectiveStressTrial,
+        eqpTrial,
+        depsP,
+        dLambda
+    ) < 0)
+        return -2;
+
+    plasticStrainTrial=plasticStrainCommit;
+    plasticStrainTrial += depsP;
+
+    Vector elasticStrain(strainTrial);
+    elasticStrain.addVector(
+        1.0,
+        plasticStrainTrial,
+        -1.0
+    );
+
+    updateDamage(effectiveStressTrial);
+    buildDamagedStiffness(damageVTrial);
+
+    stressTrial.addMatrixVector(
+        0.0,
+        Cdam,
+        elasticStrain,
+        1.0
+    );
+
+    return 0;
+}
+
+int TimberHoffman3D::setTrialStrain(
+    const Vector &strain,
+    const Vector &rate)
+{
+    return setTrialStrain(strain);
+}
+
+const Vector &TimberHoffman3D::getStress(void)
+{
+    return stressTrial;
+}
+
+const Vector &TimberHoffman3D::getStrain(void)
+{
+    return strainTrial;
+}
+
+const Matrix &TimberHoffman3D::getTangent(void)
+{
+    // IMPORTANT:
+    // This is the damaged elastic tangent, NOT yet the
+    // fully consistent elastoplastic-damage algorithmic tangent.
+    return Cdam;
+}
+
+const Matrix &TimberHoffman3D::getInitialTangent(void)
+{
+    return C0;
+}
+
+int TimberHoffman3D::commitState(void)
+{
+    strainCommit=strainTrial;
+    stressCommit=stressTrial;
+    effectiveStressCommit=effectiveStressTrial;
+    plasticStrainCommit=plasticStrainTrial;
+
+    eqpCommit=eqpTrial;
+
+    damageTCommit=damageTTrial;
+    damageC1Commit=damageC1Trial;
+    damageVCommit=damageVTrial;
+
+    FmaxTCommit=FmaxTTrial;
+    FmaxC1Commit=FmaxC1Trial;
+
+    return 0;
+}
+
+int TimberHoffman3D::revertToLastCommit(void)
+{
+    strainTrial=strainCommit;
+    stressTrial=stressCommit;
+    effectiveStressTrial=effectiveStressCommit;
+    plasticStrainTrial=plasticStrainCommit;
+
+    eqpTrial=eqpCommit;
+
+    damageTTrial=damageTCommit;
+    damageC1Trial=damageC1Commit;
+    damageVTrial=damageVCommit;
+
+    FmaxTTrial=FmaxTCommit;
+    FmaxC1Trial=FmaxC1Commit;
+
+    buildDamagedStiffness(damageVTrial);
+
+    return 0;
+}
+
+int TimberHoffman3D::revertToStart(void)
+{
+    strainTrial.Zero();
+    stressTrial.Zero();
+    effectiveStressTrial.Zero();
+    plasticStrainTrial.Zero();
+
+    strainCommit.Zero();
+    stressCommit.Zero();
+    effectiveStressCommit.Zero();
+    plasticStrainCommit.Zero();
+
+    eqpTrial=0.0;
+    eqpCommit=0.0;
+
+    damageTTrial.Zero();
+    damageTCommit.Zero();
+
+    damageVTrial.Zero();
+    damageVCommit.Zero();
+
+    damageC1Trial=0.0;
+    damageC1Commit=0.0;
+
+    FmaxTTrial.Zero();
+    FmaxTCommit.Zero();
+
+    for (int i=0;i<3;++i) {
+        FmaxTTrial(i)=1.0;
+        FmaxTCommit(i)=1.0;
+    }
+
+    FmaxC1Trial=1.0;
+    FmaxC1Commit=1.0;
+
+    Cdam=C0;
+    return 0;
+}
+
+NDMaterial *TimberHoffman3D::getCopy(void)
+{
+    return new TimberHoffman3D(*this);
+}
+
+NDMaterial *TimberHoffman3D::getCopy(const char *type)
+{
+    if (strcmp(type,"ThreeDimensional")==0 ||
+        strcmp(type,"3D")==0)
+        return getCopy();
+
+    return nullptr;
+}
+
+const char *TimberHoffman3D::getType(void) const
+{
+    return "ThreeDimensional";
+}
+
+int TimberHoffman3D::getOrder(void) const
+{
+    return 6;
+}
+
+int TimberHoffman3D::sendSelf(
+    int commitTag,
+    Channel &theChannel)
+{
+    // Minimal first implementation.
+    // For MPI/database serialization, pack parameters + committed state.
+    opserr << "TimberHoffman3D::sendSelf not yet implemented\n";
+    return -1;
+}
+
+int TimberHoffman3D::recvSelf(
+    int commitTag,
+    Channel &theChannel,
+    FEM_ObjectBroker &theBroker)
+{
+    opserr << "TimberHoffman3D::recvSelf not yet implemented\n";
+    return -1;
+}
+
+void TimberHoffman3D::Print(
+    OPS_Stream &s,
+    int flag)
+{
+    s << "TimberHoffman3D tag: " << this->getTag() << endln;
+    s << "  E1 E2 E3: "
+      << E1 << " " << E2 << " " << E3 << endln;
+    s << "  sigmaE0 h: "
+      << sigmaE0 << " " << hardeningModulus << endln;
+    s << "  Acomp Bcomp: "
+      << Acomp << " " << Bcomp << endln;
+    s << "  Lc eta dt: "
+      << Lc << " " << eta << " " << dt << endln;
+}

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -207,7 +207,10 @@ void TimberHoffman3D::buildElasticStiffness()
     S(4,4)=1.0/G13;
     S(5,5)=1.0/G23;
 
-    S.Invert(C0);  // C0 = inv(S)
+    if (S.Invert(C0) < 0) {
+        opserr << "WARNING TimberHoffman3D failed to invert elastic compliance matrix\n";
+        C0.Zero();
+    }
     Cdam = C0;
 }
 

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -674,23 +674,99 @@ int TimberHoffman3D::getOrder(void) const
     return 6;
 }
 
-int TimberHoffman3D::sendSelf(
-    int commitTag,
-    Channel &theChannel)
+int TimberHoffman3D::sendSelf(int commitTag, Channel &theChannel)
 {
-    // Minimal first implementation.
-    // For MPI/database serialization, pack parameters + committed state.
-    opserr << "TimberHoffman3D::sendSelf not yet implemented\n";
-    return -1;
+    if (this->getDbTag() == 0)
+        this->setDbTag(theChannel.getDbTag());
+
+    static Vector data(69);
+    int c = 0;
+    data(c++) = this->getTag();
+    data(c++) = E1; data(c++) = E2; data(c++) = E3;
+    data(c++) = nu12; data(c++) = nu13; data(c++) = nu23;
+    data(c++) = G12; data(c++) = G13; data(c++) = G23;
+    data(c++) = fc1; data(c++) = fc2; data(c++) = fc3;
+    data(c++) = ft1; data(c++) = ft2; data(c++) = ft3;
+    data(c++) = f12; data(c++) = f13; data(c++) = f23;
+    data(c++) = hardeningModulus; data(c++) = sigmaE0;
+    data(c++) = Acomp; data(c++) = Bcomp;
+    data(c++) = Gf1t; data(c++) = Gf2t; data(c++) = Gf3t;
+    data(c++) = eta; data(c++) = Lc; data(c++) = dt;
+    data(c++) = tol; data(c++) = maxIter; data(c++) = innerTol; data(c++) = innerMaxIter;
+
+    for (int i=0;i<6;++i) data(c++) = strainCommit(i);
+    for (int i=0;i<6;++i) data(c++) = stressCommit(i);
+    for (int i=0;i<6;++i) data(c++) = effectiveStressCommit(i);
+    for (int i=0;i<6;++i) data(c++) = plasticStrainCommit(i);
+    data(c++) = eqpCommit;
+    for (int i=0;i<3;++i) data(c++) = damageTCommit(i);
+    data(c++) = damageC1Commit;
+    for (int i=0;i<3;++i) data(c++) = damageVCommit(i);
+    for (int i=0;i<3;++i) data(c++) = FmaxTCommit(i);
+    data(c++) = FmaxC1Commit;
+
+    if (theChannel.sendVector(this->getDbTag(), commitTag, data) < 0) {
+        opserr << "TimberHoffman3D::sendSelf - failed to send Vector\n";
+        return -1;
+    }
+    return 0;
 }
 
-int TimberHoffman3D::recvSelf(
-    int commitTag,
-    Channel &theChannel,
-    FEM_ObjectBroker &theBroker)
+int TimberHoffman3D::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
-    opserr << "TimberHoffman3D::recvSelf not yet implemented\n";
-    return -1;
+    if (this->getDbTag() == 0)
+        this->setDbTag(theChannel.getDbTag());
+
+    static Vector data(69);
+    if (theChannel.recvVector(this->getDbTag(), commitTag, data) < 0) {
+        opserr << "TimberHoffman3D::recvSelf - failed to recv Vector\n";
+        return -1;
+    }
+
+    int c = 0;
+    this->setTag((int)data(c++));
+    E1 = data(c++); E2 = data(c++); E3 = data(c++);
+    nu12 = data(c++); nu13 = data(c++); nu23 = data(c++);
+    G12 = data(c++); G13 = data(c++); G23 = data(c++);
+    fc1 = data(c++); fc2 = data(c++); fc3 = data(c++);
+    ft1 = data(c++); ft2 = data(c++); ft3 = data(c++);
+    f12 = data(c++); f13 = data(c++); f23 = data(c++);
+    hardeningModulus = data(c++); sigmaE0 = data(c++);
+    Acomp = data(c++); Bcomp = data(c++);
+    Gf1t = data(c++); Gf2t = data(c++); Gf3t = data(c++);
+    eta = data(c++); Lc = data(c++); dt = data(c++);
+    tol = data(c++); maxIter = (int)data(c++); innerTol = data(c++); innerMaxIter = (int)data(c++);
+
+    buildElasticStiffness();
+    buildHoffmanPQ();
+    Z.Zero();
+    Z(0,0)=1.0; Z(1,1)=1.0; Z(2,2)=1.0;
+    Z(3,3)=0.5; Z(4,4)=0.5; Z(5,5)=0.5;
+
+    for (int i=0;i<6;++i) strainCommit(i) = data(c++);
+    for (int i=0;i<6;++i) stressCommit(i) = data(c++);
+    for (int i=0;i<6;++i) effectiveStressCommit(i) = data(c++);
+    for (int i=0;i<6;++i) plasticStrainCommit(i) = data(c++);
+    eqpCommit = data(c++);
+    for (int i=0;i<3;++i) damageTCommit(i) = data(c++);
+    damageC1Commit = data(c++);
+    for (int i=0;i<3;++i) damageVCommit(i) = data(c++);
+    for (int i=0;i<3;++i) FmaxTCommit(i) = data(c++);
+    FmaxC1Commit = data(c++);
+
+    strainTrial = strainCommit;
+    stressTrial = stressCommit;
+    effectiveStressTrial = effectiveStressCommit;
+    plasticStrainTrial = plasticStrainCommit;
+    eqpTrial = eqpCommit;
+    damageTTrial = damageTCommit;
+    damageC1Trial = damageC1Commit;
+    damageVTrial = damageVCommit;
+    FmaxTTrial = FmaxTCommit;
+    FmaxC1Trial = FmaxC1Commit;
+
+    buildDamagedStiffness(damageVCommit);
+    return 0;
 }
 
 void TimberHoffman3D::Print(

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -78,6 +78,11 @@ void *OPS_TimberHoffman3D()
         return nullptr;
     }
 
+    if (data[19] <= 0.0) {
+        opserr << "WARNING TimberHoffman3D sigmaE0 must be positive\n";
+        return nullptr;
+    }
+
     if (data[22] <= 0.0 || data[23] <= 0.0 || data[24] <= 0.0) {
         opserr << "WARNING TimberHoffman3D fracture energies must be positive\n";
         return nullptr;

--- a/SRC/material/nD/TimberHoffman3D.cpp
+++ b/SRC/material/nD/TimberHoffman3D.cpp
@@ -481,8 +481,9 @@ void TimberHoffman3D::updateDamage(const Vector &stressEff)
     dRaw(1)=damageTTrial(1);
     dRaw(2)=damageTTrial(2);
 
-    const double aOld=eta/(eta+dt);
-    const double aNew=dt/(eta+dt);
+    const double dtEff = (ops_Dt > 0.0) ? ops_Dt : dt;
+    const double aOld = eta/(eta + dtEff);
+    const double aNew = dtEff/(eta + dtEff);
 
     for (int i=0;i<3;++i) {
         damageVTrial(i)=

--- a/SRC/material/nD/TimberHoffman3D.h
+++ b/SRC/material/nD/TimberHoffman3D.h
@@ -5,14 +5,9 @@
 #include <NDMaterial.h>
 #include <Vector.h>
 #include <Matrix.h>
+#include <classTags.h>
 
-// NOTE:
-// This class tag must be unique inside the OpenSees build.
-// For a production OpenSees integration, add an official class tag
-// in classTags.h rather than relying permanently on this local value.
-#ifndef ND_TAG_TimberHoffman3D
-#define ND_TAG_TimberHoffman3D 987654
-#endif
+
 
 class TimberHoffman3D : public NDMaterial
 {

--- a/SRC/material/nD/TimberHoffman3D.h
+++ b/SRC/material/nD/TimberHoffman3D.h
@@ -1,0 +1,169 @@
+
+#ifndef TimberHoffman3D_h
+#define TimberHoffman3D_h
+
+#include <NDMaterial.h>
+#include <Vector.h>
+#include <Matrix.h>
+
+// NOTE:
+// This class tag must be unique inside the OpenSees build.
+// For a production OpenSees integration, add an official class tag
+// in classTags.h rather than relying permanently on this local value.
+#ifndef ND_TAG_TimberHoffman3D
+#define ND_TAG_TimberHoffman3D 987654
+#endif
+
+class TimberHoffman3D : public NDMaterial
+{
+public:
+    TimberHoffman3D();
+
+    TimberHoffman3D(
+        int tag,
+        double E1, double E2, double E3,
+        double nu12, double nu13, double nu23,
+        double G12, double G13, double G23,
+        double fc1, double fc2, double fc3,
+        double ft1, double ft2, double ft3,
+        double f12, double f13, double f23,
+        double h,
+        double sigmaE0,
+        double Acomp, double Bcomp,
+        double Gf1t, double Gf2t, double Gf3t,
+        double eta,
+        double Lc,
+        double dt = 1.0
+    );
+
+    ~TimberHoffman3D();
+
+    int setTrialStrain(const Vector &strain) override;
+    int setTrialStrain(const Vector &strain, const Vector &rate) override;
+
+    const Vector &getStress(void) override;
+    const Vector &getStrain(void) override;
+    const Matrix &getTangent(void) override;
+    const Matrix &getInitialTangent(void) override;
+
+    int commitState(void) override;
+    int revertToLastCommit(void) override;
+    int revertToStart(void) override;
+
+    NDMaterial *getCopy(void) override;
+    NDMaterial *getCopy(const char *type) override;
+
+    const char *getType(void) const override;
+    int getOrder(void) const override;
+
+    int sendSelf(int commitTag, Channel &theChannel) override;
+    int recvSelf(int commitTag, Channel &theChannel,
+                 FEM_ObjectBroker &theBroker) override;
+
+    void Print(OPS_Stream &s, int flag = 0) override;
+
+private:
+    void buildElasticStiffness();
+    void buildHoffmanPQ();
+
+    double sigmaEk(double eqp) const;
+    double yieldFunction(const Vector &stressEff, double eqp) const;
+    void flowDirection(const Vector &stressEff, double eqp, Vector &g) const;
+
+    double equivalentPlasticIncrement(const Vector &depsP) const;
+
+    int returnMapHardening(
+        const Vector &sigmaTrial,
+        Vector &sigmaNew,
+        double &eqpNew,
+        Vector &depsP,
+        double &dLambda
+    );
+
+    int stateForLambda(
+        const Vector &sigmaTrial,
+        double dLambda,
+        Vector &sigma,
+        double &eqp,
+        Vector &depsP
+    );
+
+    void failureIndices(
+        const Vector &stressEff,
+        Vector &Ft,
+        double &F1c
+    ) const;
+
+    double tensileDamage(double F, int direction) const;
+    double compressionDamage(double F1c) const;
+
+    void updateDamage(const Vector &stressEff);
+    void buildDamagedStiffness(const Vector &damage);
+
+private:
+    // Material parameters
+    double E1, E2, E3;
+    double nu12, nu13, nu23;
+    double G12, G13, G23;
+
+    double fc1, fc2, fc3;
+    double ft1, ft2, ft3;
+    double f12, f13, f23;
+
+    double hardeningModulus;
+    double sigmaE0;
+
+    double Acomp;
+    double Bcomp;
+
+    double Gf1t;
+    double Gf2t;
+    double Gf3t;
+
+    double eta;
+    double Lc;
+    double dt;
+
+    // Elastic and Hoffman tensors
+    Matrix C0;
+    Matrix Cdam;
+    Matrix P;
+    Vector Q0;
+    Matrix Z;
+
+    // Trial state
+    Vector strainTrial;
+    Vector stressTrial;
+    Vector effectiveStressTrial;
+    Vector plasticStrainTrial;
+
+    double eqpTrial;
+    Vector damageTTrial;
+    double damageC1Trial;
+    Vector damageVTrial;
+    Vector FmaxTTrial;
+    double FmaxC1Trial;
+
+    // Committed state
+    Vector strainCommit;
+    Vector stressCommit;
+    Vector effectiveStressCommit;
+    Vector plasticStrainCommit;
+
+    double eqpCommit;
+    Vector damageTCommit;
+    double damageC1Commit;
+    Vector damageVCommit;
+    Vector FmaxTCommit;
+    double FmaxC1Commit;
+
+    // Solver controls
+    double tol;
+    int maxIter;
+    double innerTol;
+    int innerMaxIter;
+};
+
+void *OPS_TimberHoffman3D();
+
+#endif


### PR DESCRIPTION
## Summary

This pull request adds `TimberHoffman3D`, a three-dimensional nonlinear
orthotropic timber `nDMaterial` for OpenSees.

The formulation is intended to represent the direction-dependent nonlinear
response of timber under multiaxial loading.

## Main features

- Orthotropic elastic response
- Hoffman-type multiaxial failure criterion
- Direction-dependent tensile and compressive strengths
- Nonlinear compression hardening
- Direction-dependent damage evolution
- Fracture-energy-based softening
- Viscous regularization of damage evolution

## OpenSees integration

This pull request adds:

- `TimberHoffman3D.cpp`
- `TimberHoffman3D.h`
- CMake integration
- OpenSees nDMaterial command registration
- Tcl nDMaterial registration

The material can be invoked using the `TimberHoffman3D` nDMaterial command.

## Validation

Material-level validation has been performed for loading parallel and
perpendicular to the timber grain, including tension, compression,
compression hardening, and damage evolution.

Additional benchmark and element-level examples can be added based on
maintainer feedback.