### PR TITLE
Fix varying distributed loads in ModElasticBeam3d

### DIFF
--- a/SRC/element/elasticBeamColumn/ModElasticBeam3d.cpp
+++ b/SRC/element/elasticBeamColumn/ModElasticBeam3d.cpp
@@ -478,46 +478,35 @@ int ModElasticBeam3d::addLoad(ElementalLoad *theLoad, double loadFactor) {
     q0[4] -= My;
 
   } else if (type == LOAD_TAG_Beam3dPartialUniformLoad) {
-    double wa = data(2) * loadFactor; // Axial
-    double wy = data(0) * loadFactor; // Transverse
-    double wz = data(1) * loadFactor; // Transverse
-    double a = data(3) * L;
-    double b = data(4) * L;
-    double c = 0.5 * (b + a);
-    double cOverL = c / L;
+    const double a = data(3);
+    const double b = data(4);
+    const double length = (b - a) * L;
+    // Three-point Gauss integration is exact for a linear load times the
+    // existing cubic beam interpolation, including a zero-length interval.
+    const double points[3] = {-sqrt(3.0 / 5.0), 0.0, sqrt(3.0 / 5.0)};
+    const double weights[3] = {5.0 / 9.0, 8.0 / 9.0, 5.0 / 9.0};
+    for (int i = 0; i < 3; ++i) {
+      const double t = 0.5 * (1.0 + points[i]);
+      const double x = a + (b - a) * t;
+      const double weight = 0.5 * length * weights[i] * loadFactor;
+      const double wy = ((1.0 - t) * data(0) + t * data(5)) * weight;
+      const double wz = ((1.0 - t) * data(1) + t * data(6)) * weight;
+      const double wx = ((1.0 - t) * data(2) + t * data(7)) * weight;
 
-    double P = wa * (b - a);
-    double Fy = wy * (b - a);
-    double Fz = wz * (b - a);
+      p0[0] -= wx;
+      p0[1] -= (1.0 - x) * wy;
+      p0[2] -= x * wy;
+      p0[3] -= (1.0 - x) * wz;
+      p0[4] -= x * wz;
 
-    // Reactions in basic system
-    p0[0] -= P;
-    double V1, V2;
-    V1 = Fy * (1.0 - cOverL);
-    V2 = Fy * cOverL;
-    p0[1] -= V1;
-    p0[2] -= V2;
-    V1 = Fz * (1.0 - cOverL);
-    V2 = Fz * cOverL;
-    p0[3] -= V1;
-    p0[4] -= V2;
-
-    // Fixed end forces in basic system
-    q0[0] -= P * cOverL;
-    double M1, M2;
-    double beta2 = (1 - cOverL) * (1 - cOverL);
-    double alfa2 = (cOverL) * (cOverL);
-    double gamma2 = (b - a) / L;
-    gamma2 *= gamma2;
-
-    M1 = -wy * (b - a) * (c * beta2 + gamma2 / 12.0 * (L - 3 * (L - c)));
-    M2 = wy * (b - a) * ((L - c) * alfa2 + gamma2 / 12.0 * (L - 3 * c));
-    q0[1] += M1;
-    q0[2] += M2;
-    M1 = -wz * (b - a) * (c * beta2 + gamma2 / 12.0 * (L - 3 * (L - c)));
-    M2 = wz * (b - a) * ((L - c) * alfa2 + gamma2 / 12.0 * (L - 3 * c));
-    q0[3] -= M1;
-    q0[4] -= M2;
+      const double m1 = L * x * (1.0 - x) * (1.0 - x);
+      const double m2 = -L * x * x * (1.0 - x);
+      q0[0] -= x * wx;
+      q0[1] -= m1 * wy;
+      q0[2] -= m2 * wy;
+      q0[3] += m1 * wz;
+      q0[4] += m2 * wz;
+    }
   } else if (type == LOAD_TAG_Beam3dPointLoad) {
     double Py = data(0) * loadFactor;
     double Pz = data(1) * loadFactor;

--- a/tests/test_mod_elastic_beam_loads.py
+++ b/tests/test_mod_elastic_beam_loads.py
@@ -1,0 +1,123 @@
+"""Load equilibrium and fixed-end checks for the remaining gap in issue #1612."""
+
+import pytest
+
+try:
+    import opensees as ops
+except ModuleNotFoundError:
+    import openseespy.opensees as ops
+
+
+@pytest.fixture(autouse=True)
+def clean_domain():
+    ops.wipe()
+    yield
+    ops.wipe()
+
+
+def _model(kind="ModElasticBeam3d", modifiers=(4., 4., 2.), fixed_bending=False):
+    ops.model("basic", "-ndm", 3, "-ndf", 6)
+    ops.node(1, 0., 0., 0.)
+    ops.node(2, 10., 0., 0.)
+    ops.fix(1, 1, 1, 1, 1, 1, 1)
+    if fixed_bending:
+        # Keep the axial equation free to avoid a zero-equation solver.
+        ops.fix(2, 0, 1, 1, 1, 1, 1)
+    ops.geomTransf("Linear", 1, 0., 0., 1.)
+    extra = (*modifiers, *modifiers) if kind == "ModElasticBeam3d" else ()
+    ops.element(kind, 1, 1, 2, .01, 2.e11, 8.e10, 1.e-4, 1.e-4, 1.e-4, *extra, 1)
+    ops.timeSeries("Linear", 1)
+    ops.pattern("Plain", 1, 1)
+
+
+def _load(axis, start, end, a, b):
+    first, last = [0.] * 3, [0.] * 3
+    first[axis], last[axis] = start, end
+    # Command component order is local y, z, x.
+    ops.eleLoad("-ele", 1, "-type", "-beamUniform",
+                first[1], first[2], first[0], a, b, last[1], last[2], last[0])
+
+
+def _analyze(factor=1.):
+    ops.constraints("Plain")
+    ops.numberer("Plain")
+    ops.system("FullGeneral")
+    ops.integrator("LoadControl", factor)
+    ops.algorithm("Linear")
+    ops.analysis("Static")
+    assert ops.analyze(1) == 0
+    ops.reactions()
+
+
+def _integral(coefficients, start, end, a, b):
+    # Exact polynomial antiderivative in x/L; independent of element quadrature.
+    if a == b:
+        return 0.
+    slope = (end - start) / (b - a)
+    intercept = start - slope * a
+    return 10. * sum(c * (intercept * (b**(i+1) - a**(i+1)) / (i+1)
+                         + slope * (b**(i+2) - a**(i+2)) / (i+2))
+                     for i, c in enumerate(coefficients))
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("start,end", [(-2., -2.), (-2., 0.), (0., -2.), (-2., 3.)])
+@pytest.mark.parametrize("a,b", [(0., 1.), (.2, .8), (.4, .4)])
+@pytest.mark.parametrize("modifiers", [(4., 4., 2.), (3.6, 3.6, 2.4)])
+def test_cantilever_force_and_moment_balance(axis, start, end, a, b, modifiers):
+    _model(modifiers=modifiers)
+    _load(axis, start, end, a, b)
+    _analyze(.5)
+    expected = [0.] * 6
+    expected[axis] = -.5 * _integral([1.], start, end, a, b)
+    if axis != 0:
+        moment = .5 * _integral([0., 10.], start, end, a, b)
+        expected[5 if axis == 1 else 4] = -moment if axis == 1 else moment
+    assert ops.nodeReaction(1) == pytest.approx(expected, abs=1.e-9)
+
+
+@pytest.mark.parametrize("axis", [1, 2])
+@pytest.mark.parametrize("start,end", [(-2., 0.), (0., -2.), (-2., 3.), (-2., -2.)])
+@pytest.mark.parametrize("a,b", [(0., 1.), (.2, .8)])
+def test_fixed_end_forces_in_ordinary_beam_limit(axis, start, end, a, b):
+    _model(fixed_bending=True)
+    _load(axis, start, end, a, b)
+    _analyze()
+    shears = ([1., 0., -3., 2.], [0., 0., 3., -2.])
+    moments = ([0., 10., -20., 10.], [0., 0., -10., 10.])
+    for index, tag in enumerate((1, 2)):
+        expected = [0.] * 6
+        expected[axis] = -_integral(shears[index], start, end, a, b)
+        moment = _integral(moments[index], start, end, a, b)
+        expected[5 if axis == 1 else 4] = -moment if axis == 1 else moment
+        assert ops.nodeReaction(tag) == pytest.approx(expected, abs=1.e-9)
+
+
+def test_ordinary_beam_limit_displacements_and_load_superposition():
+    results = []
+    for kind in ("elasticBeamColumn", "ModElasticBeam3d"):
+        ops.wipe()
+        _model(kind=kind)
+        _load(1, -2., 3., .2, .8)
+        _load(2, 0., -4., 0., 1.)
+        _load(0, 5., -1., .1, .9)
+        _analyze()
+        results.append((ops.nodeDisp(2), ops.eleForce(1)))
+    for actual, expected in zip(results[1], results[0]):
+        assert actual == pytest.approx(expected, rel=1.e-10, abs=1.e-10)
+
+
+def test_partial_uniform_matches_existing_full_uniform_load():
+    results = []
+    for partial in (False, True):
+        ops.wipe()
+        _model(modifiers=(3.6, 3.6, 2.4))
+        if partial:
+            for axis, value in enumerate((3., -2., 4.)):
+                _load(axis, value, value, 0., 1.)
+        else:
+            ops.eleLoad("-ele", 1, "-type", "-beamUniform", -2., 4., 3.)
+        _analyze()
+        results.append((ops.nodeDisp(2), ops.eleForce(1)))
+    for actual, expected in zip(results[1], results[0]):
+        assert actual == pytest.approx(expected, rel=1.e-10, abs=1.e-10)


### PR DESCRIPTION
## Summary

Addresses the remaining ModElasticBeam3d portion of #1612, reported by @SoggyBottomBoy. Does not close the broader multi-element issue.

The partial distributed-load branch used only the intensity at the start of the loaded segment. For a length-10 cantilever with a triangular transverse load increasing from 0 to -2, analysis returned success but the support shear and moment were both zero instead of 10 and 66.6667. Reversing the intensities gave shear 20 instead of 10.

- Integrate all three linearly varying load components using three-point Gauss quadrature, exact for the existing cubic load interpolation times a linear intensity.
- Preserve the existing uniform-load and stiffness-modifier conventions. This does not introduce a new semi-rigid beam theory or change the stiffness matrix.
- Handle full-span, partial-span, uniform, triangular, sign-changing, and zero-length loaded intervals without division by the interval length.
- Add 90 focused regression cases: force/moment equilibrium for all axes with standard and modified stiffness, fixed-end forces in the ordinary-beam limit, ordinary-beam displacement equivalence, load superposition/scaling, and uniform-load compatibility.

## Verification

- Before the fix: 49 focused tests failed and 41 passed against the locally compiled pre-fix module.
- Rebuilt OpenSeesPy from this branch with AppleClang, GNU Fortran, Python 3.11 and the existing Conan toolchain, with MPI discovery disabled for the serial build.
- After the fix: all 97 tests passed (90 new plus 7 existing), using an explicit `ExtensionFileLoader` to load the newly built `build/verification/OpenSeesPy.dylib` as `opensees` before running pytest.
- `git diff --check` passed.
- Linux and Windows validation is left to GitHub CI; no remote pass is claimed.

Authored by Musawer Ahmad Saqif <saqif@umich.com>. Original authorship and issue-report credit are preserved.
