### PR TITLE
Conserve CatenaryCable Clough-style mass

### DIFF
--- a/SRC/element/catenaryCable/CatenaryCable.cpp
+++ b/SRC/element/catenaryCable/CatenaryCable.cpp
@@ -174,6 +174,8 @@ CatenaryCable::CatenaryCable(int tag, int node1, int node2, double weight_, doub
   rho(rho_),
   error_tol(error_tol_),
   Nsubsteps(Nsubsteps_),
+  w1(0.0), w2(0.0), w3(weight_),
+  f1(0.0), f2(0.0), f3(0.0),
   first_step(true),
   massType(massType_)
 {
@@ -211,6 +213,8 @@ CatenaryCable::CatenaryCable()
   rho(0),
   error_tol(0),
   Nsubsteps(0),
+  w1(0.0), w2(0.0), w3(0.0),
+  f1(0.0), f2(0.0), f3(0.0),
   first_step(true),
   massType(0)
 {
@@ -1300,17 +1304,19 @@ void CatenaryCable::computeMassByIntegration()
 
 void CatenaryCable::computeMassCloughStyle()
 {
-  double total_mass = rho*L0;
-  double f1x = fabs((*load)(0));
-  double f2x = fabs((*load)(3));
-  double f1y = fabs((*load)(1));
-  double f2y = fabs((*load)(4));
-  double f1z = fabs((*load)(2));
-  double f2z = fabs((*load)(5));
-  double f1 = sqrt(f1x*f1x + f1y*f1y + f1z*f1z);
-  double f2 = sqrt(f2x*f2x + f2y*f2y + f2z*f2z);
-  double m1 = total_mass*f1/(f1+f2);
-  double m2 = total_mass*f1/(f1+f2);
+  Mass.Zero();
+  // Use current end forces, not the cached vector from the last force query.
+  const double tension1 = hypot(hypot(f1, f2), f3);
+  const double tension2 = hypot(hypot(-f1-w1*L0, -f2-w2*L0), -f3-w3*L0);
+  const double total_tension = tension1 + tension2;
+  if (total_tension == 0.0 || rho == 0.0) {
+    // With no tension there is no preferred end for mass allocation.
+    computeMassLumped();
+    return;
+  }
+  const double total_mass = rho*L0;
+  const double m1 = total_mass*(tension1/total_tension);
+  const double m2 = total_mass*(tension2/total_tension);
   Mass(0,0) = m1;
   Mass(1,1) = m1;
   Mass(2,2) = m1;
@@ -1318,4 +1324,3 @@ void CatenaryCable::computeMassCloughStyle()
   Mass(4,4) = m2;
   Mass(5,5) = m2;
 }
-

--- a/tests/test_catenary_mass.py
+++ b/tests/test_catenary_mass.py
@@ -1,0 +1,88 @@
+"""Clough-style cable mass must conserve mass and be node-order independent."""
+
+import math
+
+import pytest
+
+try:
+    import opensees as ops
+except ModuleNotFoundError:
+    import openseespy.opensees as ops
+
+
+@pytest.fixture(autouse=True)
+def clean_domain():
+    ops.wipe()
+    yield
+    ops.wipe()
+
+
+def _model(reverse=False, height=30., rho=1., mass_type=2, free_end=False):
+    ops.model("basic", "-ndm", 3, "-ndf", 3)
+    ops.node(1, 0., 0., 0.)
+    ops.node(2, 100., 0., height)
+    ops.fix(1, 1, 1, 1)
+    if not free_end:
+        ops.fix(2, 1, 1, 1)
+    ends = (2, 1) if reverse else (1, 2)
+    ops.element("CatenaryCable", 1, *ends, -10., 2.e11, 1.e-3,
+                110., 0., 0., rho, 1.e-9, 10, mass_type)
+    return ends
+
+
+def _nodal_masses(acceleration, reverse=False, height=30., rho=1., mass_type=2):
+    ops.wipe()
+    _model(reverse, height, rho, mass_type)
+    ops.reactions()
+    static = [ops.nodeReaction(tag) for tag in (1, 2)]
+    for tag in (1, 2):
+        for dof, value in enumerate(acceleration, start=1):
+            ops.setNodeAccel(tag, dof, value, "-commit")
+    ops.reactions("-dynamic")
+    return [[(ops.nodeReaction(tag, dof+1) - static[tag-1][dof]) / value
+             for dof, value in enumerate(acceleration)] for tag in (1, 2)]
+
+
+@pytest.mark.parametrize("height", [-30., 0., 30.])
+@pytest.mark.parametrize("rho", [0., 1., 2.5])
+@pytest.mark.parametrize("mass_type", [0, 2, 3])
+def test_rigid_acceleration_conserves_mass_and_node_order(height, rho, mass_type):
+    acceleration = (1., -2., 3.)
+    forward = _nodal_masses(acceleration, height=height, rho=rho, mass_type=mass_type)
+    backward = _nodal_masses(acceleration, reverse=True, height=height,
+                              rho=rho, mass_type=mass_type)
+    for dof in range(3):
+        assert forward[0][dof] + forward[1][dof] == pytest.approx(110. * rho, abs=1.e-8)
+    for actual, expected in zip(backward, forward):
+        assert actual == pytest.approx(expected, abs=1.e-8)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_each_end_mass_uses_its_own_tension(reverse):
+    ends = _model(reverse=reverse)
+    forces = ops.eleForce(1)
+    tensions = [math.sqrt(sum(f*f for f in forces[i:i+3])) for i in (0, 3)]
+    expected = {tag: 110. * tension / sum(tensions) for tag, tension in zip(ends, tensions)}
+    masses = _nodal_masses((1., 2., -3.), reverse=reverse)
+    for tag in (1, 2):
+        assert masses[tag-1] == pytest.approx([expected[tag]] * 3, abs=1.e-8)
+
+
+@pytest.mark.parametrize("query_force_first", [False, True])
+def test_clough_mass_assembly(query_force_first):
+    _model(free_end=True)
+    if query_force_first:
+        ops.eleForce(1)
+    ops.constraints("Plain")
+    ops.numberer("Plain")
+    ops.system("FullGeneral")
+    ops.integrator("GimmeMCK", 1., 0., 0.)
+    ops.algorithm("Linear")
+    ops.analysis("Transient")
+    assert ops.analyze(1, 0.) == 0
+    mass = ops.printA("-ret")
+    force = ops.eleForce(1)
+    tensions = [math.sqrt(sum(f*f for f in force[i:i+3])) for i in (0, 3)]
+    nodal_mass = 110. * tensions[1] / sum(tensions)
+    assert mass == pytest.approx([nodal_mass if i == j else 0.
+                                 for i in range(3) for j in range(3)], abs=1.e-8)


### PR DESCRIPTION
## Summary

Correct the optional Clough-style (`massType=2`) CatenaryCable mass allocation. The current implementation uses the first end's tension for both nodal masses. In a sloped cable with specified mass `rho*L0=110`, rigid-acceleration reactions give total mass 94.18086165; reversing element connectivity changes it to 125.81913835.

- Weight each nodal mass by that end's own tension.
- Derive tensions from the current internal-force state, not the cached force-response vector, so querying forces is not a prerequisite for correct mass assembly.
- Initialize the relevant force/load state, use `hypot` for the tension norms, and use equal lumping if total tension is zero.
- Clear the shared mass matrix before assembling this diagonal formulation.
- Add 31 regression cases covering sloped/level cables, reversal, both nodal allocations, all translational inertia components, zero/nonzero density, mass assembly, and lumped/equivalent-truss controls.

This branch starts from current master and is separate from the six-DOF extension in #1788. It does not change the default lumped-mass formulation or the self-weight loading convention addressed in #1798.

## Verification

- Pre-fix focused suite: 8 failed, 23 passed.
- Compiled the changed source into a local OpenSeesPy verification build: all 31 cable-mass tests passed; combined with the separately developed beam-load tests and existing tests, 128 passed.
- A separately compiled C++ probe passed zero-tension initialization and `getMass()` before/after force queries, including after a displacement update. This probe is local verification, not an automated CI claim.
- `git diff --check` passed.
- Platform tested: macOS / AppleClang / GNU Fortran / Python 3.11, serial build with the existing Conan toolchain. Linux/Windows and remote CI results are not claimed.

Authored by Musawer Ahmad Saqif <saqif@umich.com>; original element authorship is preserved.
